### PR TITLE
feat(guilds): implement POST /api/guilds/{guildId}/owner/transfer (#23)

### DIFF
--- a/src/Harmonie.API/Program.cs
+++ b/src/Harmonie.API/Program.cs
@@ -16,6 +16,7 @@ using Harmonie.Application.Features.Guilds.InviteMember;
 using Harmonie.Application.Features.Guilds.LeaveGuild;
 using Harmonie.Application.Features.Guilds.ListUserGuilds;
 using Harmonie.Application.Features.Guilds.RemoveMember;
+using Harmonie.Application.Features.Guilds.TransferOwnership;
 using Harmonie.Application.Features.Guilds.UpdateMemberRole;
 using Harmonie.Application.Features.Users.GetMyProfile;
 using Harmonie.Application.Features.Users.UpdateMyProfile;
@@ -136,7 +137,7 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
-    app.MapScalarApiReference();  
+    app.MapScalarApiReference();
 }
 
 app.UseMiddleware<GlobalExceptionHandler>();
@@ -152,10 +153,10 @@ app.UseRateLimiter();
 // ============================================================
 
 // Health check endpoint
-app.MapGet("/health", () => Results.Ok(new 
-{ 
-    status = "healthy", 
-    timestamp = DateTime.UtcNow 
+app.MapGet("/health", () => Results.Ok(new
+{
+    status = "healthy",
+    timestamp = DateTime.UtcNow
 }))
 .WithName("HealthCheck")
 .WithTags("System")
@@ -175,6 +176,7 @@ GetGuildMembersEndpoint.Map(app);
 LeaveGuildEndpoint.Map(app);
 RemoveMemberEndpoint.Map(app);
 UpdateMemberRoleEndpoint.Map(app);
+TransferOwnershipEndpoint.Map(app);
 SendMessageEndpoint.Map(app);
 GetMessagesEndpoint.Map(app);
 GetMyProfileEndpoint.Map(app);

--- a/src/Harmonie.Application/Common/ApplicationErrorCodes.cs
+++ b/src/Harmonie.Application/Common/ApplicationErrorCodes.cs
@@ -35,6 +35,7 @@ public static class ApplicationErrorCodes
         public const string MemberNotFound = "GUILD_MEMBER_NOT_FOUND";
         public const string OwnerCannotBeRemoved = "GUILD_OWNER_CANNOT_BE_REMOVED";
         public const string OwnerRoleCannotBeChanged = "GUILD_OWNER_ROLE_CANNOT_BE_CHANGED";
+        public const string OwnerTransferToSelf = "GUILD_OWNER_TRANSFER_TO_SELF";
     }
 
     public static class Channel

--- a/src/Harmonie.Application/Common/EndpointExtensions.cs
+++ b/src/Harmonie.Application/Common/EndpointExtensions.cs
@@ -108,6 +108,7 @@ public static class EndpointExtensions
             ApplicationErrorCodes.Guild.MemberNotFound => HttpStatusCode.NotFound,
             ApplicationErrorCodes.Guild.OwnerCannotBeRemoved => HttpStatusCode.Conflict,
             ApplicationErrorCodes.Guild.OwnerRoleCannotBeChanged => HttpStatusCode.Conflict,
+            ApplicationErrorCodes.Guild.OwnerTransferToSelf => HttpStatusCode.Conflict,
             ApplicationErrorCodes.Channel.NotFound => HttpStatusCode.NotFound,
             ApplicationErrorCodes.Channel.AccessDenied => HttpStatusCode.Forbidden,
             ApplicationErrorCodes.Channel.NotText => HttpStatusCode.Conflict,

--- a/src/Harmonie.Application/DependencyInjection.cs
+++ b/src/Harmonie.Application/DependencyInjection.cs
@@ -14,6 +14,7 @@ using Harmonie.Application.Features.Guilds.InviteMember;
 using Harmonie.Application.Features.Guilds.LeaveGuild;
 using Harmonie.Application.Features.Guilds.ListUserGuilds;
 using Harmonie.Application.Features.Guilds.RemoveMember;
+using Harmonie.Application.Features.Guilds.TransferOwnership;
 using Harmonie.Application.Features.Guilds.UpdateMemberRole;
 using Harmonie.Application.Features.Users.GetMyProfile;
 using Harmonie.Application.Features.Users.UpdateMyProfile;
@@ -46,6 +47,7 @@ public static class DependencyInjection
         services.AddScoped<LeaveGuildHandler>();
         services.AddScoped<RemoveMemberHandler>();
         services.AddScoped<UpdateMemberRoleHandler>();
+        services.AddScoped<TransferOwnershipHandler>();
         services.AddScoped<GetGuildChannelsHandler>();
         services.AddScoped<GetGuildMembersHandler>();
         services.AddScoped<SendMessageHandler>();

--- a/src/Harmonie.Application/Features/Guilds/TransferOwnership/TransferOwnershipEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/TransferOwnership/TransferOwnershipEndpoint.cs
@@ -1,0 +1,80 @@
+using FluentValidation;
+using Harmonie.Application.Common;
+using Harmonie.Domain.ValueObjects;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Harmonie.Application.Features.Guilds.TransferOwnership;
+
+public static class TransferOwnershipEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/guilds/{guildId}/owner/transfer", HandleAsync)
+            .WithName("TransferOwnership")
+            .WithTags("Guilds")
+            .RequireAuthorization()
+            .WithSummary("Transfer guild ownership")
+            .WithDescription("Transfers ownership of the guild to an existing member. Only the current owner can perform this action.")
+            .Produces(StatusCodes.Status204NoContent)
+            .Produces<ApplicationError>(StatusCodes.Status400BadRequest)
+            .Produces<ApplicationError>(StatusCodes.Status401Unauthorized)
+            .Produces<ApplicationError>(StatusCodes.Status403Forbidden)
+            .Produces<ApplicationError>(StatusCodes.Status404NotFound)
+            .Produces<ApplicationError>(StatusCodes.Status409Conflict)
+            .Produces<ApplicationError>(StatusCodes.Status500InternalServerError);
+    }
+
+    private static async Task<IResult> HandleAsync(
+        [AsParameters] TransferOwnershipRouteRequest routeRequest,
+        [FromBody] TransferOwnershipRequest request,
+        [FromServices] TransferOwnershipHandler handler,
+        [FromServices] IValidator<TransferOwnershipRouteRequest> routeValidator,
+        [FromServices] IValidator<TransferOwnershipRequest> validator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var routeValidationError = await routeRequest.ValidateAsync(routeValidator, cancellationToken);
+        if (routeValidationError is not null)
+            return ApplicationResponse<bool>.Fail(routeValidationError).ToHttpResult();
+
+        var validationError = await request.ValidateAsync(validator, cancellationToken);
+        if (validationError is not null)
+            return ApplicationResponse<bool>.Fail(validationError).ToHttpResult();
+
+        if (routeRequest.GuildId is not string guildIdStr
+            || !GuildId.TryParse(guildIdStr, out var parsedGuildId)
+            || parsedGuildId is null)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Common.InvalidState,
+                "Route validation succeeded but guild ID parsing failed.").ToHttpResult();
+        }
+
+        if (request.NewOwnerId is not string newOwnerIdStr
+            || !UserId.TryParse(newOwnerIdStr, out var parsedNewOwnerId)
+            || parsedNewOwnerId is null)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Common.InvalidState,
+                "Body validation succeeded but new owner ID parsing failed.").ToHttpResult();
+        }
+
+        if (!httpContext.TryGetAuthenticatedUserId(out var callerId) || callerId is null)
+        {
+            return ApplicationResponse<bool>.Fail(
+                    ApplicationErrorCodes.Auth.InvalidCredentials,
+                    "Authenticated user identifier is missing.")
+                .ToHttpResult();
+        }
+
+        var response = await handler.HandleAsync(parsedGuildId, callerId, parsedNewOwnerId, cancellationToken);
+
+        if (response.Success)
+            return Results.NoContent();
+
+        return response.ToHttpResult();
+    }
+}

