### PR TITLE
feat(files): delete conversation attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository currently provides:
 - Direct message full-text search in conversations with cursor pagination
 - Direct message editing in conversations
 - Direct message deletion in conversations
+- Direct message attachment deletion in conversations
 - Direct message sending in conversations
 - Voice channel join token issuance via LiveKit
 - Voice presence notifications via LiveKit webhooks and SignalR

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,6 +31,7 @@ Current mapped endpoints:
 - `GET /api/conversations/{conversationId}/messages`
 - `PATCH /api/conversations/{conversationId}/messages/{messageId}`
 - `DELETE /api/conversations/{conversationId}/messages/{messageId}`
+- `DELETE /api/conversations/{conversationId}/messages/{messageId}/attachments/{attachmentId}`
 - `GET /api/users/me`
 - `PUT /api/users/me`
 - `GET /hubs/realtime` (SignalR for text channels and voice presence)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -70,6 +70,7 @@ In `docker-compose`, the API stores them in the `uploads-data` volume.
 - Read conversation messages: `GET /api/conversations/{conversationId}/messages`
 - Edit conversation message: `PATCH /api/conversations/{conversationId}/messages/{messageId}`
 - Delete conversation message: `DELETE /api/conversations/{conversationId}/messages/{messageId}`
+- Delete conversation attachment: `DELETE /api/conversations/{conversationId}/messages/{messageId}/attachments/{attachmentId}`
 - Send conversation message: `POST /api/conversations/{conversationId}/messages`
 - Send message: `POST /api/channels/{channelId}/messages`
 - Read messages: `GET /api/channels/{channelId}/messages`

--- a/src/Harmonie.API/Program.cs
+++ b/src/Harmonie.API/Program.cs
@@ -16,6 +16,7 @@ using ChannelGetMessages = Harmonie.Application.Features.Channels.GetMessages.Ge
 using Harmonie.Application.Features.Channels.JoinVoiceChannel;
 using ChannelSendMessage = Harmonie.Application.Features.Channels.SendMessage.SendMessageEndpoint;
 using Harmonie.Application.Features.Channels.UpdateChannel;
+using ConversationDeleteMessageAttachment = Harmonie.Application.Features.Conversations.DeleteMessageAttachment.DeleteMessageAttachmentEndpoint;
 using ConversationDeleteMessage = Harmonie.Application.Features.Conversations.DeleteMessage.DeleteMessageEndpoint;
 using ConversationEditMessage = Harmonie.Application.Features.Conversations.EditMessage.EditMessageEndpoint;
 using ConversationGetMessages = Harmonie.Application.Features.Conversations.GetMessages.GetMessagesEndpoint;
@@ -292,6 +293,7 @@ ConversationGetMessages.Map(app);
 SearchConversationMessagesEndpoint.Map(app);
 ConversationEditMessage.Map(app);
 ConversationDeleteMessage.Map(app);
+ConversationDeleteMessageAttachment.Map(app);
 ConversationSendMessage.Map(app);
 app.MapHub<RealtimeHub>("/hubs/realtime");
 

--- a/src/Harmonie.Application/DependencyInjection.cs
+++ b/src/Harmonie.Application/DependencyInjection.cs
@@ -14,6 +14,7 @@ using ChannelGetMessagesHandler = Harmonie.Application.Features.Channels.GetMess
 using Harmonie.Application.Features.Channels.JoinVoiceChannel;
 using ChannelSendMessageHandler = Harmonie.Application.Features.Channels.SendMessage.SendMessageHandler;
 using Harmonie.Application.Features.Channels.UpdateChannel;
+using ConversationDeleteMessageAttachmentHandler = Harmonie.Application.Features.Conversations.DeleteMessageAttachment.DeleteMessageAttachmentHandler;
 using ConversationDeleteMessageHandler = Harmonie.Application.Features.Conversations.DeleteMessage.DeleteMessageHandler;
 using ConversationEditMessageHandler = Harmonie.Application.Features.Conversations.EditMessage.EditMessageHandler;
 using ConversationGetMessagesHandler = Harmonie.Application.Features.Conversations.GetMessages.GetMessagesHandler;
