### PR TITLE
Implement issue 188 critical and high fixes

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -42,15 +42,20 @@ dotnet run --project src/Harmonie.API
 LiveKit defaults are split on purpose:
 - `LiveKit:PublicUrl` is the client-facing WebSocket URL returned by the API.
 - `LiveKit:InternalUrl` is the HTTP base URL used by the server SDK for room queries.
+- `LiveKit:RequestTimeoutSeconds` controls the timeout applied to outbound LiveKit HTTP calls. The development default is `5`.
 
 When you run through `docker-compose`, the API container uses `http://livekit:7880` internally while clients still use `ws://localhost:7880`.
+
+CORS allowed origins are configured through `Cors:AllowedOrigins`.
+In `Development`, the default is `["*"]`.
+For non-development environments, set explicit origins in configuration or environment variables such as `Cors__AllowedOrigins__0=https://app.example.com`.
 
 Uploads are stored on the local filesystem and served by the API from `/files/*`.
 In `docker-compose`, the API stores them in the `uploads-data` volume.
 
 ## 4. Verify the API
 
-- Health: `GET /health`
+- Health: `GET /health` (checks both PostgreSQL and LiveKit reachability)
 - Register: `POST /api/auth/register`
 - Login: `POST /api/auth/login`
 - Logout current session: `POST /api/auth/logout`

--- a/src/Harmonie.API/Configuration/CorsSettings.cs
+++ b/src/Harmonie.API/Configuration/CorsSettings.cs
@@ -1,0 +1,6 @@
+namespace Harmonie.API.Configuration;
+
+public sealed class CorsSettings
+{
+    public string[] AllowedOrigins { get; init; } = [];
+}

--- a/src/Harmonie.API/Middleware/AuthenticatedUserContextMiddleware.cs
+++ b/src/Harmonie.API/Middleware/AuthenticatedUserContextMiddleware.cs
@@ -1,0 +1,39 @@
+using Harmonie.Application.Common;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Harmonie.API.Middleware;
+
+public sealed class AuthenticatedUserContextMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public AuthenticatedUserContextMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!RequiresAuthorization(context))
+        {
+            await _next(context);
+            return;
+        }
+
+        if (!context.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
+        {
+            await EndpointExtensions.WriteErrorAsync(
+                context.Response,
+                new ApplicationError(
+                    ApplicationErrorCodes.Auth.InvalidCredentials,
+                    "Authenticated user identifier is missing."));
+            return;
+        }
+
+        context.SetAuthenticatedUserId(currentUserId);
+        await _next(context);
+    }
+
+    private static bool RequiresAuthorization(HttpContext context)
+        => context.GetEndpoint()?.Metadata.GetMetadata<IAuthorizeData>() is not null;
+}

--- a/src/Harmonie.API/Program.cs
+++ b/src/Harmonie.API/Program.cs
@@ -2,6 +2,7 @@ using Harmonie.API.Middleware;
 using Harmonie.API.RealTime;
 using Harmonie.Application;
 using Harmonie.Application.Common;
+using Harmonie.API.Configuration;
 using Harmonie.Application.Features.Auth.Login;
 using Harmonie.Application.Features.Auth.LogoutAll;
 using Harmonie.Application.Features.Auth.Logout;
@@ -41,7 +42,10 @@ using Harmonie.Application.Features.Uploads.UploadFile;
 using Harmonie.Application.Features.Voice.HandleLiveKitWebhook;
 using Harmonie.Application.Interfaces;
 using Harmonie.Infrastructure;
+using Harmonie.Infrastructure.Configuration;
+using Harmonie.Infrastructure.HealthChecks;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.IdentityModel.Tokens;
 using Serilog;
@@ -51,6 +55,8 @@ using System.Threading.RateLimiting;
 using Microsoft.OpenApi;
 using Scalar.AspNetCore;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System.Text.Json;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -65,6 +71,7 @@ builder.Host.UseSerilog();
 
 // Add layers
 builder.Services.AddApplication();
+builder.Services.Configure<CorsSettings>(builder.Configuration.GetSection("Cors"));
 builder.Services.Configure<UploadOptions>(builder.Configuration.GetSection("Uploads"));
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
@@ -75,6 +82,9 @@ builder.Services.AddSignalR();
 builder.Services.AddScoped<ITextChannelNotifier, SignalRTextChannelNotifier>();
 builder.Services.AddScoped<IVoicePresenceNotifier, SignalRVoicePresenceNotifier>();
 builder.Services.AddScoped<IDirectMessageNotifier, SignalRDirectMessageNotifier>();
