### PR TITLE
feat(voice): LiveKit infrastructure setup + ILiveKitTokenService

### DIFF
--- a/Harmonie.sln
+++ b/Harmonie.sln
@@ -3,8 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-
-# Source Projects
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmonie.Domain", "src\Harmonie.Domain\Harmonie.Domain.csproj", "{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmonie.Application", "src\Harmonie.Application\Harmonie.Application.csproj", "{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A2}"
@@ -13,20 +11,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmonie.Infrastructure", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmonie.API", "src\Harmonie.API\Harmonie.API.csproj", "{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A4}"
 EndProject
-
-# Test Projects
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmonie.Domain.Tests", "tests\Harmonie.Domain.Tests\Harmonie.Domain.Tests.csproj", "{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmonie.Application.Tests", "tests\Harmonie.Application.Tests\Harmonie.Application.Tests.csproj", "{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmonie.API.IntegrationTests", "tests\Harmonie.API.IntegrationTests\Harmonie.API.IntegrationTests.csproj", "{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B3}"
 EndProject
-
-# Tools
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmonie.Migrations", "tools\Harmonie.Migrations\Harmonie.Migrations.csproj", "{D1E7A1F1-8C2E-4D3A-9F5B-1234567890C1}"
 EndProject
-
-# Solution Folders
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E1E7A1F1-8C2E-4D3A-9F5B-1234567890D1}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{E1E7A1F1-8C2E-4D3A-9F5B-1234567890D2}"
@@ -50,45 +42,126 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{B5EEC096-4
 		docs\VERTICAL_SLICE_ARCHITECTURE.md = docs\VERTICAL_SLICE_ARCHITECTURE.md
 	EndProjectSection
 EndProject
-
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmonie.Infrastructure.Tests", "tests\Harmonie.Infrastructure.Tests\Harmonie.Infrastructure.Tests.csproj", "{41BF7DBE-349D-41F0-8779-CD2A42AAB553}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A1}.Debug|x64.Build.0 = Debug|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A1}.Debug|x86.Build.0 = Debug|Any CPU
 		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A1}.Release|x64.ActiveCfg = Release|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A1}.Release|x64.Build.0 = Release|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A1}.Release|x86.ActiveCfg = Release|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A1}.Release|x86.Build.0 = Release|Any CPU
 		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A2}.Debug|x64.Build.0 = Debug|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A2}.Debug|x86.Build.0 = Debug|Any CPU
 		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A2}.Release|x64.ActiveCfg = Release|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A2}.Release|x64.Build.0 = Release|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A2}.Release|x86.ActiveCfg = Release|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A2}.Release|x86.Build.0 = Release|Any CPU
 		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A3}.Debug|x64.Build.0 = Debug|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A3}.Debug|x86.Build.0 = Debug|Any CPU
 		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A3}.Release|x64.ActiveCfg = Release|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A3}.Release|x64.Build.0 = Release|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A3}.Release|x86.ActiveCfg = Release|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A3}.Release|x86.Build.0 = Release|Any CPU
 		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A4}.Debug|x64.Build.0 = Debug|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A4}.Debug|x86.Build.0 = Debug|Any CPU
 		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A4}.Release|x64.ActiveCfg = Release|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A4}.Release|x64.Build.0 = Release|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A4}.Release|x86.ActiveCfg = Release|Any CPU
+		{B1E7A1F1-8C2E-4D3A-9F5B-1234567890A4}.Release|x86.Build.0 = Release|Any CPU
 		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B1}.Debug|x64.Build.0 = Debug|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B1}.Debug|x86.Build.0 = Debug|Any CPU
 		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B1}.Release|x64.ActiveCfg = Release|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B1}.Release|x64.Build.0 = Release|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B1}.Release|x86.ActiveCfg = Release|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B1}.Release|x86.Build.0 = Release|Any CPU
 		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B2}.Debug|x64.Build.0 = Debug|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B2}.Debug|x86.Build.0 = Debug|Any CPU
 		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B2}.Release|x64.ActiveCfg = Release|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B2}.Release|x64.Build.0 = Release|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B2}.Release|x86.ActiveCfg = Release|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B2}.Release|x86.Build.0 = Release|Any CPU
 		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B3}.Debug|x64.Build.0 = Debug|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B3}.Debug|x86.Build.0 = Debug|Any CPU
 		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B3}.Release|x64.ActiveCfg = Release|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B3}.Release|x64.Build.0 = Release|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B3}.Release|x86.ActiveCfg = Release|Any CPU