--- a/src/Harmonie.Application/Features/Guilds/TransferOwnership/TransferOwnershipHandler.cs
+++ b/src/Harmonie.Application/Features/Guilds/TransferOwnership/TransferOwnershipHandler.cs
@@ -1,0 +1,121 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Interfaces;
+using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects;
+using Microsoft.Extensions.Logging;
+
+namespace Harmonie.Application.Features.Guilds.TransferOwnership;
+
+public sealed class TransferOwnershipHandler
+{
+    private readonly IGuildRepository _guildRepository;
+    private readonly IGuildMemberRepository _guildMemberRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<TransferOwnershipHandler> _logger;
+
+    public TransferOwnershipHandler(
+        IGuildRepository guildRepository,
+        IGuildMemberRepository guildMemberRepository,
+        IUnitOfWork unitOfWork,
+        ILogger<TransferOwnershipHandler> logger)
+    {
+        _guildRepository = guildRepository;
+        _guildMemberRepository = guildMemberRepository;
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task<ApplicationResponse<bool>> HandleAsync(
+        GuildId guildId,
+        UserId callerId,
+        UserId newOwnerId,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation(
+            "TransferOwnership started. GuildId={GuildId}, CallerId={CallerId}, NewOwnerId={NewOwnerId}",
+            guildId,
+            callerId,
+            newOwnerId);
+
+        var guild = await _guildRepository.GetByIdAsync(guildId, cancellationToken);
+        if (guild is null)
+        {
+            _logger.LogWarning(
+                "TransferOwnership failed because guild was not found. GuildId={GuildId}",
+                guildId);
+
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Guild.NotFound,
+                "Guild was not found");
+        }
+
+        if (guild.OwnerUserId != callerId)
+        {
+            _logger.LogWarning(
+                "TransferOwnership failed because caller is not the guild owner. GuildId={GuildId}, CallerId={CallerId}",
+                guildId,
+                callerId);
+
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Guild.AccessDenied,
+                "Only the guild owner can transfer ownership");
+        }
+
+        if (newOwnerId == callerId)
+        {
+            _logger.LogWarning(
+                "TransferOwnership failed because caller tried to transfer ownership to themselves. GuildId={GuildId}, CallerId={CallerId}",
+                guildId,
+                callerId);
+
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Guild.OwnerTransferToSelf,
+                "Cannot transfer ownership to yourself");
+        }
+
+        // Begin the transaction before the membership check so that
+        // UpdateRoleAsync executes in the same transaction scope.
+        // UpdateRoleAsync returns the number of rows affected: if 0, the
+        // member was removed concurrently after the check passed, and the
+        // transaction is abandoned (not committed) to keep state consistent.
+        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
+
+        var newOwnerRole = await _guildMemberRepository.GetRoleAsync(guildId, newOwnerId, cancellationToken);
+        if (newOwnerRole is null)
+        {
+            _logger.LogWarning(
+                "TransferOwnership failed because new owner is not a member. GuildId={GuildId}, NewOwnerId={NewOwnerId}",
+                guildId,
+                newOwnerId);
+
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Guild.MemberNotFound,
+                "The specified user is not a member of this guild");
+        }
+
+        await _guildRepository.UpdateOwnerAsync(guildId, newOwnerId, cancellationToken);
+        var rowsUpdated = await _guildMemberRepository.UpdateRoleAsync(guildId, newOwnerId, GuildRole.Admin, cancellationToken);
+
+        if (rowsUpdated == 0)
+        {
+            _logger.LogWarning(
+                "TransferOwnership aborted: new owner membership was deleted concurrently. GuildId={GuildId}, NewOwnerId={NewOwnerId}",
+                guildId,
+                newOwnerId);
+
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Guild.MemberNotFound,
+                "The specified user is not a member of this guild");
+        }
+
+        await transaction.CommitAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "TransferOwnership succeeded. GuildId={GuildId}, PreviousOwnerId={PreviousOwnerId}, NewOwnerId={NewOwnerId}",
+            guildId,
+            callerId,
+            newOwnerId);
+
+        return ApplicationResponse<bool>.Ok(true);
+    }
+}