+builder.Services.AddHealthChecks()
+    .AddCheck<PostgresHealthCheck>("postgres")
+    .AddCheck<LiveKitHealthCheck>("livekit");
 builder.Services.AddRateLimiter(options =>
 {
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
@@ -161,11 +171,36 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 builder.Services.AddAuthorization();
 
 // CORS
+var corsSettings = builder.Configuration.GetSection("Cors").Get<CorsSettings>() ?? new CorsSettings();
+var allowedOrigins = corsSettings.AllowedOrigins
+    .Where(origin => !string.IsNullOrWhiteSpace(origin))
+    .Select(origin => origin.Trim())
+    .Distinct(StringComparer.OrdinalIgnoreCase)
+    .ToArray();
+
 builder.Services.AddCors(options =>
 {
-    options.AddPolicy("AllowAll", policy =>
+    options.AddPolicy("ApiCors", policy =>
     {
-        policy.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader();
+        if (builder.Environment.IsDevelopment()
+            && allowedOrigins.Contains("*", StringComparer.Ordinal))
+        {
+            policy.AllowAnyOrigin()
+                .AllowAnyMethod()
+                .AllowAnyHeader();
+            return;
+        }
+
+        var configuredOrigins = allowedOrigins
+            .Where(origin => !string.Equals(origin, "*", StringComparison.Ordinal))
+            .ToArray();
+
+        if (configuredOrigins.Length > 0)
+        {
+            policy.WithOrigins(configuredOrigins)
+                .WithMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .WithHeaders("Authorization", "Content-Type");
+        }
     });
 });
 
@@ -181,9 +216,10 @@ if (app.Environment.IsDevelopment())
 app.UseMiddleware<GlobalExceptionHandler>();
 app.UseSerilogRequestLogging();
 app.UseHttpsRedirection();
-app.UseCors("AllowAll");
+app.UseCors("ApiCors");
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseMiddleware<AuthenticatedUserContextMiddleware>();
 app.UseRateLimiter();
 
 var localBasePath = app.Configuration["ObjectStorage:LocalBasePath"] ?? "uploads";
@@ -200,15 +236,12 @@ app.UseStaticFiles(new StaticFileOptions
 // MAP ENDPOINTS - Vertical Slice Architecture
 // ============================================================
 
-// Health check endpoint
-app.MapGet("/health", () => Results.Ok(new
+app.MapHealthChecks("/health", new HealthCheckOptions
 {
-    status = "healthy",
-    timestamp = DateTime.UtcNow
-}))
+    ResponseWriter = WriteHealthCheckResponseAsync
+})
 .WithName("HealthCheck")
-.WithTags("System")
-.Produces(StatusCodes.Status200OK);
+.WithTags("System");
 
 // Auth endpoints
 RegisterEndpoint.Map(app);
@@ -267,6 +300,26 @@ static string ResolveMessagePostPartitionKey(HttpContext httpContext)
 
     var remoteIp = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
     return $"ip:{remoteIp}";
+}
+
+static Task WriteHealthCheckResponseAsync(HttpContext httpContext, HealthReport report)
+{
+    httpContext.Response.ContentType = "application/json";
+
+    var payload = new
+    {
+        status = report.Status.ToString(),
+        timestamp = DateTime.UtcNow,
+        checks = report.Entries.ToDictionary(
+            entry => entry.Key,
+            entry => new
+            {
+                status = entry.Value.Status.ToString(),
+                description = entry.Value.Description
+            })
+    };
+
+    return httpContext.Response.WriteAsync(JsonSerializer.Serialize(payload));
 }
 
 // Make Program class accessible to integration tests

--- a/src/Harmonie.API/appsettings.Development.json
+++ b/src/Harmonie.API/appsettings.Development.json
@@ -10,10 +10,16 @@
     "PublicUrl": "ws://localhost:7880",
     "InternalUrl": "http://localhost:7880",
     "ApiKey": "devkey",
-    "ApiSecret": "devsecret-that-is-long-enough-for-hmac-signing"
+    "ApiSecret": "devsecret-that-is-long-enough-for-hmac-signing",
+    "RequestTimeoutSeconds": 5
   },
   "Uploads": {
     "MaxFileSizeBytes": 26214400
+  },
+  "Cors": {
+    "AllowedOrigins": [
+      "*"
+    ]
   },
   "ObjectStorage": {
     "LocalBasePath": "uploads",

--- a/src/Harmonie.API/appsettings.json
+++ b/src/Harmonie.API/appsettings.json
@@ -6,5 +6,8 @@
         "Microsoft.AspNetCore": "Warning"
       }
     }
+  },
+  "Cors": {
+    "AllowedOrigins": []
   }
 }

--- a/src/Harmonie.Application/Common/HttpContextUserExtensions.cs
+++ b/src/Harmonie.Application/Common/HttpContextUserExtensions.cs
@@ -6,6 +6,8 @@ namespace Harmonie.Application.Common;
 
 public static class HttpContextUserExtensions
 {
+    private const string AuthenticatedUserIdItemKey = "__authenticated_user_id";
+
     public static bool TryGetAuthenticatedUserId(
         this HttpContext httpContext,
         out UserId? userId)
@@ -30,6 +32,30 @@ public static class HttpContextUserExtensions
 
         userId = parsedUserId;
         return true;
+    }
+
+    public static void SetAuthenticatedUserId(this HttpContext httpContext, UserId userId)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+        ArgumentNullException.ThrowIfNull(userId);
+
+        httpContext.Items[AuthenticatedUserIdItemKey] = userId;
+    }
+
+    public static UserId GetRequiredAuthenticatedUserId(this HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        if (httpContext.Items.TryGetValue(AuthenticatedUserIdItemKey, out var storedUserId)
+            && storedUserId is UserId currentUserId)
+        {
+            return currentUserId;
+        }
+
+        if (httpContext.TryGetAuthenticatedUserId(out var parsedUserId) && parsedUserId is not null)
+            return parsedUserId;
+
+        throw new InvalidOperationException("Authenticated user identifier is missing from the current request.");
     }
 
     private static string? FindFirstValue(this ClaimsPrincipal principal, string claimType)

--- a/src/Harmonie.Application/Features/Auth/Logout/LogoutEndpoint.cs
+++ b/src/Harmonie.Application/Features/Auth/Logout/LogoutEndpoint.cs
@@ -38,13 +38,7 @@ public static class LogoutEndpoint
         if (validationError is not null)
             return ApplicationResponse<LogoutResponse>.Fail(validationError).ToHttpResult();
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<LogoutResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(request, currentUserId, cancellationToken);
         if (!response.Success)

--- a/src/Harmonie.Application/Features/Auth/LogoutAll/LogoutAllEndpoint.cs
+++ b/src/Harmonie.Application/Features/Auth/LogoutAll/LogoutAllEndpoint.cs
@@ -29,13 +29,7 @@ public static class LogoutAllEndpoint
         HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<LogoutAllResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(currentUserId, cancellationToken);
         if (!response.Success)

--- a/src/Harmonie.Application/Features/Channels/DeleteChannel/DeleteChannelEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/DeleteChannel/DeleteChannelEndpoint.cs
@@ -48,13 +48,7 @@ public static class DeleteChannelEndpoint
                 "Route validation succeeded but channel ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var callerId) || callerId is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedChannelId, callerId, cancellationToken);
 