+		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B3}.Release|x86.Build.0 = Release|Any CPU
 		{D1E7A1F1-8C2E-4D3A-9F5B-1234567890C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D1E7A1F1-8C2E-4D3A-9F5B-1234567890C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D1E7A1F1-8C2E-4D3A-9F5B-1234567890C1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D1E7A1F1-8C2E-4D3A-9F5B-1234567890C1}.Debug|x64.Build.0 = Debug|Any CPU
+		{D1E7A1F1-8C2E-4D3A-9F5B-1234567890C1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D1E7A1F1-8C2E-4D3A-9F5B-1234567890C1}.Debug|x86.Build.0 = Debug|Any CPU
 		{D1E7A1F1-8C2E-4D3A-9F5B-1234567890C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1E7A1F1-8C2E-4D3A-9F5B-1234567890C1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D1E7A1F1-8C2E-4D3A-9F5B-1234567890C1}.Release|x64.ActiveCfg = Release|Any CPU
+		{D1E7A1F1-8C2E-4D3A-9F5B-1234567890C1}.Release|x64.Build.0 = Release|Any CPU
+		{D1E7A1F1-8C2E-4D3A-9F5B-1234567890C1}.Release|x86.ActiveCfg = Release|Any CPU
+		{D1E7A1F1-8C2E-4D3A-9F5B-1234567890C1}.Release|x86.Build.0 = Release|Any CPU
+		{41BF7DBE-349D-41F0-8779-CD2A42AAB553}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{41BF7DBE-349D-41F0-8779-CD2A42AAB553}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{41BF7DBE-349D-41F0-8779-CD2A42AAB553}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{41BF7DBE-349D-41F0-8779-CD2A42AAB553}.Debug|x64.Build.0 = Debug|Any CPU
+		{41BF7DBE-349D-41F0-8779-CD2A42AAB553}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{41BF7DBE-349D-41F0-8779-CD2A42AAB553}.Debug|x86.Build.0 = Debug|Any CPU
+		{41BF7DBE-349D-41F0-8779-CD2A42AAB553}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{41BF7DBE-349D-41F0-8779-CD2A42AAB553}.Release|Any CPU.Build.0 = Release|Any CPU
+		{41BF7DBE-349D-41F0-8779-CD2A42AAB553}.Release|x64.ActiveCfg = Release|Any CPU
+		{41BF7DBE-349D-41F0-8779-CD2A42AAB553}.Release|x64.Build.0 = Release|Any CPU
+		{41BF7DBE-349D-41F0-8779-CD2A42AAB553}.Release|x86.ActiveCfg = Release|Any CPU
+		{41BF7DBE-349D-41F0-8779-CD2A42AAB553}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -102,6 +175,7 @@ Global
 		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B2} = {E1E7A1F1-8C2E-4D3A-9F5B-1234567890D2}
 		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B3} = {E1E7A1F1-8C2E-4D3A-9F5B-1234567890D2}
 		{D1E7A1F1-8C2E-4D3A-9F5B-1234567890C1} = {E1E7A1F1-8C2E-4D3A-9F5B-1234567890D3}
+		{41BF7DBE-349D-41F0-8779-CD2A42AAB553} = {E1E7A1F1-8C2E-4D3A-9F5B-1234567890D2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F1E7A1F1-8C2E-4D3A-9F5B-1234567890E1}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,20 @@ services:
       - harmonie-network
     restart: "no"
 
+  # LiveKit Server
+  livekit:
+    image: livekit/livekit-server:latest
+    container_name: harmonie-livekit
+    command:
+      - --dev
+      - --webhook-urls=http://harmonie-api:80/api/webhooks/livekit
+    ports:
+      - "7880:7880"
+      - "7881:7881"
+      - "50000-60000:50000-60000/udp"
+    networks:
+      - harmonie-network
+
   # Harmonie API
   harmonie-api:
     build:

--- a/src/Harmonie.API/appsettings.Development.json
+++ b/src/Harmonie.API/appsettings.Development.json
@@ -6,6 +6,11 @@
     "AccessTokenExpirationMinutes": 15,
     "RefreshTokenExpirationDays": 30
   },