@@ -116,6 +117,7 @@ public static class DependencyInjection
         services.AddScoped<SearchConversationMessagesHandler>();
         services.AddScoped<ConversationEditMessageHandler>();
         services.AddScoped<ConversationDeleteMessageHandler>();
+        services.AddScoped<ConversationDeleteMessageAttachmentHandler>();
         services.AddScoped<ConversationSendMessageHandler>();
         // Add more handlers as features are created
 

--- a/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentEndpoint.cs
@@ -1,0 +1,83 @@
+using FluentValidation;
+using Harmonie.Application.Common;
+using Harmonie.Domain.ValueObjects;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Harmonie.Application.Features.Conversations.DeleteMessageAttachment;
+
+public static class DeleteMessageAttachmentEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        app.MapDelete("/api/conversations/{conversationId}/messages/{messageId}/attachments/{attachmentId}", HandleAsync)
+            .WithName("DeleteConversationMessageAttachment")
+            .WithTags("Conversations")
+            .RequireAuthorization()
+            .WithSummary("Delete a conversation message attachment")
+            .WithDescription("Deletes a specific attachment from a conversation message. Only the message author can delete attachments from their own messages.")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesErrors(
+                ApplicationErrorCodes.Common.ValidationFailed,
+                ApplicationErrorCodes.Auth.InvalidCredentials,
+                ApplicationErrorCodes.Conversation.NotFound,
+                ApplicationErrorCodes.Conversation.AccessDenied,
+                ApplicationErrorCodes.Message.NotFound,
+                ApplicationErrorCodes.Message.AttachmentNotFound,
+                ApplicationErrorCodes.Message.DeleteForbidden);
+    }
+
+    private static async Task<IResult> HandleAsync(
+        [AsParameters] DeleteMessageAttachmentRouteRequest routeRequest,
+        [FromServices] DeleteMessageAttachmentHandler handler,
+        [FromServices] IValidator<DeleteMessageAttachmentRouteRequest> routeValidator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var routeValidationError = await routeRequest.ValidateAsync(routeValidator, cancellationToken);
+        if (routeValidationError is not null)
+            return ApplicationResponse<bool>.Fail(routeValidationError).ToHttpResult();
+
+        if (routeRequest.ConversationId is not string conversationIdStr
+            || !ConversationId.TryParse(conversationIdStr, out var parsedConversationId)
+            || parsedConversationId is null)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Common.InvalidState,
+                "Route validation succeeded but conversation ID parsing failed.").ToHttpResult();
+        }
+
+        if (routeRequest.MessageId is not string messageIdStr
+            || !MessageId.TryParse(messageIdStr, out var parsedMessageId)
+            || parsedMessageId is null)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Common.InvalidState,
+                "Route validation succeeded but message ID parsing failed.").ToHttpResult();
+        }
+
+        if (routeRequest.AttachmentId is not string attachmentIdStr
+            || !UploadedFileId.TryParse(attachmentIdStr, out var parsedAttachmentId)
+            || parsedAttachmentId is null)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Common.InvalidState,
+                "Route validation succeeded but attachment ID parsing failed.").ToHttpResult();
+        }
+
+        var callerId = httpContext.GetRequiredAuthenticatedUserId();
+        var response = await handler.HandleAsync(
+            parsedConversationId,
+            parsedMessageId,
+            parsedAttachmentId,
+            callerId,
+            cancellationToken);
+
+        if (response.Success)
+            return Results.NoContent();
+
+        return response.ToHttpResult();
+    }
+}