--- a/src/Harmonie.Application/Features/Channels/DeleteMessage/DeleteMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/DeleteMessage/DeleteMessageEndpoint.cs
@@ -59,13 +59,7 @@ public static class DeleteMessageEndpoint
                 "Route validation succeeded but message ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var callerId) || callerId is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedChannelId, parsedMessageId, callerId, cancellationToken);
 

--- a/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageEndpoint.cs
@@ -68,13 +68,7 @@ public static class EditMessageEndpoint
                 "Route validation succeeded but message ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var callerId) || callerId is null)
-        {
-            return ApplicationResponse<EditMessageResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedChannelId, parsedMessageId, request, callerId, cancellationToken);
         return response.ToHttpResult();

--- a/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesEndpoint.cs
@@ -54,13 +54,7 @@ public static class GetMessagesEndpoint
                 "Route validation succeeded but channel ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<GetMessagesResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedChannelId, request, currentUserId, cancellationToken);
         return response.ToHttpResult();

--- a/src/Harmonie.Application/Features/Channels/JoinVoiceChannel/JoinVoiceChannelEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/JoinVoiceChannel/JoinVoiceChannelEndpoint.cs
@@ -48,13 +48,7 @@ public static class JoinVoiceChannelEndpoint
                 "Route validation succeeded but channel ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<JoinVoiceChannelResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedChannelId, currentUserId, cancellationToken);
         return response.ToHttpResult();

--- a/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageEndpoint.cs
@@ -59,13 +59,7 @@ public static class SendMessageEndpoint
                 "Route validation succeeded but channel ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<SendMessageResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedChannelId, request, currentUserId, cancellationToken);
         return response.ToCreatedHttpResult(data => $"/api/channels/{data.ChannelId}/messages/{data.MessageId}");

--- a/src/Harmonie.Application/Features/Channels/UpdateChannel/UpdateChannelEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/UpdateChannel/UpdateChannelEndpoint.cs
@@ -71,13 +71,7 @@ public static class UpdateChannelEndpoint
                 "Route validation succeeded but channel ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var callerId) || callerId is null)
-        {
-            return ApplicationResponse<UpdateChannelResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedChannelId, callerId, request, cancellationToken);
         return response.ToHttpResult();

--- a/src/Harmonie.Application/Features/Conversations/DeleteDirectMessage/DeleteDirectMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteDirectMessage/DeleteDirectMessageEndpoint.cs
@@ -57,13 +57,7 @@ public static class DeleteDirectMessageEndpoint
                 "Route validation succeeded but message ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var callerId) || callerId is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedConversationId, parsedMessageId, callerId, cancellationToken);
         if (response.Success)

--- a/src/Harmonie.Application/Features/Conversations/EditDirectMessage/EditDirectMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/EditDirectMessage/EditDirectMessageEndpoint.cs
@@ -66,13 +66,7 @@ public static class EditDirectMessageEndpoint
                 "Route validation succeeded but message ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var callerId) || callerId is null)
-        {
-            return ApplicationResponse<EditDirectMessageResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedConversationId, parsedMessageId, request, callerId, cancellationToken);
         return response.ToHttpResult();

--- a/src/Harmonie.Application/Features/Conversations/GetDirectMessages/GetDirectMessagesEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetDirectMessages/GetDirectMessagesEndpoint.cs
@@ -52,13 +52,7 @@ public static class GetDirectMessagesEndpoint
                 "Route validation succeeded but conversation ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<GetDirectMessagesResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedConversationId, request, currentUserId, cancellationToken);
         return response.ToHttpResult();

--- a/src/Harmonie.Application/Features/Conversations/ListConversations/ListConversationsEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/ListConversations/ListConversationsEndpoint.cs
@@ -26,13 +26,7 @@ public static class ListConversationsEndpoint
         HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<ListConversationsResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(currentUserId, cancellationToken);
         return response.ToHttpResult();