+  "LiveKit": {
+    "Url": "http://localhost:7880",
+    "ApiKey": "devkey",
+    "ApiSecret": "secret"
+  },
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5432;Database=harmonie;Username=harmonie_user;Password=harmonie_password"
   },

--- a/src/Harmonie.Application/Interfaces/ILiveKitTokenService.cs
+++ b/src/Harmonie.Application/Interfaces/ILiveKitTokenService.cs
@@ -1,0 +1,8 @@
+using Harmonie.Domain.ValueObjects;
+
+namespace Harmonie.Application.Interfaces;
+
+public interface ILiveKitTokenService
+{
+    Task<string> GenerateRoomTokenAsync(GuildChannelId channelId, UserId userId, string username, CancellationToken ct);
+}

--- a/src/Harmonie.Infrastructure/Authentication/LiveKitTokenService.cs
+++ b/src/Harmonie.Infrastructure/Authentication/LiveKitTokenService.cs
@@ -1,0 +1,25 @@
+using Harmonie.Application.Interfaces;
+using Harmonie.Domain.ValueObjects;
+using Harmonie.Infrastructure.Configuration;
+using Livekit.Server.Sdk.Dotnet;
+using Microsoft.Extensions.Options;
+
+namespace Harmonie.Infrastructure.Authentication;
+
+public sealed class LiveKitTokenService : ILiveKitTokenService
+{
+    private readonly LiveKitSettings _settings;
+
+    public LiveKitTokenService(IOptions<LiveKitSettings> settings) => _settings = settings.Value;
+
+    public Task<string> GenerateRoomTokenAsync(GuildChannelId channelId, UserId userId, string username, CancellationToken ct)
+    {
+        var jwt = new AccessToken(_settings.ApiKey, _settings.ApiSecret)
+            .WithIdentity(userId.ToString())
+            .WithName(username)
+            .WithGrants(new VideoGrants { RoomJoin = true, Room = $"channel:{channelId}" })
+            .ToJwt();
+
+        return Task.FromResult(jwt);
+    }
+}

--- a/src/Harmonie.Infrastructure/Configuration/LiveKitSettings.cs
+++ b/src/Harmonie.Infrastructure/Configuration/LiveKitSettings.cs
@@ -1,0 +1,8 @@
+namespace Harmonie.Infrastructure.Configuration;
+
+public sealed class LiveKitSettings
+{
+    public string Url { get; init; } = null!;
+    public string ApiKey { get; init; } = null!;
+    public string ApiSecret { get; init; } = null!;
+}

