### PR TITLE
Register — Combine duplicate email/username checks into single query

### DIFF
--- a/src/Harmonie.Application/Features/Auth/Register/RegisterHandler.cs
+++ b/src/Harmonie.Application/Features/Auth/Register/RegisterHandler.cs
@@ -64,12 +64,14 @@ public sealed class RegisterHandler
         }
 
         // Check for duplicates
-        if (await _userRepository.ExistsByEmailAsync(emailResult.Value, cancellationToken))
+        var duplicates = await _userRepository.CheckDuplicatesAsync(emailResult.Value, usernameResult.Value, cancellationToken);
+
+        if (duplicates.EmailExists)
             return ApplicationResponse<RegisterResponse>.Fail(
                 ApplicationErrorCodes.Auth.DuplicateEmail,
                 $"A user with email '{emailResult.Value}' already exists");
 
-        if (await _userRepository.ExistsByUsernameAsync(usernameResult.Value, cancellationToken))
+        if (duplicates.UsernameExists)
             return ApplicationResponse<RegisterResponse>.Fail(
                 ApplicationErrorCodes.Auth.DuplicateUsername,
                 $"A user with username '{usernameResult.Value}' already exists");

--- a/src/Harmonie.Application/Interfaces/IUserRepository.cs
+++ b/src/Harmonie.Application/Interfaces/IUserRepository.cs
@@ -3,6 +3,8 @@ using Harmonie.Domain.ValueObjects;
 
 namespace Harmonie.Application.Interfaces;
 
+public sealed record UserDuplicateCheck(bool EmailExists, bool UsernameExists);
+
 /// <summary>
 /// Repository interface for User aggregate.
 /// This is a "port" in Hexagonal Architecture - the infrastructure layer provides the implementation.
@@ -33,6 +35,11 @@ public interface IUserRepository
     /// Check if a username already exists
     /// </summary>
     Task<bool> ExistsByUsernameAsync(Username username, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Check email and username uniqueness in a single query
+    /// </summary>
+    Task<UserDuplicateCheck> CheckDuplicatesAsync(Email email, Username username, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Add a new user

--- a/src/Harmonie.Infrastructure/Persistence/UserRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/UserRepository.cs
@@ -98,6 +98,21 @@ public sealed class UserRepository : IUserRepository
         return await conn.ExecuteScalarAsync<bool>(cmd);
     }
 
+    public async Task<UserDuplicateCheck> CheckDuplicatesAsync(Email email, Username username, CancellationToken ct = default)
+    {
+        const string sql = """
+                           SELECT EXISTS(SELECT 1 FROM users WHERE email = @Email AND deleted_at IS NULL) AS "EmailExists",
+                                  EXISTS(SELECT 1 FROM users WHERE username = @Username AND deleted_at IS NULL) AS "UsernameExists"
+                           """;
+        var conn = await _dbSession.GetOpenConnectionAsync(ct);
+        var cmd = new CommandDefinition(
+            sql,
+            new { Email = email.Value, Username = username.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: ct);
+        return await conn.QueryFirstAsync<UserDuplicateCheck>(cmd);
+    }
+
     public async Task AddAsync(User user, CancellationToken ct = default)
     {
         const string sql = @"

--- a/tests/Harmonie.Application.Tests/RegisterHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/RegisterHandlerTests.cs
@@ -57,12 +57,8 @@ public sealed class RegisterHandlerTests
             "Test123!@#");
 
         _userRepositoryMock
-            .Setup(x => x.ExistsByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
-
-        _userRepositoryMock
-            .Setup(x => x.ExistsByUsernameAsync(It.IsAny<Username>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
+            .Setup(x => x.CheckDuplicatesAsync(It.IsAny<Email>(), It.IsAny<Username>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserDuplicateCheck(false, false));
 
         _passwordHasherMock
             .Setup(x => x.HashPassword(It.IsAny<string>(), It.IsAny<string>()))
@@ -136,12 +132,8 @@ public sealed class RegisterHandlerTests
             "Test123!@#");
 
         _userRepositoryMock
-            .Setup(x => x.ExistsByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
-
-        _userRepositoryMock
-            .Setup(x => x.ExistsByUsernameAsync(It.IsAny<Username>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
+            .Setup(x => x.CheckDuplicatesAsync(It.IsAny<Email>(), It.IsAny<Username>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserDuplicateCheck(false, false));
 
         _passwordHasherMock
             .Setup(x => x.HashPassword(It.IsAny<string>(), It.IsAny<string>()))
@@ -216,8 +208,8 @@ public sealed class RegisterHandlerTests
             "Test123!@#");
 
         _userRepositoryMock
-            .Setup(x => x.ExistsByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
+            .Setup(x => x.CheckDuplicatesAsync(It.IsAny<Email>(), It.IsAny<Username>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserDuplicateCheck(true, false));
 
         // Act
         var response = await _handler.HandleAsync(request);
@@ -239,12 +231,8 @@ public sealed class RegisterHandlerTests
             "Test123!@#");
 
         _userRepositoryMock
-            .Setup(x => x.ExistsByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
-
-        _userRepositoryMock
-            .Setup(x => x.ExistsByUsernameAsync(It.IsAny<Username>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
+            .Setup(x => x.CheckDuplicatesAsync(It.IsAny<Email>(), It.IsAny<Username>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserDuplicateCheck(false, true));
 
         // Act
         var response = await _handler.HandleAsync(request);


### PR DESCRIPTION
## Summary
- Add `UserDuplicateCheck` record and `CheckDuplicatesAsync` to `IUserRepository`
- Implement in `UserRepository` with a single SQL query checking both fields simultaneously
- Replace 2 sequential calls in `RegisterHandler` with single `CheckDuplicatesAsync` call
- Update unit tests to mock the new method

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — all 254 tests pass

Closes #55