--- a/src/Harmonie.Application/Features/Conversations/OpenConversation/OpenConversationEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/OpenConversation/OpenConversationEndpoint.cs
@@ -37,13 +37,7 @@ public static class OpenConversationEndpoint
         if (validationError is not null)
             return ApplicationResponse<OpenConversationResponse>.Fail(validationError).ToHttpResult();
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<OpenConversationResponse>.Fail(
-                ApplicationErrorCodes.Auth.InvalidCredentials,
-                "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(request, currentUserId, cancellationToken);
         if (!response.Success)

--- a/src/Harmonie.Application/Features/Conversations/SearchConversationMessages/SearchConversationMessagesEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/SearchConversationMessages/SearchConversationMessagesEndpoint.cs
@@ -52,13 +52,7 @@ public static class SearchConversationMessagesEndpoint
                 "Route validation succeeded but conversation ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<SearchConversationMessagesResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedConversationId, request, currentUserId, cancellationToken);
         return response.ToHttpResult();

--- a/src/Harmonie.Application/Features/Conversations/SendDirectMessage/SendDirectMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendDirectMessage/SendDirectMessageEndpoint.cs
@@ -57,13 +57,7 @@ public static class SendDirectMessageEndpoint
                 "Route validation succeeded but conversation ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<SendDirectMessageResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedConversationId, request, currentUserId, cancellationToken);
         return response.ToCreatedHttpResult(

--- a/src/Harmonie.Application/Features/Guilds/CreateChannel/CreateChannelEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/CreateChannel/CreateChannelEndpoint.cs
@@ -54,13 +54,7 @@ public static class CreateChannelEndpoint
                 "Route validation succeeded but guild ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var callerId) || callerId is null)
-        {
-            return ApplicationResponse<CreateChannelResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(
             parsedGuildId,

--- a/src/Harmonie.Application/Features/Guilds/CreateGuild/CreateGuildEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/CreateGuild/CreateGuildEndpoint.cs
@@ -35,13 +35,7 @@ public static class CreateGuildEndpoint
         if (validationError is not null)
             return ApplicationResponse<CreateGuildResponse>.Fail(validationError).ToHttpResult();
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<CreateGuildResponse>.Fail(
-                ApplicationErrorCodes.Auth.InvalidCredentials,
-                "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(request, currentUserId, cancellationToken);
         return response.ToCreatedHttpResult(data => $"/api/guilds/{data.GuildId}");

--- a/src/Harmonie.Application/Features/Guilds/GetGuildChannels/GetGuildChannelsEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/GetGuildChannels/GetGuildChannelsEndpoint.cs
@@ -46,13 +46,7 @@ public static class GetGuildChannelsEndpoint
                 "Route validation succeeded but guild ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<GetGuildChannelsResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedGuildId, currentUserId, cancellationToken);
         return response.ToHttpResult();

--- a/src/Harmonie.Application/Features/Guilds/GetGuildMembers/GetGuildMembersEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/GetGuildMembers/GetGuildMembersEndpoint.cs
@@ -46,13 +46,7 @@ public static class GetGuildMembersEndpoint
                 "Route validation succeeded but guild ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<GetGuildMembersResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedGuildId, currentUserId, cancellationToken);
         return response.ToHttpResult();

--- a/src/Harmonie.Application/Features/Guilds/GetGuildVoiceParticipants/GetGuildVoiceParticipantsEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/GetGuildVoiceParticipants/GetGuildVoiceParticipantsEndpoint.cs
@@ -46,13 +46,7 @@ public static class GetGuildVoiceParticipantsEndpoint
                 "Route validation succeeded but guild ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<GetGuildVoiceParticipantsResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedGuildId, currentUserId, cancellationToken);
         return response.ToHttpResult();

--- a/src/Harmonie.Application/Features/Guilds/InviteMember/InviteMemberEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/InviteMember/InviteMemberEndpoint.cs
@@ -55,13 +55,7 @@ public static class InviteMemberEndpoint
                 "Route validation succeeded but guild ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<InviteMemberResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedGuildId, request, currentUserId, cancellationToken);
         return response.ToHttpResult();

--- a/src/Harmonie.Application/Features/Guilds/LeaveGuild/LeaveGuildEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/LeaveGuild/LeaveGuildEndpoint.cs
@@ -47,13 +47,7 @@ public static class LeaveGuildEndpoint
                 "Route validation succeeded but guild ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedGuildId, currentUserId, cancellationToken);
 

--- a/src/Harmonie.Application/Features/Guilds/ListUserGuilds/ListUserGuildsEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/ListUserGuilds/ListUserGuildsEndpoint.cs
@@ -26,13 +26,7 @@ public static class ListUserGuildsEndpoint
         HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<ListUserGuildsResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(currentUserId, cancellationToken);
         return response.ToHttpResult();

--- a/src/Harmonie.Application/Features/Guilds/RemoveMember/RemoveMemberEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/RemoveMember/RemoveMemberEndpoint.cs
@@ -57,13 +57,7 @@ public static class RemoveMemberEndpoint
                 "Route validation succeeded but user ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var callerId) || callerId is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedGuildId, callerId, parsedTargetId, cancellationToken);
 

--- a/src/Harmonie.Application/Features/Guilds/SearchMessages/SearchMessagesEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/SearchMessages/SearchMessagesEndpoint.cs
@@ -55,13 +55,7 @@ public static class SearchMessagesEndpoint
                 "Route validation succeeded but guild ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<SearchMessagesResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedGuildId, request, currentUserId, cancellationToken);
         return response.ToHttpResult();

--- a/src/Harmonie.Application/Features/Guilds/TransferOwnership/TransferOwnershipEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/TransferOwnership/TransferOwnershipEndpoint.cs
@@ -63,13 +63,7 @@ public static class TransferOwnershipEndpoint
                 "Body validation succeeded but new owner ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var callerId) || callerId is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedGuildId, callerId, parsedNewOwnerId, cancellationToken);
 

--- a/src/Harmonie.Application/Features/Guilds/UpdateMemberRole/UpdateMemberRoleEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/UpdateMemberRole/UpdateMemberRoleEndpoint.cs
@@ -63,13 +63,7 @@ public static class UpdateMemberRoleEndpoint
                 "Route validation succeeded but user ID parsing failed.").ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var callerId) || callerId is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(parsedGuildId, callerId, parsedTargetId, request.Role.ToDomain(), cancellationToken);
 

--- a/src/Harmonie.Application/Features/Uploads/UploadFile/UploadFileEndpoint.cs
+++ b/src/Harmonie.Application/Features/Uploads/UploadFile/UploadFileEndpoint.cs
@@ -46,13 +46,7 @@ public static class UploadFileEndpoint
                 .ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<UploadFileResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var fileName = Path.GetFileName(file.FileName);
         var contentType = file.ContentType?.Trim();

--- a/src/Harmonie.Application/Features/Users/GetMyProfile/GetMyProfileEndpoint.cs
+++ b/src/Harmonie.Application/Features/Users/GetMyProfile/GetMyProfileEndpoint.cs
@@ -27,13 +27,7 @@ public static class GetMyProfileEndpoint
         HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<GetMyProfileResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(currentUserId, cancellationToken);
         return response.ToHttpResult();

--- a/src/Harmonie.Application/Features/Users/SearchUsers/SearchUsersEndpoint.cs
+++ b/src/Harmonie.Application/Features/Users/SearchUsers/SearchUsersEndpoint.cs
@@ -36,13 +36,7 @@ public static class SearchUsersEndpoint
         if (validationError is not null)
             return ApplicationResponse<SearchUsersResponse>.Fail(validationError).ToHttpResult();
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<SearchUsersResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(request, currentUserId, cancellationToken);
         return response.ToHttpResult();

--- a/src/Harmonie.Application/Features/Users/UpdateMyProfile/UpdateMyProfileEndpoint.cs
+++ b/src/Harmonie.Application/Features/Users/UpdateMyProfile/UpdateMyProfileEndpoint.cs
@@ -53,13 +53,7 @@ public static class UpdateMyProfileEndpoint
         if (validationError is not null)
             return ApplicationResponse<UpdateMyProfileResponse>.Fail(validationError).ToHttpResult();
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<UpdateMyProfileResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(request, currentUserId, cancellationToken);
         return response.ToHttpResult();

--- a/src/Harmonie.Application/Features/Users/UploadMyAvatar/UploadMyAvatarEndpoint.cs
+++ b/src/Harmonie.Application/Features/Users/UploadMyAvatar/UploadMyAvatarEndpoint.cs
@@ -46,13 +46,7 @@ public static class UploadMyAvatarEndpoint
                 .ToHttpResult();
         }
 
-        if (!httpContext.TryGetAuthenticatedUserId(out var currentUserId) || currentUserId is null)
-        {
-            return ApplicationResponse<UploadMyAvatarResponse>.Fail(
-                    ApplicationErrorCodes.Auth.InvalidCredentials,
-                    "Authenticated user identifier is missing.")
-                .ToHttpResult();
-        }
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var fileName = Path.GetFileName(file.FileName);
         var contentType = file.ContentType?.Trim();

--- a/src/Harmonie.Domain/Entities/GuildChannel.cs
+++ b/src/Harmonie.Domain/Entities/GuildChannel.cs
@@ -77,6 +77,7 @@ public sealed class GuildChannel : Entity<GuildChannelId>
             return Result.Failure("Channel name cannot exceed 100 characters");
 
         Name = normalized;
+        MarkAsUpdated();
         return Result.Success();
     }
 
@@ -86,6 +87,7 @@ public sealed class GuildChannel : Entity<GuildChannelId>
             return Result.Failure("Channel position cannot be negative");
 
         Position = position;
+        MarkAsUpdated();
         return Result.Success();
     }
 

