### PR TITLE
feat(docker): add full stack Docker Compose setup with migrations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # PostgreSQL Database
   postgres:
@@ -22,24 +20,40 @@ services:
       timeout: 5s
       retries: 5
 
-  # Harmonie API (uncomment when ready to run in Docker)
-  # harmonie-api:
-  #   build:
-  #     context: .
-  #     dockerfile: src/Harmonie.API/Dockerfile
-  #   container_name: harmonie-api
-  #   environment:
-  #     - ASPNETCORE_ENVIRONMENT=Development
-  #     - ASPNETCORE_URLS=https://+:443;http://+:80
-  #     - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=harmonie;Username=harmonie_user;Password=harmonie_password
-  #   ports:
-  #     - "5001:80"
-  #     - "7001:443"
-  #   depends_on:
-  #     postgres:
-  #       condition: service_healthy
-  #   networks:
-  #     - harmonie-network
+  # Database migrations (runs once then exits)
+  harmonie-migrations:
+    build:
+      context: .
+      dockerfile: tools/Harmonie.Migrations/Dockerfile
+    container_name: harmonie-migrations
+    environment:
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=harmonie;Username=harmonie_user;Password=harmonie_password
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - harmonie-network
+    restart: "no"
+
+  # Harmonie API
+  harmonie-api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: harmonie-api
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_URLS=http://+:80
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=harmonie;Username=harmonie_user;Password=harmonie_password
+    ports:
+      - "5001:80"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      harmonie-migrations:
+        condition: service_completed_successfully
+    networks:
+      - harmonie-network
 
 volumes:
   postgres-data:

--- a/tools/Harmonie.Migrations/Dockerfile
+++ b/tools/Harmonie.Migrations/Dockerfile
@@ -1,0 +1,17 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY ["tools/Harmonie.Migrations/Harmonie.Migrations.csproj", "tools/Harmonie.Migrations/"]
+RUN dotnet restore "tools/Harmonie.Migrations/Harmonie.Migrations.csproj"
+
+COPY tools/Harmonie.Migrations/ tools/Harmonie.Migrations/
+WORKDIR "/src/tools/Harmonie.Migrations"
+RUN dotnet publish "Harmonie.Migrations.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+
+ENTRYPOINT ["dotnet", "Harmonie.Migrations.dll"]


### PR DESCRIPTION
Closes #62

## Changes

- **`docker-compose.yml`**: add `harmonie-migrations` and `harmonie-api` services, remove deprecated `version` field
- **`tools/Harmonie.Migrations/Dockerfile`**: new multi-stage Dockerfile to build and run the DbUp migrations console app

## Startup chain

```
postgres (healthcheck: pg_isready)
    ↓ service_healthy
harmonie-migrations (one-shot, restart: "no")
    ↓ service_completed_successfully
harmonie-api (HTTP on :5001)
```

## Usage

```bash
# Full stack
docker compose up --build

# Postgres only (local dev)
docker compose up postgres
```