--- a/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
@@ -1,0 +1,127 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Interfaces;
+using Harmonie.Domain.ValueObjects;
+using Microsoft.Extensions.Logging;
+
+namespace Harmonie.Application.Features.Conversations.DeleteMessageAttachment;
+
+public sealed class DeleteMessageAttachmentHandler
+{
+    private readonly IConversationRepository _conversationRepository;
+    private readonly IMessageRepository _conversationMessageRepository;
+    private readonly UploadedFileCleanupService _uploadedFileCleanupService;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<DeleteMessageAttachmentHandler> _logger;
+
+    public DeleteMessageAttachmentHandler(
+        IConversationRepository conversationRepository,
+        IMessageRepository conversationMessageRepository,
+        UploadedFileCleanupService uploadedFileCleanupService,
+        IUnitOfWork unitOfWork,
+        ILogger<DeleteMessageAttachmentHandler> logger)
+    {
+        _conversationRepository = conversationRepository;
+        _conversationMessageRepository = conversationMessageRepository;
+        _uploadedFileCleanupService = uploadedFileCleanupService;
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task<ApplicationResponse<bool>> HandleAsync(
+        ConversationId conversationId,
+        MessageId messageId,
+        UploadedFileId attachmentId,
+        UserId callerId,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation(
+            "DeleteConversationMessageAttachment started. ConversationId={ConversationId}, MessageId={MessageId}, AttachmentId={AttachmentId}, CallerId={CallerId}",
+            conversationId,
+            messageId,
+            attachmentId,
+            callerId);
+
+        var conversation = await _conversationRepository.GetByIdAsync(conversationId, cancellationToken);
+        if (conversation is null)
+        {
+            _logger.LogWarning(
+                "DeleteConversationMessageAttachment failed because conversation was not found. ConversationId={ConversationId}",
+                conversationId);
+
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Conversation.NotFound,
+                "Conversation was not found");
+        }
+
+        if (conversation.User1Id != callerId && conversation.User2Id != callerId)
+        {
+            _logger.LogWarning(
+                "DeleteConversationMessageAttachment access denied because caller is not a participant. ConversationId={ConversationId}, CallerId={CallerId}",
+                conversationId,
+                callerId);
+
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Conversation.AccessDenied,
+                "You do not have access to this conversation");
+        }
+
+        var message = await _conversationMessageRepository.GetByIdAsync(messageId, cancellationToken);
+        var messageConversationId = message?.ConversationId;
+        if (message is null || messageConversationId is null || messageConversationId != conversationId)
+        {
+            _logger.LogWarning(
+                "DeleteConversationMessageAttachment failed because message was not found. ConversationId={ConversationId}, MessageId={MessageId}",
+                conversationId,
+                messageId);
+
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Message.NotFound,
+                "Message was not found");
+        }
+
+        if (message.AuthorUserId != callerId)
+        {
+            _logger.LogWarning(
+                "DeleteConversationMessageAttachment forbidden because caller is not the author. ConversationId={ConversationId}, MessageId={MessageId}, CallerId={CallerId}",
+                conversationId,
+                messageId,
+                callerId);
+
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Message.DeleteForbidden,
+                "You can only delete attachments from your own messages");
+        }
+
+        var removeAttachmentResult = message.RemoveAttachment(attachmentId);
+        if (removeAttachmentResult.IsFailure)
+        {
+            _logger.LogWarning(
+                "DeleteConversationMessageAttachment failed because attachment was not found on message. ConversationId={ConversationId}, MessageId={MessageId}, AttachmentId={AttachmentId}",
+                conversationId,
+                messageId,
+                attachmentId);
+
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Message.AttachmentNotFound,
+                removeAttachmentResult.Error ?? "Attachment was not found on message");
+        }
+
+        await using (var transaction = await _unitOfWork.BeginAsync(cancellationToken))
+        {
+            await _conversationMessageRepository.UpdateAsync(message, cancellationToken);
+            await _conversationMessageRepository.RemoveAttachmentAsync(message.Id, attachmentId, cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+        }
+
+        await _uploadedFileCleanupService.DeleteIfExistsAsync(attachmentId, cancellationToken);
+
+        _logger.LogInformation(
+            "DeleteConversationMessageAttachment succeeded. ConversationId={ConversationId}, MessageId={MessageId}, AttachmentId={AttachmentId}, CallerId={CallerId}",
+            conversationId,
+            messageId,
+            attachmentId,
+            callerId);
+
+        return ApplicationResponse<bool>.Ok(true);
+    }
+}