--- a/src/Harmonie.Infrastructure/Configuration/DatabaseSettings.cs
+++ b/src/Harmonie.Infrastructure/Configuration/DatabaseSettings.cs
@@ -1,5 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Harmonie.Infrastructure.Configuration;
+
 public sealed class DatabaseSettings
 {
-    public string ConnectionString { get; init; } = null!;
+    [Required(AllowEmptyStrings = false)]
+    public string ConnectionString { get; set; } = string.Empty;
 }

--- a/src/Harmonie.Infrastructure/Configuration/JwtSettings.cs
+++ b/src/Harmonie.Infrastructure/Configuration/JwtSettings.cs
@@ -1,9 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Harmonie.Infrastructure.Configuration;
+
 public sealed class JwtSettings
 {
-    public string Secret { get; init; } = null!;
-    public string Issuer { get; init; } = null!;
-    public string Audience { get; init; } = null!;
+    [Required(AllowEmptyStrings = false)]
+    [MinLength(32)]
+    public string Secret { get; init; } = string.Empty;
+
+    [Required(AllowEmptyStrings = false)]
+    public string Issuer { get; init; } = string.Empty;
+
+    [Required(AllowEmptyStrings = false)]
+    public string Audience { get; init; } = string.Empty;
+
+    [Range(1, 1440)]
     public int AccessTokenExpirationMinutes { get; init; } = 15;
+
+    [Range(1, 365)]
     public int RefreshTokenExpirationDays { get; init; } = 30;
 }

--- a/src/Harmonie.Infrastructure/Configuration/LiveKitSettings.cs
+++ b/src/Harmonie.Infrastructure/Configuration/LiveKitSettings.cs
@@ -1,14 +1,43 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Harmonie.Infrastructure.Configuration;
 
-public sealed class LiveKitSettings
+public sealed class LiveKitSettings : IValidatableObject
 {
+    [Required(AllowEmptyStrings = false)]
     public string PublicUrl { get; init; } = string.Empty;
+
     public string InternalUrl { get; init; } = string.Empty;
+
+    [Required(AllowEmptyStrings = false)]
     public string ApiKey { get; init; } = string.Empty;
+
+    [Required(AllowEmptyStrings = false)]
     public string ApiSecret { get; init; } = string.Empty;
+
+    [Range(1, 30)]
+    public int RequestTimeoutSeconds { get; init; } = 5;
 
     public string GetInternalUrl()
         => string.IsNullOrWhiteSpace(InternalUrl)
             ? PublicUrl
             : InternalUrl;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (!Uri.TryCreate(PublicUrl, UriKind.Absolute, out _))
+        {
+            yield return new ValidationResult(
+                "LiveKit:PublicUrl must be a valid absolute URL.",
+                [nameof(PublicUrl)]);
+        }
+
+        if (!string.IsNullOrWhiteSpace(InternalUrl)
+            && !Uri.TryCreate(InternalUrl, UriKind.Absolute, out _))
+        {
+            yield return new ValidationResult(
+                "LiveKit:InternalUrl must be a valid absolute URL when provided.",
+                [nameof(InternalUrl)]);
+        }
+    }
 }

--- a/src/Harmonie.Infrastructure/Configuration/ObjectStorageSettings.cs
+++ b/src/Harmonie.Infrastructure/Configuration/ObjectStorageSettings.cs
@@ -1,7 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Harmonie.Infrastructure.Configuration;
 
 public sealed class ObjectStorageSettings
 {
+    [Required(AllowEmptyStrings = false)]
     public string LocalBasePath { get; init; } = "uploads";
+
+    [Required(AllowEmptyStrings = false)]
     public string LocalBaseUrl { get; init; } = "http://localhost:5000/files";
 }

--- a/src/Harmonie.Infrastructure/DependencyInjection.cs
+++ b/src/Harmonie.Infrastructure/DependencyInjection.cs
@@ -1,32 +1,53 @@
 using Harmonie.Application.Interfaces;
 using Harmonie.Infrastructure.Authentication;
 using Harmonie.Infrastructure.Configuration;