--- a/src/Harmonie.Application/Features/Guilds/TransferOwnership/TransferOwnershipRequest.cs
+++ b/src/Harmonie.Application/Features/Guilds/TransferOwnership/TransferOwnershipRequest.cs
@@ -1,0 +1,3 @@
+namespace Harmonie.Application.Features.Guilds.TransferOwnership;
+
+public sealed record TransferOwnershipRequest(string NewOwnerId);

--- a/src/Harmonie.Application/Features/Guilds/TransferOwnership/TransferOwnershipRouteRequest.cs
+++ b/src/Harmonie.Application/Features/Guilds/TransferOwnership/TransferOwnershipRouteRequest.cs
@@ -1,0 +1,6 @@
+namespace Harmonie.Application.Features.Guilds.TransferOwnership;
+
+public sealed class TransferOwnershipRouteRequest
+{
+    public string? GuildId { get; init; }
+}

--- a/src/Harmonie.Application/Features/Guilds/TransferOwnership/TransferOwnershipRouteValidator.cs
+++ b/src/Harmonie.Application/Features/Guilds/TransferOwnership/TransferOwnershipRouteValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+
+namespace Harmonie.Application.Features.Guilds.TransferOwnership;
+
+public sealed class TransferOwnershipRouteValidator : AbstractValidator<TransferOwnershipRouteRequest>
+{
+    public TransferOwnershipRouteValidator()
+    {
+        RuleFor(x => x.GuildId)
+            .NotEmpty()
+            .WithMessage("Guild ID is required")
+            .Must(guildId => Guid.TryParse(guildId, out var parsed) && parsed != Guid.Empty)
+            .WithMessage("Guild ID must be a valid non-empty GUID");
+    }
+}