--- a/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentRouteRequest.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentRouteRequest.cs
@@ -1,0 +1,8 @@
+namespace Harmonie.Application.Features.Conversations.DeleteMessageAttachment;
+
+public sealed class DeleteMessageAttachmentRouteRequest
+{
+    public string? ConversationId { get; init; }
+    public string? MessageId { get; init; }
+    public string? AttachmentId { get; init; }
+}

--- a/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentRouteValidator.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentRouteValidator.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+
+namespace Harmonie.Application.Features.Conversations.DeleteMessageAttachment;
+
+public sealed class DeleteMessageAttachmentRouteValidator : AbstractValidator<DeleteMessageAttachmentRouteRequest>
+{
+    public DeleteMessageAttachmentRouteValidator()
+    {
+        RuleFor(x => x.ConversationId)
+            .NotEmpty()
+            .WithMessage("Conversation ID is required")
+            .Must(id => Guid.TryParse(id, out var parsed) && parsed != Guid.Empty)
+            .WithMessage("Conversation ID must be a valid non-empty GUID");
+
+        RuleFor(x => x.MessageId)
+            .NotEmpty()
+            .WithMessage("Message ID is required")
+            .Must(id => Guid.TryParse(id, out var parsed) && parsed != Guid.Empty)
+            .WithMessage("Message ID must be a valid non-empty GUID");
+
+        RuleFor(x => x.AttachmentId)
+            .NotEmpty()
+            .WithMessage("Attachment ID is required")
+            .Must(id => Guid.TryParse(id, out var parsed) && parsed != Guid.Empty)
+            .WithMessage("Attachment ID must be a valid non-empty GUID");
+    }
+}

--- a/tests/Harmonie.API.IntegrationTests/ConversationMessageEndpointsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/ConversationMessageEndpointsTests.cs
@@ -482,6 +482,144 @@ public sealed class ConversationMessageEndpointsTests : IClassFixture<WebApplica
     }
 
     [Fact]