--- a/src/Harmonie.Infrastructure/DependencyInjection.cs
+++ b/src/Harmonie.Infrastructure/DependencyInjection.cs
@@ -12,8 +12,10 @@ public static class DependencyInjection
     {
         services.Configure<JwtSettings>(configuration.GetSection("Jwt"));
         services.Configure<DatabaseSettings>(configuration.GetSection("Database"));
+        services.Configure<LiveKitSettings>(configuration.GetSection("LiveKit"));
         services.AddScoped<IPasswordHasher, PasswordHasher>();
         services.AddScoped<IJwtTokenService, JwtTokenService>();
+        services.AddScoped<ILiveKitTokenService, LiveKitTokenService>();
 
         var connectionString = configuration.GetConnectionString("DefaultConnection");
         if (string.IsNullOrWhiteSpace(connectionString))

--- a/src/Harmonie.Infrastructure/Harmonie.Infrastructure.csproj
+++ b/src/Harmonie.Infrastructure/Harmonie.Infrastructure.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <!-- Database -->
     <PackageReference Include="Dapper" Version="2.1.66" />
+    <PackageReference Include="Livekit.Server.Sdk.Dotnet" Version="1.2.0" />
     <PackageReference Include="Npgsql" Version="10.0.0" />
     
     <!-- JWT -->

--- a/tests/Harmonie.Infrastructure.Tests/Harmonie.Infrastructure.Tests.csproj
+++ b/tests/Harmonie.Infrastructure.Tests/Harmonie.Infrastructure.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Harmonie.Infrastructure\Harmonie.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Harmonie.Infrastructure.Tests/LiveKitTokenServiceTests.cs
+++ b/tests/Harmonie.Infrastructure.Tests/LiveKitTokenServiceTests.cs
@@ -1,0 +1,87 @@
+using System.IdentityModel.Tokens.Jwt;
+using FluentAssertions;
+using Harmonie.Domain.ValueObjects;
+using Harmonie.Infrastructure.Authentication;
+using Harmonie.Infrastructure.Configuration;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Harmonie.Infrastructure.Tests;
+
+public sealed class LiveKitTokenServiceTests
+{
+    private readonly LiveKitTokenService _service;
+    private readonly string _apiKey = "testkey";
+    private readonly string _apiSecret = "testsecret-that-is-long-enough-for-hmac";
+
+    public LiveKitTokenServiceTests()
+    {
+        var settings = Options.Create(new LiveKitSettings
+        {
+            Url = "http://localhost:7880",
+            ApiKey = _apiKey,
+            ApiSecret = _apiSecret,
+        });
+        _service = new LiveKitTokenService(settings);
+    }
+
+    [Fact]
+    public async Task GenerateRoomTokenAsync_ShouldReturnValidJwt()
+    {
+        var channelId = GuildChannelId.New();
+        var userId = UserId.New();
+        const string username = "testuser";
+
+        var token = await _service.GenerateRoomTokenAsync(channelId, userId, username, CancellationToken.None);
+
+        token.Should().NotBeNullOrWhiteSpace();
+        token.Split('.').Should().HaveCount(3, "a JWT must have three segments");
+    }
+
+    [Fact]
+    public async Task GenerateRoomTokenAsync_ShouldEmbedUserIdAsIdentity()
+    {
+        var channelId = GuildChannelId.New();
+        var userId = UserId.New();
+        const string username = "testuser";
+
+        var token = await _service.GenerateRoomTokenAsync(channelId, userId, username, CancellationToken.None);
+
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(token);
+        var sub = jwt.Subject;
+
+        sub.Should().Be(userId.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateRoomTokenAsync_ShouldEmbedRoomNameWithChannelConvention()
+    {
+        var channelId = GuildChannelId.New();
+        var userId = UserId.New();
+        const string username = "testuser";
+
+        var token = await _service.GenerateRoomTokenAsync(channelId, userId, username, CancellationToken.None);
+
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(token);
+
+        // LiveKit embeds VideoGrants in the "video" claim as a JSON object
+        var videoClaim = jwt.Claims.FirstOrDefault(c => c.Type == "video");
+        videoClaim.Should().NotBeNull();
+        videoClaim!.Value.Should().Contain($"channel:{channelId}");
+    }
+
+    [Fact]
+    public async Task GenerateRoomTokenAsync_DifferentChannels_ShouldProduceDifferentTokens()
+    {
+        var userId = UserId.New();
+        var channelId1 = GuildChannelId.New();
+        var channelId2 = GuildChannelId.New();
+
+        var token1 = await _service.GenerateRoomTokenAsync(channelId1, userId, "user", CancellationToken.None);
+        var token2 = await _service.GenerateRoomTokenAsync(channelId2, userId, "user", CancellationToken.None);
+
+        token1.Should().NotBe(token2);
+    }
+}


### PR DESCRIPTION
Closes #71

## Summary

- **Docker Compose**: adds `livekit/livekit-server` service on the internal network with webhook pointing to `http://harmonie-api:80/api/webhooks/livekit`; exposes ports `7880`, `7881`, `50000-60000/udp`
- **NuGet**: adds `Livekit.Server.Sdk.Dotnet 1.2.0` to `Harmonie.Infrastructure`
- **Config**: `LiveKitSettings` POCO + `LiveKit:Url/ApiKey/ApiSecret` in `appsettings.Development.json`
- **Interface**: `ILiveKitTokenService.GenerateRoomTokenAsync` in `Harmonie.Application.Interfaces`
- **Implementation**: `LiveKitTokenService` using `AccessToken` + `VideoGrants { RoomJoin = true, Room = "channel:{channelId}" }`
- **DI**: registered in `Harmonie.Infrastructure/DependencyInjection.cs`
- **Tests**: new `Harmonie.Infrastructure.Tests` project with 4 unit tests covering token generation, identity embedding, room name convention, and token uniqueness per channel

## Test plan

- [ ] `dotnet test` — all 258 tests pass
- [ ] `docker compose up` — livekit service starts and is reachable on port 7880
- [ ] Token returned by `GenerateRoomTokenAsync` decodes with correct `sub` (userId) and `video.room` (`channel:{channelId}`)