--- a/src/Harmonie.Application/Features/Guilds/TransferOwnership/TransferOwnershipValidator.cs
+++ b/src/Harmonie.Application/Features/Guilds/TransferOwnership/TransferOwnershipValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+
+namespace Harmonie.Application.Features.Guilds.TransferOwnership;
+
+public sealed class TransferOwnershipValidator : AbstractValidator<TransferOwnershipRequest>
+{
+    public TransferOwnershipValidator()
+    {
+        RuleFor(x => x.NewOwnerId)
+            .NotEmpty()
+            .WithMessage("New owner ID is required")
+            .Must(id => Guid.TryParse(id, out var parsed) && parsed != Guid.Empty)
+            .WithMessage("New owner ID must be a valid non-empty GUID");
+    }
+}

--- a/src/Harmonie.Application/Interfaces/IGuildMemberRepository.cs
+++ b/src/Harmonie.Application/Interfaces/IGuildMemberRepository.cs
@@ -33,7 +33,7 @@ public interface IGuildMemberRepository
         UserId userId,
         CancellationToken cancellationToken = default);
 
-    Task UpdateRoleAsync(
+    Task<int> UpdateRoleAsync(
         GuildId guildId,
         UserId userId,
         GuildRole newRole,

--- a/src/Harmonie.Application/Interfaces/IGuildRepository.cs
+++ b/src/Harmonie.Application/Interfaces/IGuildRepository.cs
@@ -8,4 +8,6 @@ public interface IGuildRepository
     Task<Guild?> GetByIdAsync(GuildId guildId, CancellationToken cancellationToken = default);
 
     Task AddAsync(Guild guild, CancellationToken cancellationToken = default);
+
+    Task UpdateOwnerAsync(GuildId guildId, UserId newOwnerId, CancellationToken cancellationToken = default);
 }

--- a/src/Harmonie.Infrastructure/Persistence/GuildMemberRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/GuildMemberRepository.cs
@@ -206,7 +206,7 @@ public sealed class GuildMemberRepository : IGuildMemberRepository
         await connection.ExecuteAsync(command);
     }
 
