### PR TITLE
CreateChannel — Reduce from 3 to 2 DB round trips

### DIFF
--- a/src/Harmonie.Application/Features/Guilds/CreateChannel/CreateChannelHandler.cs
+++ b/src/Harmonie.Application/Features/Guilds/CreateChannel/CreateChannelHandler.cs
@@ -10,20 +10,17 @@ namespace Harmonie.Application.Features.Guilds.CreateChannel;
 public sealed class CreateChannelHandler
 {
     private readonly IGuildRepository _guildRepository;
-    private readonly IGuildMemberRepository _guildMemberRepository;
     private readonly IGuildChannelRepository _guildChannelRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<CreateChannelHandler> _logger;
 
     public CreateChannelHandler(
         IGuildRepository guildRepository,
-        IGuildMemberRepository guildMemberRepository,
         IGuildChannelRepository guildChannelRepository,
         IUnitOfWork unitOfWork,
         ILogger<CreateChannelHandler> logger)
     {
         _guildRepository = guildRepository;
-        _guildMemberRepository = guildMemberRepository;
         _guildChannelRepository = guildChannelRepository;
         _unitOfWork = unitOfWork;
         _logger = logger;
@@ -44,8 +41,8 @@ public sealed class CreateChannelHandler
             name,
             channelType);
 
-        var guildExists = await _guildRepository.ExistsAsync(guildId, cancellationToken);
-        if (!guildExists)
+        var ctx = await _guildRepository.GetWithCallerRoleAsync(guildId, callerId, cancellationToken);
+        if (ctx is null)
         {
             _logger.LogWarning(
                 "CreateChannel failed because guild was not found. GuildId={GuildId}",
@@ -56,26 +53,12 @@ public sealed class CreateChannelHandler
                 "Guild was not found");
         }
 
-        var role = await _guildMemberRepository.GetRoleAsync(guildId, callerId, cancellationToken);
-        if (role is null)
+        if (ctx.CallerRole is null || ctx.CallerRole != GuildRole.Admin)
         {
             _logger.LogWarning(
-                "CreateChannel failed because caller is not a member. GuildId={GuildId}, CallerId={CallerId}",
+                "CreateChannel failed because caller is not an admin. GuildId={GuildId}, CallerId={CallerId}",
                 guildId,
                 callerId);
-
-            return ApplicationResponse<CreateChannelResponse>.Fail(
-                ApplicationErrorCodes.Guild.AccessDenied,
-                "You do not have access to this guild");
-        }
-
-        if (role != GuildRole.Admin)
-        {
-            _logger.LogWarning(
-                "CreateChannel failed because caller is not an admin. GuildId={GuildId}, CallerId={CallerId}, Role={Role}",
-                guildId,
-                callerId,
-                role);
 
             return ApplicationResponse<CreateChannelResponse>.Fail(
                 ApplicationErrorCodes.Guild.AccessDenied,

--- a/tests/Harmonie.Application.Tests/CreateChannelHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/CreateChannelHandlerTests.cs
@@ -14,7 +14,6 @@ namespace Harmonie.Application.Tests;
 public sealed class CreateChannelHandlerTests
 {
     private readonly Mock<IGuildRepository> _guildRepositoryMock;
-    private readonly Mock<IGuildMemberRepository> _guildMemberRepositoryMock;
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
@@ -23,7 +22,6 @@ public sealed class CreateChannelHandlerTests
     public CreateChannelHandlerTests()
     {
         _guildRepositoryMock = new Mock<IGuildRepository>();
-        _guildMemberRepositoryMock = new Mock<IGuildMemberRepository>();
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
@@ -42,7 +40,6 @@ public sealed class CreateChannelHandlerTests
 
         _handler = new CreateChannelHandler(
             _guildRepositoryMock.Object,
-            _guildMemberRepositoryMock.Object,
             _guildChannelRepositoryMock.Object,
             _unitOfWorkMock.Object,
             NullLogger<CreateChannelHandler>.Instance);
@@ -55,8 +52,8 @@ public sealed class CreateChannelHandlerTests
         var callerId = UserId.New();
 
         _guildRepositoryMock
-            .Setup(x => x.ExistsAsync(guildId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
+            .Setup(x => x.GetWithCallerRoleAsync(guildId, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GuildAccessContext?)null);
 
         var response = await _handler.HandleAsync(guildId, callerId, "general", GuildChannelType.Text, 0);
 
@@ -68,18 +65,14 @@ public sealed class CreateChannelHandlerTests
     [Fact]
     public async Task HandleAsync_WhenCallerIsNotMember_ShouldReturnAccessDenied()
     {
-        var guildId = GuildId.New();
+        var guild = CreateGuild();
         var callerId = UserId.New();
 
         _guildRepositoryMock
-            .Setup(x => x.ExistsAsync(guildId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
+            .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildAccessContext(guild, null));
 
-        _guildMemberRepositoryMock
-            .Setup(x => x.GetRoleAsync(guildId, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((GuildRole?)null);
-
-        var response = await _handler.HandleAsync(guildId, callerId, "general", GuildChannelType.Text, 0);
+        var response = await _handler.HandleAsync(guild.Id, callerId, "general", GuildChannelType.Text, 0);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -89,18 +82,14 @@ public sealed class CreateChannelHandlerTests
     [Fact]
     public async Task HandleAsync_WhenCallerIsMemberNotAdmin_ShouldReturnAccessDenied()
     {
-        var guildId = GuildId.New();
+        var guild = CreateGuild();
         var callerId = UserId.New();
 
         _guildRepositoryMock
-            .Setup(x => x.ExistsAsync(guildId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
+            .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
 
-        _guildMemberRepositoryMock
-            .Setup(x => x.GetRoleAsync(guildId, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(GuildRole.Member);
-
-        var response = await _handler.HandleAsync(guildId, callerId, "general", GuildChannelType.Text, 0);
+        var response = await _handler.HandleAsync(guild.Id, callerId, "general", GuildChannelType.Text, 0);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -110,26 +99,22 @@ public sealed class CreateChannelHandlerTests
     [Fact]
     public async Task HandleAsync_WhenNameAlreadyExistsInGuild_ShouldReturnNameConflict()
     {
-        var guildId = GuildId.New();
+        var guild = CreateGuild();
         var adminId = UserId.New();
 
         _guildRepositoryMock
-            .Setup(x => x.ExistsAsync(guildId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
-
-        _guildMemberRepositoryMock
-            .Setup(x => x.GetRoleAsync(guildId, adminId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(GuildRole.Admin);
+            .Setup(x => x.GetWithCallerRoleAsync(guild.Id, adminId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Admin));
 
         _guildChannelRepositoryMock
             .Setup(x => x.ExistsByNameInGuildAsync(
-                guildId,
+                guild.Id,
                 "announcements",
                 It.IsAny<GuildChannelId>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        var response = await _handler.HandleAsync(guildId, adminId, "announcements", GuildChannelType.Text, 2);
+        var response = await _handler.HandleAsync(guild.Id, adminId, "announcements", GuildChannelType.Text, 2);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -139,23 +124,19 @@ public sealed class CreateChannelHandlerTests
     [Fact]
     public async Task HandleAsync_WhenAdminCreatesTextChannel_ShouldReturnCreatedChannel()
     {
-        var guildId = GuildId.New();
+        var guild = CreateGuild();
         var adminId = UserId.New();
 
         _guildRepositoryMock
-            .Setup(x => x.ExistsAsync(guildId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
+            .Setup(x => x.GetWithCallerRoleAsync(guild.Id, adminId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Admin));
 
-        _guildMemberRepositoryMock
-            .Setup(x => x.GetRoleAsync(guildId, adminId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(GuildRole.Admin);
-
-        var response = await _handler.HandleAsync(guildId, adminId, "announcements", GuildChannelType.Text, 2);
+        var response = await _handler.HandleAsync(guild.Id, adminId, "announcements", GuildChannelType.Text, 2);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
         response.Data.Should().NotBeNull();
-        response.Data!.GuildId.Should().Be(guildId.ToString());
+        response.Data!.GuildId.Should().Be(guild.Id.ToString());
         response.Data.Name.Should().Be("announcements");
         response.Data.Type.Should().Be("Text");
         response.Data.IsDefault.Should().BeFalse();
@@ -166,18 +147,14 @@ public sealed class CreateChannelHandlerTests
     [Fact]
     public async Task HandleAsync_WhenAdminCreatesVoiceChannel_ShouldReturnCreatedChannel()
     {
-        var guildId = GuildId.New();
+        var guild = CreateGuild();
         var adminId = UserId.New();
 
         _guildRepositoryMock
-            .Setup(x => x.ExistsAsync(guildId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
+            .Setup(x => x.GetWithCallerRoleAsync(guild.Id, adminId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Admin));
 
-        _guildMemberRepositoryMock
-            .Setup(x => x.GetRoleAsync(guildId, adminId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(GuildRole.Admin);
-
-        var response = await _handler.HandleAsync(guildId, adminId, "Gaming", GuildChannelType.Voice, 5);
+        var response = await _handler.HandleAsync(guild.Id, adminId, "Gaming", GuildChannelType.Voice, 5);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -190,18 +167,14 @@ public sealed class CreateChannelHandlerTests
     [Fact]
     public async Task HandleAsync_WhenAdminCreatesChannel_ShouldPersistAndCommit()
     {
-        var guildId = GuildId.New();
+        var guild = CreateGuild();
         var adminId = UserId.New();
 
         _guildRepositoryMock
-            .Setup(x => x.ExistsAsync(guildId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
+            .Setup(x => x.GetWithCallerRoleAsync(guild.Id, adminId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Admin));
 
-        _guildMemberRepositoryMock
-            .Setup(x => x.GetRoleAsync(guildId, adminId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(GuildRole.Admin);
-
-        await _handler.HandleAsync(guildId, adminId, "lounge", GuildChannelType.Text, 3);
+        await _handler.HandleAsync(guild.Id, adminId, "lounge", GuildChannelType.Text, 3);
 
         _guildChannelRepositoryMock.Verify(
             x => x.AddAsync(It.IsAny<GuildChannel>(), It.IsAny<CancellationToken>()),
@@ -210,5 +183,18 @@ public sealed class CreateChannelHandlerTests
         _transactionMock.Verify(
             x => x.CommitAsync(It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    private static Guild CreateGuild()
+    {
+        var nameResult = GuildName.Create("Create Channel Test Guild");
+        if (nameResult.IsFailure)
+            throw new InvalidOperationException("Failed to create guild name for tests.");
+
+        var guildResult = Guild.Create(nameResult.Value!, UserId.New());
+        if (guildResult.IsFailure)
+            throw new InvalidOperationException("Failed to create guild for tests.");
+
+        return guildResult.Value!;
     }
 }


### PR DESCRIPTION
## Summary
- Replace `ExistsAsync` + `GetRoleAsync` (2 DB calls) with single `GetWithCallerRoleAsync` via `GuildAccessContext`
- Remove `IGuildMemberRepository` dependency from `CreateChannelHandler`
- Update all unit tests to use `GuildAccessContext` pattern

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — all 254 tests pass (42 + 119 + 93)

Closes #54