+using Harmonie.Infrastructure.HealthChecks;
 using Harmonie.Infrastructure.LiveKit;
 using Harmonie.Infrastructure.ObjectStorage;
 using Harmonie.Infrastructure.Persistence;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Harmonie.Infrastructure;
 public static class DependencyInjection
 {
     public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
     {
-        services.Configure<JwtSettings>(configuration.GetSection("Jwt"));
-        services.Configure<DatabaseSettings>(configuration.GetSection("Database"));
-        services.Configure<LiveKitSettings>(configuration.GetSection("LiveKit"));
-        services.Configure<ObjectStorageSettings>(configuration.GetSection("ObjectStorage"));
+        services.AddOptions<JwtSettings>()
+            .Bind(configuration.GetSection("Jwt"))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+        services.AddOptions<DatabaseSettings>()
+            .Configure(options => options.ConnectionString = configuration.GetConnectionString("DefaultConnection") ?? string.Empty)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+        services.AddOptions<LiveKitSettings>()
+            .Bind(configuration.GetSection("LiveKit"))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+        services.AddOptions<ObjectStorageSettings>()
+            .Bind(configuration.GetSection("ObjectStorage"))
+            .ValidateDataAnnotations()
+            .Validate(
+                settings => Uri.TryCreate(settings.LocalBaseUrl, UriKind.Absolute, out _),
+                "ObjectStorage:LocalBaseUrl must be a valid absolute URL.")
+            .ValidateOnStart();
         services.AddScoped<IPasswordHasher, PasswordHasher>();
         services.AddScoped<IJwtTokenService, JwtTokenService>();
         services.AddScoped<ILiveKitTokenService, LiveKitTokenService>();
         services.AddScoped<ILiveKitWebhookReceiver, LiveKitWebhookReceiver>();
+        services.AddSingleton(sp =>
+        {
+            _ = sp.GetRequiredService<IOptions<LiveKitSettings>>().Value;
+            return new HttpClient();
+        });
         services.AddScoped<ILiveKitRoomApiClient, LiveKitSdkRoomApiClient>();
         services.AddScoped<ILiveKitRoomService, LiveKitRoomService>();
         services.AddScoped<IObjectStorageService, LocalFileSystemObjectStorageService>();
 
-        var connectionString = configuration.GetConnectionString("DefaultConnection");
-        if (string.IsNullOrWhiteSpace(connectionString))
-            throw new InvalidOperationException("Connection string 'DefaultConnection' is required.");
+        var connectionString = configuration.GetConnectionString("DefaultConnection")
+            ?? throw new InvalidOperationException("Connection string 'DefaultConnection' is required.");
 
         services.AddScoped(_ => new DbSession(connectionString));
         services.AddScoped<IUnitOfWork, UnitOfWork>();

--- a/src/Harmonie.Infrastructure/HealthChecks/LiveKitHealthCheck.cs
+++ b/src/Harmonie.Infrastructure/HealthChecks/LiveKitHealthCheck.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Harmonie.Infrastructure.LiveKit;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Harmonie.Infrastructure.HealthChecks;
+
+public sealed class LiveKitHealthCheck : IHealthCheck
+{
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+
+    public LiveKitHealthCheck(IServiceScopeFactory serviceScopeFactory)
+    {
+        _serviceScopeFactory = serviceScopeFactory;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var scope = _serviceScopeFactory.CreateScope();
+            var liveKitRoomApiClient = scope.ServiceProvider.GetRequiredService<ILiveKitRoomApiClient>();
+
+            await liveKitRoomApiClient.ListRoomsAsync(cancellationToken);
+            return HealthCheckResult.Healthy("LiveKit is reachable.");
+        }
+        catch (Exception exception)
+        {
+            return HealthCheckResult.Unhealthy("LiveKit is unreachable.", exception);
+        }
+    }
+}

--- a/src/Harmonie.Infrastructure/HealthChecks/PostgresHealthCheck.cs
+++ b/src/Harmonie.Infrastructure/HealthChecks/PostgresHealthCheck.cs
@@ -1,0 +1,36 @@
+using Harmonie.Infrastructure.Configuration;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Npgsql;
+
+namespace Harmonie.Infrastructure.HealthChecks;
+
+public sealed class PostgresHealthCheck : IHealthCheck
+{
+    private readonly string _connectionString;
+
+    public PostgresHealthCheck(IOptions<DatabaseSettings> settings)
+    {
+        _connectionString = settings.Value.ConnectionString;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var connection = new NpgsqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            await using var command = new NpgsqlCommand("SELECT 1", connection);
+            await command.ExecuteScalarAsync(cancellationToken);
+
+            return HealthCheckResult.Healthy("PostgreSQL is reachable.");
+        }
+        catch (Exception exception)
+        {
+            return HealthCheckResult.Unhealthy("PostgreSQL is unreachable.", exception);
+        }
+    }
+}