-    public async Task UpdateRoleAsync(
+    public async Task<int> UpdateRoleAsync(
         GuildId guildId,
         UserId userId,
         GuildRole newRole,
@@ -231,7 +231,7 @@ public sealed class GuildMemberRepository : IGuildMemberRepository
             transaction: _dbSession.Transaction,
             cancellationToken: cancellationToken);
 
-        await connection.ExecuteAsync(command);
+        return await connection.ExecuteAsync(command);
     }
 
     private static UserGuildMembership MapToUserGuildMembership(UserGuildMembershipDto row)

--- a/src/Harmonie.Infrastructure/Persistence/GuildRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/GuildRepository.cs
@@ -72,6 +72,29 @@ public sealed class GuildRepository : IGuildRepository
         await connection.ExecuteAsync(command);
     }
 
+    public async Task UpdateOwnerAsync(GuildId guildId, UserId newOwnerId, CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+                           UPDATE guilds
+                           SET owner_user_id = @NewOwnerId,
+                               updated_at_utc = NOW()
+                           WHERE id = @GuildId
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new
+            {
+                GuildId = guildId.Value,
+                NewOwnerId = newOwnerId.Value
+            },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        await connection.ExecuteAsync(command);
+    }
+
     private static Guild MapToGuild(GuildDto row)
     {
         var nameResult = GuildName.Create(row.Name);

--- a/tests/Harmonie.API.IntegrationTests/GuildEndpointsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/GuildEndpointsTests.cs
@@ -11,6 +11,7 @@ using Harmonie.Application.Features.Guilds.GetGuildChannels;
 using Harmonie.Application.Features.Guilds.GetGuildMembers;
 using Harmonie.Application.Features.Guilds.InviteMember;
 using Harmonie.Application.Features.Guilds.ListUserGuilds;
+using Harmonie.Application.Features.Guilds.TransferOwnership;
 using Harmonie.Application.Features.Guilds.UpdateMemberRole;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
@@ -461,6 +462,152 @@ public sealed class GuildEndpointsTests : IClassFixture<WebApplicationFactory<Pr
         };
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
         return await _client.SendAsync(request);