+    public async Task DeleteConversationMessageAttachment_WhenAuthorDeletesOwnAttachment_ShouldReturn204AndRemoveAttachment()
+    {
+        var caller = await RegisterAsync();
+        var target = await RegisterAsync();
+        var conversationId = await OpenConversationAsync(caller.AccessToken, target.UserId);
+        var uploadedFile = await UploadAttachmentAsync(caller.AccessToken, "notes.txt", "text/plain", "attachment payload");
+
+        var sendResponse = await SendAuthorizedPostAsync(
+            $"/api/conversations/{conversationId}/messages",
+            new SendMessageRequest("message with attachment", [uploadedFile.FileId]),
+            caller.AccessToken);
+        sendResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        sendPayload.Should().NotBeNull();
+
+        var deleteResponse = await SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}/messages/{sendPayload!.MessageId}/attachments/{uploadedFile.FileId}",
+            caller.AccessToken);
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var listResponse = await SendAuthorizedGetAsync(
+            $"/api/conversations/{conversationId}/messages",
+            caller.AccessToken);
+        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var listPayload = await listResponse.Content.ReadFromJsonAsync<GetMessagesResponse>();
+        listPayload.Should().NotBeNull();
+        listPayload!.Items.Should().ContainSingle();
+        listPayload.Items[0].Attachments.Should().BeEmpty();
+
+        var fileResponse = await SendAuthorizedGetAsync($"/api/files/{uploadedFile.FileId}", caller.AccessToken);
+        fileResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteConversationMessageAttachment_WhenConversationDoesNotExist_ShouldReturnNotFound()
+    {
+        var caller = await RegisterAsync();
+
+        var response = await SendAuthorizedDeleteAsync(
+            $"/api/conversations/{Guid.NewGuid()}/messages/{Guid.NewGuid()}/attachments/{Guid.NewGuid()}",
+            caller.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteConversationMessageAttachment_WhenCallerIsNotParticipant_ShouldReturnForbidden()
+    {
+        var participantOne = await RegisterAsync();
+        var participantTwo = await RegisterAsync();
+        var outsider = await RegisterAsync();
+        var conversationId = await OpenConversationAsync(participantOne.AccessToken, participantTwo.UserId);
+        var uploadedFile = await UploadAttachmentAsync(participantOne.AccessToken, "notes.txt", "text/plain", "attachment payload");
+
+        var sendResponse = await SendAuthorizedPostAsync(
+            $"/api/conversations/{conversationId}/messages",
+            new SendMessageRequest("message with attachment", [uploadedFile.FileId]),
+            participantOne.AccessToken);
+        sendResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        sendPayload.Should().NotBeNull();
+
+        var response = await SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}/messages/{sendPayload!.MessageId}/attachments/{uploadedFile.FileId}",
+            outsider.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
+    }
+
+    [Fact]
+    public async Task DeleteConversationMessageAttachment_WhenCallerIsNotAuthor_ShouldReturnForbidden()
+    {
+        var participantOne = await RegisterAsync();
+        var participantTwo = await RegisterAsync();
+        var conversationId = await OpenConversationAsync(participantOne.AccessToken, participantTwo.UserId);
+        var uploadedFile = await UploadAttachmentAsync(participantOne.AccessToken, "notes.txt", "text/plain", "attachment payload");
+
+        var sendResponse = await SendAuthorizedPostAsync(
+            $"/api/conversations/{conversationId}/messages",
+            new SendMessageRequest("message with attachment", [uploadedFile.FileId]),
+            participantOne.AccessToken);
+        sendResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        sendPayload.Should().NotBeNull();
+
+        var response = await SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}/messages/{sendPayload!.MessageId}/attachments/{uploadedFile.FileId}",
+            participantTwo.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Message.DeleteForbidden);
+    }
+
+    [Fact]
+    public async Task DeleteConversationMessageAttachment_WhenAttachmentIsNotOnMessage_ShouldReturnNotFound()
+    {
+        var caller = await RegisterAsync();
+        var target = await RegisterAsync();
+        var conversationId = await OpenConversationAsync(caller.AccessToken, target.UserId);
+        var message = await SendConversationMessageAsync(conversationId, "message without attachment", caller.AccessToken);
+        var uploadedFile = await UploadAttachmentAsync(caller.AccessToken, "unused.txt", "text/plain", "unused attachment");
+
+        var response = await SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}/messages/{message.MessageId}/attachments/{uploadedFile.FileId}",
+            caller.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Message.AttachmentNotFound);
+    }
+
+    [Fact]
+    public async Task DeleteConversationMessageAttachment_WithoutAuthentication_ShouldReturnUnauthorized()
+    {
+        var response = await _client.DeleteAsync(
+            $"/api/conversations/{Guid.NewGuid()}/messages/{Guid.NewGuid()}/attachments/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
     public async Task DeleteConversationMessage_WithoutAuthentication_ShouldReturnUnauthorized()
     {
         var response = await _client.DeleteAsync(

--- a/tests/Harmonie.API.IntegrationTests/UploadsLocalFileSystemE2ETests.cs
+++ b/tests/Harmonie.API.IntegrationTests/UploadsLocalFileSystemE2ETests.cs
@@ -3,6 +3,9 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using Harmonie.Application.Features.Auth.Register;
 using Harmonie.Application.Features.Channels.SendMessage;
+using Harmonie.Application.Features.Conversations.OpenConversation;
+using ConversationSendMessageRequest = Harmonie.Application.Features.Conversations.SendMessage.SendMessageRequest;
+using ConversationSendMessageResponse = Harmonie.Application.Features.Conversations.SendMessage.SendMessageResponse;
 using Harmonie.Application.Features.Guilds.CreateChannel;
 using Harmonie.Application.Features.Guilds.CreateGuild;
 using Harmonie.Application.Features.Uploads.UploadFile;
@@ -323,6 +326,43 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<WebApplicatio
     }
 
     [Fact]
+    public async Task DeleteConversationMessageAttachment_WhenMessageHasUploadedAttachment_ShouldDeleteStoredFile()
+    {
+        using var factory = BuildFactory();
+        using var client = factory.CreateClient();
+
+        var caller = await RegisterAsync(client);
+        var target = await RegisterAsync(client);
+        var conversationId = await OpenConversationAsync(client, caller.AccessToken, target.UserId);
+        using var multipart = CreateMultipartContent("conversation-attachment-delete.txt", "text/plain", "conversation attachment to delete");
+
+        var uploadResponse = await SendAuthorizedMultipartAsync(client, "/api/files/uploads", multipart, caller.AccessToken);
+        Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
+
+        var uploadPayload = await uploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>();
+        Assert.NotNull(uploadPayload);
+
+        var sendMessageResponse = await SendAuthorizedPostAsync(
+            client,
+            $"/api/conversations/{conversationId}/messages",
+            new ConversationSendMessageRequest("message with attachment", [uploadPayload!.FileId]),
+            caller.AccessToken);
+        Assert.Equal(HttpStatusCode.Created, sendMessageResponse.StatusCode);
+
+        var sendMessagePayload = await sendMessageResponse.Content.ReadFromJsonAsync<ConversationSendMessageResponse>();
+        Assert.NotNull(sendMessagePayload);
+
+        var deleteAttachmentResponse = await SendAuthorizedDeleteAsync(
+            client,
+            $"/api/conversations/{conversationId}/messages/{sendMessagePayload!.MessageId}/attachments/{uploadPayload.FileId}",
+            caller.AccessToken);
+        Assert.Equal(HttpStatusCode.NoContent, deleteAttachmentResponse.StatusCode);
+
+        var oldFileResponse = await SendAuthorizedGetAsync(client, $"/api/files/{uploadPayload.FileId}", caller.AccessToken);
+        Assert.Equal(HttpStatusCode.NotFound, oldFileResponse.StatusCode);
+    }
+
+    [Fact]
     public async Task DeleteGuildIcon_WhenGuildHasUploadedIcon_ShouldDeleteStoredFile()
     {
         using var factory = BuildFactory();
@@ -397,6 +437,23 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<WebApplicatio
         var payload = await response.Content.ReadFromJsonAsync<RegisterResponse>();
         Assert.NotNull(payload);
         return payload!;
+    }
+
+    private static async Task<string> OpenConversationAsync(
+        HttpClient client,
+        string accessToken,
+        string targetUserId)
+    {
+        var response = await SendAuthorizedPostAsync(
+            client,
+            "/api/conversations",
+            new OpenConversationRequest(targetUserId),
+            accessToken);
+        Assert.True(response.StatusCode is HttpStatusCode.Created or HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<OpenConversationResponse>();
+        Assert.NotNull(payload);
+        return payload!.ConversationId;
     }
 
     private static async Task<string> CreateGuildAsync(

--- a/tests/Harmonie.Application.Tests/DeleteConversationMessageAttachmentHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/DeleteConversationMessageAttachmentHandlerTests.cs
@@ -1,0 +1,263 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Conversations.DeleteMessageAttachment;
+using Harmonie.Application.Interfaces;
+using Harmonie.Domain.Entities;
+using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests;
+
+public sealed class DeleteConversationMessageAttachmentHandlerTests
+{
+    private readonly Mock<IConversationRepository> _conversationRepositoryMock;
+    private readonly Mock<IMessageRepository> _conversationMessageRepositoryMock;
+    private readonly Mock<IUploadedFileRepository> _uploadedFileRepositoryMock;
+    private readonly Mock<IObjectStorageService> _objectStorageServiceMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly DeleteMessageAttachmentHandler _handler;
+
+    public DeleteConversationMessageAttachmentHandlerTests()
+    {
+        _conversationRepositoryMock = new Mock<IConversationRepository>();
+        _conversationMessageRepositoryMock = new Mock<IMessageRepository>();
+        _uploadedFileRepositoryMock = new Mock<IUploadedFileRepository>();
+        _objectStorageServiceMock = new Mock<IObjectStorageService>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _transactionMock = new Mock<IUnitOfWorkTransaction>();
+
+        _unitOfWorkMock
+            .Setup(x => x.BeginAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_transactionMock.Object);
+
+        _transactionMock
+            .Setup(x => x.DisposeAsync())
+            .Returns(ValueTask.CompletedTask);
+
+        _handler = new DeleteMessageAttachmentHandler(
+            _conversationRepositoryMock.Object,
+            _conversationMessageRepositoryMock.Object,
+            new UploadedFileCleanupService(
+                _uploadedFileRepositoryMock.Object,
+                _objectStorageServiceMock.Object,
+                NullLogger<UploadedFileCleanupService>.Instance),
+            _unitOfWorkMock.Object,
+            NullLogger<DeleteMessageAttachmentHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenConversationDoesNotExist_ShouldReturnConversationNotFound()
+    {
+        var conversationId = ConversationId.New();
+        var messageId = MessageId.New();
+        var attachmentId = UploadedFileId.New();
+        var callerId = UserId.New();
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdAsync(conversationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Conversation?)null);
+
+        var response = await _handler.HandleAsync(conversationId, messageId, attachmentId, callerId);
+
+        response.Success.Should().BeFalse();
+        response.Error.Should().NotBeNull();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCallerIsNotParticipant_ShouldReturnConversationAccessDenied()
+    {
+        var participantOne = UserId.New();
+        var participantTwo = UserId.New();
+        var outsider = UserId.New();
+        var conversation = CreateConversation(participantOne, participantTwo);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdAsync(conversation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(conversation);
+
+        var response = await _handler.HandleAsync(
+            conversation.Id,
+            MessageId.New(),
+            UploadedFileId.New(),
+            outsider);
+
+        response.Success.Should().BeFalse();
+        response.Error.Should().NotBeNull();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCallerIsNotAuthor_ShouldReturnDeleteForbidden()
+    {
+        var participantOne = UserId.New();
+        var participantTwo = UserId.New();
+        var conversation = CreateConversation(participantOne, participantTwo);
+        var attachmentId = UploadedFileId.New();
+        var message = CreateConversationMessage(conversation.Id, participantTwo, attachmentId);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdAsync(conversation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(conversation);
+
+        _conversationMessageRepositoryMock
+            .Setup(x => x.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        var response = await _handler.HandleAsync(conversation.Id, message.Id, attachmentId, participantOne);
+
+        response.Success.Should().BeFalse();
+        response.Error.Should().NotBeNull();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Message.DeleteForbidden);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenAttachmentIsNotOnMessage_ShouldReturnAttachmentNotFound()
+    {
+        var participantOne = UserId.New();
+        var participantTwo = UserId.New();
+        var conversation = CreateConversation(participantOne, participantTwo);
+        var message = CreateConversationMessage(conversation.Id, participantOne, UploadedFileId.New());
+        var missingAttachmentId = UploadedFileId.New();
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdAsync(conversation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(conversation);
+
+        _conversationMessageRepositoryMock
+            .Setup(x => x.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        var response = await _handler.HandleAsync(
+            conversation.Id,
+            message.Id,
+            missingAttachmentId,
+            participantOne);
+
+        response.Success.Should().BeFalse();
+        response.Error.Should().NotBeNull();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Message.AttachmentNotFound);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenAuthorDeletesAttachment_ShouldRemoveReferenceCommitAndCleanupFile()
+    {
+        var participantOne = UserId.New();
+        var participantTwo = UserId.New();
+        var conversation = CreateConversation(participantOne, participantTwo);
+        var attachmentId = UploadedFileId.New();
+        var message = CreateConversationMessage(conversation.Id, participantOne, attachmentId);
+        var uploadedFile = CreateUploadedFile(attachmentId, participantOne);
+        var sequence = new MockSequence();
+
+        _conversationRepositoryMock
+            .InSequence(sequence)
+            .Setup(x => x.GetByIdAsync(conversation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(conversation);
+
+        _conversationMessageRepositoryMock
+            .InSequence(sequence)
+            .Setup(x => x.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        _unitOfWorkMock
+            .InSequence(sequence)
+            .Setup(x => x.BeginAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_transactionMock.Object);
+
+        _conversationMessageRepositoryMock
+            .InSequence(sequence)
+            .Setup(x => x.UpdateAsync(
+                It.Is<Message>(updatedMessage =>
+                    updatedMessage.Id == message.Id
+                    && updatedMessage.Attachments.All(attachment => attachment.FileId != attachmentId)),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _conversationMessageRepositoryMock
+            .InSequence(sequence)
+            .Setup(x => x.RemoveAttachmentAsync(message.Id, attachmentId, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _transactionMock
+            .InSequence(sequence)
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _uploadedFileRepositoryMock
+            .InSequence(sequence)
+            .Setup(x => x.GetByIdAsync(attachmentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(uploadedFile);
+
+        _objectStorageServiceMock
+            .InSequence(sequence)
+            .Setup(x => x.DeleteIfExistsAsync(uploadedFile.StorageKey, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _uploadedFileRepositoryMock
+            .InSequence(sequence)
+            .Setup(x => x.DeleteAsync(attachmentId, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var response = await _handler.HandleAsync(conversation.Id, message.Id, attachmentId, participantOne);
+
+        response.Success.Should().BeTrue();
+        message.Attachments.Should().BeEmpty();
+        _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _conversationMessageRepositoryMock.Verify(
+            x => x.RemoveAttachmentAsync(message.Id, attachmentId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private static Conversation CreateConversation(UserId user1Id, UserId user2Id)
+    {
+        var result = Conversation.Create(user1Id, user2Id);
+        if (result.IsFailure || result.Value is null)
+            throw new InvalidOperationException("Failed to create test conversation.");
+
+        return result.Value;
+    }
+
+    private static Message CreateConversationMessage(
+        ConversationId conversationId,
+        UserId authorId,
+        UploadedFileId attachmentId)
+    {
+        var contentResult = MessageContent.Create("hello");
+        if (contentResult.IsFailure || contentResult.Value is null)
+            throw new InvalidOperationException("Failed to create message content for tests.");
+
+        return Message.Rehydrate(
+            MessageId.New(),
+            channelId: null,
+            conversationId,
+            authorId,
+            contentResult.Value,
+            createdAtUtc: DateTime.UtcNow.AddMinutes(-5),
+            updatedAtUtc: null,
+            deletedAtUtc: null,
+            attachments:
+            [
+                new MessageAttachment(attachmentId, "notes.txt", "text/plain", 12)
+            ]);
+    }
+
+    private static UploadedFile CreateUploadedFile(
+        UploadedFileId attachmentId,
+        UserId uploaderUserId)
+    {
+        return UploadedFile.Rehydrate(
+            attachmentId,
+            uploaderUserId,
+            "notes.txt",
+            "text/plain",
+            12,
+            "attachments/file.txt",
+            UploadPurpose.Attachment,
+            DateTime.UtcNow.AddMinutes(-10));
+    }
+}


### PR DESCRIPTION
## Summary
- add the authenticated DELETE /api/conversations/{conversationId}/messages/{messageId}/attachments/{attachmentId} endpoint and handler
- remove the attachment link in a transaction, then clean up the uploaded file after commit
- cover the flow with unit tests, conversation integration tests, and local filesystem cleanup tests

Closes #217