### PR TITLE
Fix OpenAPI error example JSON casing

### DIFF
--- a/src/Harmonie.Application/Common/EndpointExtensions.cs
+++ b/src/Harmonie.Application/Common/EndpointExtensions.cs
@@ -14,6 +14,8 @@ namespace Harmonie.Application.Common;
 /// </summary>
 public static class EndpointExtensions
 {
+    private static readonly JsonSerializerOptions OpenApiExampleSerializerOptions = new(JsonSerializerDefaults.Web);
+
     /// <summary>
     /// Validate a request using FluentValidation and return a standardized error payload.
     /// </summary>
@@ -178,11 +180,11 @@ public static class EndpointExtensions
                     mediaType.Examples[code] = new OpenApiExample
                     {
                         Summary = code,
-                        Value = JsonNode.Parse(JsonSerializer.Serialize(
+                        Value = ToOpenApiJsonNode(
                             EnrichError(
                                 new ApplicationError(code, BuildExampleDetail(code), errors),
                                 status,
-                                "trace-id")))
+                                "trace-id"))
                     };
                 }
             }
@@ -224,7 +226,7 @@ public static class EndpointExtensions
             if (examples.Length == 0)
                 return;
 
-            mediaType.Example = JsonNode.Parse(JsonSerializer.Serialize(examples[0].Value));
+            mediaType.Example = ToOpenApiJsonNode(examples[0].Value);
             mediaType.Examples ??= new Dictionary<string, IOpenApiExample>();
 
             foreach (var (name, summary, value) in examples)
@@ -232,7 +234,7 @@ public static class EndpointExtensions
                 mediaType.Examples[name] = new OpenApiExample
                 {
                     Summary = summary,
-                    Value = JsonNode.Parse(JsonSerializer.Serialize(value))
+                    Value = ToOpenApiJsonNode(value)
                 };
             }
 
@@ -266,6 +268,9 @@ public static class EndpointExtensions
             Status = status,
             TraceId = string.IsNullOrWhiteSpace(traceId) ? error.TraceId : traceId
         };
+
+    private static JsonNode? ToOpenApiJsonNode(object? value)
+        => JsonSerializer.SerializeToNode(value, OpenApiExampleSerializerOptions);
 
     public static string NormalizeValidationErrorCode(string fluentValidationCode)
         => fluentValidationCode switch

--- a/tests/Harmonie.API.IntegrationTests/OpenApiDocumentTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/OpenApiDocumentTests.cs
@@ -41,8 +41,14 @@ public sealed class OpenApiDocumentTests : IClassFixture<WebApplicationFactory<P
         validationExample.Should().NotBeNull();
         validationExample!["code"]?.GetValue<string>().Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
         validationExample["detail"]?.GetValue<string>().Should().Be("Validation failed");
+        validationExample["errors"]?["field"]?[0]?["code"]?.GetValue<string>().Should().Be(ApplicationErrorCodes.Validation.Required);
         validationExample["status"]?.GetValue<int>().Should().Be(400);
         validationExample["traceId"]?.GetValue<string>().Should().Be("trace-id");
+        validationExample["Code"].Should().BeNull();
+        validationExample["Detail"].Should().BeNull();
+        validationExample["Errors"].Should().BeNull();
+        validationExample["Status"].Should().BeNull();
+        validationExample["TraceId"].Should().BeNull();
 
         var unauthorizedDescription = getGuildChannels["401"]?["description"]?.GetValue<string>();
         unauthorizedDescription.Should().NotBeNull();
@@ -52,6 +58,10 @@ public sealed class OpenApiDocumentTests : IClassFixture<WebApplicationFactory<P
         unauthorizedExample.Should().NotBeNull();
         unauthorizedExample!["code"]?.GetValue<string>().Should().Be(ApplicationErrorCodes.Auth.InvalidCredentials);
         unauthorizedExample["detail"]?.GetValue<string>().Should().Be("Invalid credentials");
+        unauthorizedExample["status"]?.GetValue<int>().Should().Be(401);
+        unauthorizedExample["traceId"]?.GetValue<string>().Should().Be("trace-id");
+        unauthorizedExample["Code"].Should().BeNull();
+        unauthorizedExample["TraceId"].Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- switch shared OpenAPI example serialization to web JSON defaults so documented payloads use camelCase
- cover error examples with assertions for lowercase keys and trace/status fields
- keep request body examples aligned with the same shared serializer

## Testing
- dotnet test

Closes #195