--- a/src/Harmonie.Infrastructure/LiveKit/LiveKitSdkRoomApiClient.cs
+++ b/src/Harmonie.Infrastructure/LiveKit/LiveKitSdkRoomApiClient.cs
@@ -6,34 +6,36 @@ namespace Harmonie.Infrastructure.LiveKit;
 
 public sealed class LiveKitSdkRoomApiClient : ILiveKitRoomApiClient
 {
-    private readonly LiveKitSettings _settings;
-    private readonly string _internalUrl;
+    private readonly RoomServiceClient _roomServiceClient;
 
-    public LiveKitSdkRoomApiClient(IOptions<LiveKitSettings> settings)
+    public LiveKitSdkRoomApiClient(HttpClient httpClient, IOptions<LiveKitSettings> settings)
     {
-        _settings = settings.Value;
-        _internalUrl = _settings.GetInternalUrl();
+        var liveKitSettings = settings.Value;
+        var internalUrl = liveKitSettings.GetInternalUrl();
 
-        if (string.IsNullOrWhiteSpace(_internalUrl))
+        if (string.IsNullOrWhiteSpace(internalUrl))
             throw new InvalidOperationException("Configuration value 'LiveKit:PublicUrl' or 'LiveKit:InternalUrl' is required.");
 
-        if (string.IsNullOrWhiteSpace(_settings.ApiKey))
+        if (string.IsNullOrWhiteSpace(liveKitSettings.ApiKey))
             throw new InvalidOperationException("Configuration value 'LiveKit:ApiKey' is required.");
 
-        if (string.IsNullOrWhiteSpace(_settings.ApiSecret))
+        if (string.IsNullOrWhiteSpace(liveKitSettings.ApiSecret))
             throw new InvalidOperationException("Configuration value 'LiveKit:ApiSecret' is required.");
+
+        httpClient.Timeout = TimeSpan.FromSeconds(liveKitSettings.RequestTimeoutSeconds);
+
+        _roomServiceClient = new RoomServiceClient(
+            internalUrl,
+            liveKitSettings.ApiKey,
+            liveKitSettings.ApiSecret,
+            httpClient);
     }
 
     public async Task<IReadOnlyList<Room>> ListRoomsAsync(CancellationToken cancellationToken)
     {
-        using var httpClient = new HttpClient();
-        var roomServiceClient = new RoomServiceClient(
-            _internalUrl,
-            _settings.ApiKey,
-            _settings.ApiSecret,
-            httpClient);
-
-        var response = await roomServiceClient.ListRooms(new ListRoomsRequest());
+        var response = await _roomServiceClient
+            .ListRooms(new ListRoomsRequest())
+            .WaitAsync(cancellationToken);
         return response.Rooms.ToArray();
     }
 
@@ -41,17 +43,12 @@ public sealed class LiveKitSdkRoomApiClient : ILiveKitRoomApiClient
         string roomName,
         CancellationToken cancellationToken)
     {
-        using var httpClient = new HttpClient();
-        var roomServiceClient = new RoomServiceClient(
-            _internalUrl,
-            _settings.ApiKey,
-            _settings.ApiSecret,
-            httpClient);
-
-        var response = await roomServiceClient.ListParticipants(new ListParticipantsRequest
-        {
-            Room = roomName
-        });
+        var response = await _roomServiceClient
+            .ListParticipants(new ListParticipantsRequest
+            {
+                Room = roomName
+            })
+            .WaitAsync(cancellationToken);
 
         return response.Participants.ToArray();
     }

--- a/tests/Harmonie.API.IntegrationTests/CorsPolicyTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/CorsPolicyTests.cs
@@ -1,0 +1,28 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Harmonie.API.IntegrationTests;
+
+public sealed class CorsPolicyTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public CorsPolicyTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task PreflightRequest_InDevelopment_ShouldAllowWildcardOrigin()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Options, "/health");
+        request.Headers.Add("Origin", "http://localhost:3000");
+        request.Headers.Add("Access-Control-Request-Method", "GET");
+
+        var response = await _client.SendAsync(request);
+
+        response.Headers.TryGetValues("Access-Control-Allow-Origin", out var origins).Should().BeTrue();
+        origins.Should().Contain("*");
+    }
+}

--- a/tests/Harmonie.Domain.Tests/GuildChannelTests.cs
+++ b/tests/Harmonie.Domain.Tests/GuildChannelTests.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+using Harmonie.Domain.Entities;
+using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects;
+using Xunit;
+
+namespace Harmonie.Domain.Tests;
+
+public sealed class GuildChannelTests
+{
+    [Fact]
+    public void UpdateName_ShouldMarkChannelAsUpdated()
+    {
+        var channel = CreateChannel();
+
+        var result = channel.UpdateName("updated-name");
+
+        result.IsSuccess.Should().BeTrue();
+        channel.Name.Should().Be("updated-name");
+        channel.UpdatedAtUtc.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void UpdatePosition_ShouldMarkChannelAsUpdated()
+    {
+        var channel = CreateChannel();
+
+        var result = channel.UpdatePosition(4);
+
+        result.IsSuccess.Should().BeTrue();
+        channel.Position.Should().Be(4);
+        channel.UpdatedAtUtc.Should().NotBeNull();
+    }
+
+    private static GuildChannel CreateChannel()
+    {
+        var channelResult = GuildChannel.Create(
+            GuildId.New(),
+            "general",
+            GuildChannelType.Text,
+            isDefault: true,
+            position: 0);
+
+        if (channelResult.IsFailure || channelResult.Value is null)
+            throw new InvalidOperationException("Failed to create guild channel for tests.");
+
+        return channelResult.Value;
+    }
+}

--- a/tests/Harmonie.Infrastructure.Tests/ConfigurationValidationTests.cs
+++ b/tests/Harmonie.Infrastructure.Tests/ConfigurationValidationTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using Harmonie.Infrastructure.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Harmonie.Infrastructure.Tests;
+
+public sealed class ConfigurationValidationTests
+{
+    [Fact]
+    public void JwtSettings_WithShortSecret_ShouldFailValidation()
+    {
+        using var serviceProvider = BuildServiceProvider(new Dictionary<string, string?>
+        {
+            ["Jwt:Secret"] = "too-short",
+            ["Jwt:Issuer"] = "harmonie",
+            ["Jwt:Audience"] = "harmonie-client",
+            ["LiveKit:PublicUrl"] = "ws://localhost:7880",
+            ["LiveKit:InternalUrl"] = "http://localhost:7880",
+            ["LiveKit:ApiKey"] = "devkey",
+            ["LiveKit:ApiSecret"] = "devsecret-that-is-long-enough-for-hmac-signing",
+            ["ObjectStorage:LocalBasePath"] = "uploads",
+            ["ObjectStorage:LocalBaseUrl"] = "http://localhost:5000/files",
+            ["ConnectionStrings:DefaultConnection"] = "Host=localhost;Port=5432;Database=harmonie;Username=user;Password=password"
+        });
+
+        var act = () => serviceProvider.GetRequiredService<IOptions<JwtSettings>>().Value;
+
+        act.Should().Throw<OptionsValidationException>();
+    }
+
+    [Fact]
+    public void LiveKitSettings_WithInvalidUrl_ShouldFailValidation()
+    {
+        using var serviceProvider = BuildServiceProvider(new Dictionary<string, string?>
+        {
+            ["Jwt:Secret"] = "c4ed062a496bfa0e2e5f1977960bcdc1e4ec09983e6e22af468f5b45fb902678",
+            ["Jwt:Issuer"] = "harmonie",
+            ["Jwt:Audience"] = "harmonie-client",
+            ["LiveKit:PublicUrl"] = "not-a-url",
+            ["LiveKit:ApiKey"] = "devkey",
+            ["LiveKit:ApiSecret"] = "devsecret-that-is-long-enough-for-hmac-signing",
+            ["ObjectStorage:LocalBasePath"] = "uploads",
+            ["ObjectStorage:LocalBaseUrl"] = "http://localhost:5000/files",
+            ["ConnectionStrings:DefaultConnection"] = "Host=localhost;Port=5432;Database=harmonie;Username=user;Password=password"
+        });
+
+        var act = () => serviceProvider.GetRequiredService<IOptions<LiveKitSettings>>().Value;
+
+        act.Should().Throw<OptionsValidationException>();
+    }
+
+    [Fact]
+    public void ObjectStorageSettings_WithInvalidBaseUrl_ShouldFailValidation()
+    {
+        using var serviceProvider = BuildServiceProvider(new Dictionary<string, string?>
+        {
+            ["Jwt:Secret"] = "c4ed062a496bfa0e2e5f1977960bcdc1e4ec09983e6e22af468f5b45fb902678",
+            ["Jwt:Issuer"] = "harmonie",
+            ["Jwt:Audience"] = "harmonie-client",
+            ["LiveKit:PublicUrl"] = "ws://localhost:7880",
+            ["LiveKit:InternalUrl"] = "http://localhost:7880",
+            ["LiveKit:ApiKey"] = "devkey",
+            ["LiveKit:ApiSecret"] = "devsecret-that-is-long-enough-for-hmac-signing",
+            ["ObjectStorage:LocalBasePath"] = "uploads",
+            ["ObjectStorage:LocalBaseUrl"] = "invalid-url",
+            ["ConnectionStrings:DefaultConnection"] = "Host=localhost;Port=5432;Database=harmonie;Username=user;Password=password"
+        });
+
+        var act = () => serviceProvider.GetRequiredService<IOptions<ObjectStorageSettings>>().Value;
+
+        act.Should().Throw<OptionsValidationException>();
+    }
+
+    private static ServiceProvider BuildServiceProvider(Dictionary<string, string?> settings)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddInfrastructure(configuration);
+        return services.BuildServiceProvider();
+    }
+}