+    }
+
+    [Fact]
+    public async Task TransferOwnership_WhenOwnerTransfersToMember_ShouldReturn204()
+    {
+        var owner = await RegisterAsync();
+        var member = await RegisterAsync();
+
+        var createGuildResponse = await SendAuthorizedPostAsync(
+            "/api/guilds",
+            new CreateGuildRequest("Transfer Guild"),
+            owner.AccessToken);
+        createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        createGuildPayload.Should().NotBeNull();
+
+        var inviteResponse = await SendAuthorizedPostAsync(
+            $"/api/guilds/{createGuildPayload!.GuildId}/members/invite",
+            new InviteMemberRequest(member.UserId),
+            owner.AccessToken);
+        inviteResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var transferResponse = await SendAuthorizedPostAsync(
+            $"/api/guilds/{createGuildPayload.GuildId}/owner/transfer",
+            new TransferOwnershipRequest(member.UserId),
+            owner.AccessToken);
+        transferResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task TransferOwnership_WhenNonOwnerTriesToTransfer_ShouldReturn403()
+    {
+        var owner = await RegisterAsync();
+        var member = await RegisterAsync();
+        var otherMember = await RegisterAsync();
+
+        var createGuildResponse = await SendAuthorizedPostAsync(
+            "/api/guilds",
+            new CreateGuildRequest("Non Owner Transfer Guild"),
+            owner.AccessToken);
+        createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        createGuildPayload.Should().NotBeNull();
+
+        await SendAuthorizedPostAsync(
+            $"/api/guilds/{createGuildPayload!.GuildId}/members/invite",
+            new InviteMemberRequest(member.UserId),
+            owner.AccessToken);
+
+        await SendAuthorizedPostAsync(
+            $"/api/guilds/{createGuildPayload.GuildId}/members/invite",
+            new InviteMemberRequest(otherMember.UserId),
+            owner.AccessToken);
+
+        var transferResponse = await SendAuthorizedPostAsync(
+            $"/api/guilds/{createGuildPayload.GuildId}/owner/transfer",
+            new TransferOwnershipRequest(otherMember.UserId),
+            member.AccessToken);
+        transferResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        var error = await transferResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
+    }
+
+    [Fact]
+    public async Task TransferOwnership_WhenOwnerTransfersToSelf_ShouldReturn409()
+    {
+        var owner = await RegisterAsync();
+
+        var createGuildResponse = await SendAuthorizedPostAsync(
+            "/api/guilds",
+            new CreateGuildRequest("Self Transfer Guild"),
+            owner.AccessToken);
+        createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        createGuildPayload.Should().NotBeNull();
+
+        var transferResponse = await SendAuthorizedPostAsync(
+            $"/api/guilds/{createGuildPayload!.GuildId}/owner/transfer",
+            new TransferOwnershipRequest(owner.UserId),
+            owner.AccessToken);
+        transferResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
+
+        var error = await transferResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Guild.OwnerTransferToSelf);
+    }
+
+    [Fact]
+    public async Task TransferOwnership_WhenNewOwnerIsNotMember_ShouldReturn404()
+    {
+        var owner = await RegisterAsync();
+        var nonMember = await RegisterAsync();
+
+        var createGuildResponse = await SendAuthorizedPostAsync(
+            "/api/guilds",
+            new CreateGuildRequest("Non Member Transfer Guild"),
+            owner.AccessToken);
+        createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        createGuildPayload.Should().NotBeNull();
+
+        var transferResponse = await SendAuthorizedPostAsync(
+            $"/api/guilds/{createGuildPayload!.GuildId}/owner/transfer",
+            new TransferOwnershipRequest(nonMember.UserId),
+            owner.AccessToken);
+        transferResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var error = await transferResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Guild.MemberNotFound);
+    }
+
+    [Fact]
+    public async Task TransferOwnership_WhenGuildNotFound_ShouldReturn404()
+    {
+        var user = await RegisterAsync();
+        var target = await RegisterAsync();
+        var nonExistentGuildId = Guid.NewGuid();
+
+        var transferResponse = await SendAuthorizedPostAsync(
+            $"/api/guilds/{nonExistentGuildId}/owner/transfer",
+            new TransferOwnershipRequest(target.UserId),
+            user.AccessToken);
+        transferResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var error = await transferResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Guild.NotFound);
+    }
+
+    [Fact]
+    public async Task TransferOwnership_WhenNotAuthenticated_ShouldReturn401()
+    {
+        var target = await RegisterAsync();
+        var nonExistentGuildId = Guid.NewGuid();
+
+        var transferResponse = await _client.PostAsJsonAsync(
+            $"/api/guilds/{nonExistentGuildId}/owner/transfer",
+            new TransferOwnershipRequest(target.UserId));
+        transferResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/TransferOwnershipHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/TransferOwnershipHandlerTests.cs
@@ -1,0 +1,236 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Guilds.TransferOwnership;
+using Harmonie.Application.Interfaces;
+using Harmonie.Domain.Entities;
+using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests;
+
+public sealed class TransferOwnershipHandlerTests
+{
+    private readonly Mock<IGuildRepository> _guildRepositoryMock;
+    private readonly Mock<IGuildMemberRepository> _guildMemberRepositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly TransferOwnershipHandler _handler;
+
+    public TransferOwnershipHandlerTests()
+    {
+        _guildRepositoryMock = new Mock<IGuildRepository>();
+        _guildMemberRepositoryMock = new Mock<IGuildMemberRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _transactionMock = new Mock<IUnitOfWorkTransaction>();
+
+        _unitOfWorkMock
+            .Setup(x => x.BeginAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_transactionMock.Object);
+
+        _transactionMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _transactionMock
+            .Setup(x => x.DisposeAsync())
+            .Returns(ValueTask.CompletedTask);
+
+        _handler = new TransferOwnershipHandler(
+            _guildRepositoryMock.Object,
+            _guildMemberRepositoryMock.Object,
+            _unitOfWorkMock.Object,
+            NullLogger<TransferOwnershipHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenGuildNotFound_ShouldReturnNotFound()
+    {
+        var guildId = GuildId.New();
+        var callerId = UserId.New();
+        var newOwnerId = UserId.New();
+
+        _guildRepositoryMock
+            .Setup(x => x.GetByIdAsync(guildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guild?)null);
+
+        var response = await _handler.HandleAsync(guildId, callerId, newOwnerId);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.NotFound);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCallerIsNotOwner_ShouldReturnAccessDenied()
+    {
+        var ownerId = UserId.New();
+        var guild = CreateGuild(ownerId);
+        var callerId = UserId.New();
+        var newOwnerId = UserId.New();
+
+        _guildRepositoryMock
+            .Setup(x => x.GetByIdAsync(guild.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(guild);
+
+        var response = await _handler.HandleAsync(guild.Id, callerId, newOwnerId);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCallerTransfersToSelf_ShouldReturnOwnerTransferToSelf()
+    {
+        var ownerId = UserId.New();
+        var guild = CreateGuild(ownerId);
+
+        _guildRepositoryMock
+            .Setup(x => x.GetByIdAsync(guild.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(guild);
+
+        var response = await _handler.HandleAsync(guild.Id, ownerId, ownerId);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.OwnerTransferToSelf);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenNewOwnerIsNotMember_ShouldReturnMemberNotFound()
+    {
+        var ownerId = UserId.New();
+        var guild = CreateGuild(ownerId);
+        var newOwnerId = UserId.New();
+
+        _guildRepositoryMock
+            .Setup(x => x.GetByIdAsync(guild.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(guild);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.GetRoleAsync(guild.Id, newOwnerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GuildRole?)null);
+
+        var response = await _handler.HandleAsync(guild.Id, ownerId, newOwnerId);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.MemberNotFound);
+        _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenNewOwnerIsMember_ShouldSucceedAndCommitTransaction()
+    {
+        var ownerId = UserId.New();
+        var guild = CreateGuild(ownerId);
+        var newOwnerId = UserId.New();
+
+        _guildRepositoryMock
+            .Setup(x => x.GetByIdAsync(guild.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(guild);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.GetRoleAsync(guild.Id, newOwnerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GuildRole.Member);
+
+        _guildRepositoryMock
+            .Setup(x => x.UpdateOwnerAsync(guild.Id, newOwnerId, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.UpdateRoleAsync(guild.Id, newOwnerId, GuildRole.Admin, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var response = await _handler.HandleAsync(guild.Id, ownerId, newOwnerId);
+
+        response.Success.Should().BeTrue();
+        response.Error.Should().BeNull();
+        response.Data.Should().BeTrue();
+
+        _guildRepositoryMock.Verify(
+            x => x.UpdateOwnerAsync(guild.Id, newOwnerId, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _guildMemberRepositoryMock.Verify(
+            x => x.UpdateRoleAsync(guild.Id, newOwnerId, GuildRole.Admin, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _transactionMock.Verify(
+            x => x.CommitAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenNewOwnerIsAlreadyAdmin_ShouldSucceed()
+    {
+        var ownerId = UserId.New();
+        var guild = CreateGuild(ownerId);
+        var newOwnerId = UserId.New();
+
+        _guildRepositoryMock
+            .Setup(x => x.GetByIdAsync(guild.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(guild);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.GetRoleAsync(guild.Id, newOwnerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GuildRole.Admin);
+
+        _guildRepositoryMock
+            .Setup(x => x.UpdateOwnerAsync(guild.Id, newOwnerId, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.UpdateRoleAsync(guild.Id, newOwnerId, GuildRole.Admin, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var response = await _handler.HandleAsync(guild.Id, ownerId, newOwnerId);
+
+        response.Success.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenMemberDeletedConcurrently_ShouldReturnMemberNotFoundAndNotCommit()
+    {
+        var ownerId = UserId.New();
+        var guild = CreateGuild(ownerId);
+        var newOwnerId = UserId.New();
+
+        _guildRepositoryMock
+            .Setup(x => x.GetByIdAsync(guild.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(guild);
+
+        // Membership check passes (member exists at this point)
+        _guildMemberRepositoryMock
+            .Setup(x => x.GetRoleAsync(guild.Id, newOwnerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GuildRole.Member);
+
+        _guildRepositoryMock
+            .Setup(x => x.UpdateOwnerAsync(guild.Id, newOwnerId, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // UpdateRoleAsync returns 0: member was deleted concurrently between GetRoleAsync and UpdateRoleAsync
+        _guildMemberRepositoryMock
+            .Setup(x => x.UpdateRoleAsync(guild.Id, newOwnerId, GuildRole.Admin, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+
+        var response = await _handler.HandleAsync(guild.Id, ownerId, newOwnerId);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.MemberNotFound);
+
+        _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static Guild CreateGuild(UserId? ownerId = null)
+    {
+        var nameResult = GuildName.Create("Transfer Ownership Test Guild");
+        if (nameResult.IsFailure)
+            throw new InvalidOperationException("Failed to create guild name for tests.");
+
+        var guildResult = Guild.Create(nameResult.Value!, ownerId ?? UserId.New());
+        if (guildResult.IsFailure)
+            throw new InvalidOperationException("Failed to create guild for tests.");
+
+        return guildResult.Value!;
+    }
+}

--- a/tests/Harmonie.Application.Tests/UpdateMemberRoleHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/UpdateMemberRoleHandlerTests.cs
@@ -163,7 +163,7 @@ public sealed class UpdateMemberRoleHandlerTests
 
         _guildMemberRepositoryMock
             .Setup(x => x.UpdateRoleAsync(guild.Id, targetId, GuildRole.Admin, It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(1);
 
         var response = await _handler.HandleAsync(guild.Id, callerId, targetId, GuildRole.Admin);
 
@@ -197,7 +197,7 @@ public sealed class UpdateMemberRoleHandlerTests
 
         _guildMemberRepositoryMock
             .Setup(x => x.UpdateRoleAsync(guild.Id, targetId, GuildRole.Member, It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(1);
 
         var response = await _handler.HandleAsync(guild.Id, callerId, targetId, GuildRole.Member);
 


### PR DESCRIPTION
## Summary

- Implement `POST /api/guilds/{guildId}/owner/transfer` endpoint end-to-end
- Only the current guild owner can call this endpoint; attempts by other members return `403 Forbidden`
- Transferring to a non-member returns `404 Not Found`; transferring to self returns `409 Conflict`
- The operation is atomic: `guilds.owner_user_id` update and the new owner's role promotion to `Admin` are wrapped in a single transaction
- Extends `IGuildRepository` with `UpdateOwnerAsync` and `IGuildMemberRepository` with `UpdateRoleAsync` (both needed on this branch)
- Adds new error code `GUILD_OWNER_TRANSFER_TO_SELF` → `409 Conflict`

## Test plan

- [ ] Unit tests: `TransferOwnershipHandlerTests` — 5 cases covering not found, non-owner caller, transfer-to-self, non-member target, and success (member + already-admin variants)
- [ ] Integration tests: 6 new tests in `GuildEndpointsTests` covering success, non-owner 403, self-transfer 409, non-member 404, guild-not-found 404, and unauthenticated 401
- [ ] All 68 unit tests pass (`dotnet test tests/Harmonie.Application.Tests`)
- [ ] Build is warning-clean (`0 Warning(s)`)

Closes #23