--- a/tests/Harmonie.Infrastructure.Tests/HealthChecksTests.cs
+++ b/tests/Harmonie.Infrastructure.Tests/HealthChecksTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using Harmonie.Infrastructure.Configuration;
+using Harmonie.Infrastructure.HealthChecks;
+using Harmonie.Infrastructure.LiveKit;
+using Livekit.Server.Sdk.Dotnet;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Infrastructure.Tests;
+
+public sealed class HealthChecksTests
+{
+    [Fact]
+    public async Task PostgresHealthCheck_WithInvalidConnectionString_ShouldReturnUnhealthy()
+    {
+        var healthCheck = new PostgresHealthCheck(Options.Create(new DatabaseSettings
+        {
+            ConnectionString = "Host=127.0.0.1;Port=1;Database=harmonie;Username=test;Password=test"
+        }));
+
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task LiveKitHealthCheck_WhenLiveKitIsReachable_ShouldReturnHealthy()
+    {
+        var roomApiClientMock = new Mock<ILiveKitRoomApiClient>();
+        roomApiClientMock
+            .Setup(client => client.ListRoomsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new Room { Name = "room-1" }]);
+
+        using var serviceProvider = new ServiceCollection()
+            .AddScoped(_ => roomApiClientMock.Object)
+            .BuildServiceProvider();
+
+        var healthCheck = new LiveKitHealthCheck(
+            serviceProvider.GetRequiredService<IServiceScopeFactory>());
+
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task LiveKitHealthCheck_WhenLiveKitThrows_ShouldReturnUnhealthy()
+    {
+        var roomApiClientMock = new Mock<ILiveKitRoomApiClient>();
+        roomApiClientMock
+            .Setup(client => client.ListRoomsAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("LiveKit unavailable"));
+
+        using var serviceProvider = new ServiceCollection()
+            .AddScoped(_ => roomApiClientMock.Object)
+            .BuildServiceProvider();
+
+        var healthCheck = new LiveKitHealthCheck(
+            serviceProvider.GetRequiredService<IServiceScopeFactory>());
+
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+    }
+}

--- a/tests/Harmonie.Infrastructure.Tests/LiveKitRoomServiceLiveIntegrationTests.cs
+++ b/tests/Harmonie.Infrastructure.Tests/LiveKitRoomServiceLiveIntegrationTests.cs
@@ -33,7 +33,8 @@ public sealed class LiveKitRoomServiceLiveIntegrationTests
             .Setup(x => x.GetByGuildIdAsync(guildId, It.IsAny<CancellationToken>()))
             .ReturnsAsync([voiceChannel]);
 
-        var roomApiClient = new LiveKitSdkRoomApiClient(Options.Create(settings));
+        using var roomApiHttpClient = new HttpClient();
+        var roomApiClient = new LiveKitSdkRoomApiClient(roomApiHttpClient, Options.Create(settings));
         var service = new LiveKitRoomService(
             guildChannelRepositoryMock.Object,
             roomApiClient,


### PR DESCRIPTION
## Summary
- fix the issue 188 critical items around LiveKit HttpClient reuse and GuildChannel updated timestamps
- implement the high-severity improvements for authenticated user extraction, configurable CORS, startup configuration validation, health checks, and LiveKit timeouts
- add regression coverage for CORS, config validation, health checks, and GuildChannel updates

## Testing
- dotnet build -m:1 -nodeReuse:false
- dotnet test --no-build -m:1 -nodeReuse:false

Closes #188