### PR TITLE
feat(docs): add AsyncAPI documentation for SignalR hub

### DIFF
--- a/src/Harmonie.API/Harmonie.API.csproj
+++ b/src/Harmonie.API/Harmonie.API.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+    <PackageReference Include="Saunter" Version="0.13.0" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.12.40" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
   </ItemGroup>

--- a/src/Harmonie.API/Program.cs
+++ b/src/Harmonie.API/Program.cs
@@ -64,6 +64,8 @@ using System.Text;
 using System.Text.Json.Serialization;
 using System.Threading.RateLimiting;
 using Microsoft.OpenApi;
+using Saunter;
+using Saunter.AsyncApiSchema.v2;
 using Scalar.AspNetCore;
 using Harmonie.Application.Features.Uploads.DownloadFile;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -90,6 +92,25 @@ builder.Services.ConfigureHttpJsonOptions(options =>
 });
 builder.Services.AddInfrastructure(builder.Configuration);
 builder.Services.AddSignalR();
+builder.Services.AddAsyncApiSchemaGeneration(options =>
+{
+    options.AssemblyMarkerTypes = new[] { typeof(Harmonie.API.RealTime.RealtimeHubDocumentation) };
+    options.Middleware.UiTitle = "Harmonie Realtime API";
+    options.AsyncApi = new AsyncApiDocument
+    {
+        Info = new Info("Harmonie Realtime API", "1.0.0")
+        {
+            Description = "Real-time events for the Harmonie communication platform, served over SignalR (WebSocket).",
+        },
+        Servers =
+        {
+            ["signalr"] = new Server("/hubs/realtime", "ws")
+            {
+                Description = "SignalR hub — requires Bearer JWT via the access_token query parameter.",
+            },
+        },
+    };
+});
 builder.Services.AddScoped<ITextChannelNotifier, SignalRTextChannelNotifier>();
 builder.Services.AddScoped<IGuildNotifier, SignalRGuildNotifier>();
 builder.Services.AddScoped<IVoicePresenceNotifier, SignalRVoicePresenceNotifier>();
@@ -223,6 +244,8 @@ if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
     app.MapScalarApiReference();
+    app.MapAsyncApiDocuments();
+    app.MapAsyncApiUi();
 }
 
 app.UseMiddleware<GlobalExceptionHandler>();

--- a/src/Harmonie.API/RealTime/RealtimeHubDocumentation.cs
+++ b/src/Harmonie.API/RealTime/RealtimeHubDocumentation.cs
@@ -1,0 +1,100 @@
+using Saunter.Attributes;
+
+namespace Harmonie.API.RealTime;
+
+/// <summary>
+/// AsyncAPI documentation for the RealtimeHub SignalR hub.
+/// This class is not invoked at runtime — it exists solely to generate
+/// the AsyncAPI specification via Saunter's attribute scanning.
+/// </summary>
+[AsyncApi]
+public class RealtimeHubDocumentation
+{
+    // ── Client → Server (Publish) ──────────────────────────────────
+
+    [Channel("hubs/realtime/JoinChannel")]
+    [PublishOperation(typeof(JoinChannelMessage),
+        Summary = "Join a text channel group to receive real-time messages.")]
+    public void JoinChannel() { }
+
+    [Channel("hubs/realtime/LeaveChannel")]
+    [PublishOperation(typeof(LeaveChannelMessage),
+        Summary = "Leave a text channel group.")]
+    public void LeaveChannel() { }
+
+    [Channel("hubs/realtime/JoinGuild")]
+    [PublishOperation(typeof(JoinGuildMessage),
+        Summary = "Join a guild group to receive voice presence events.")]
+    public void JoinGuild() { }
+
+    [Channel("hubs/realtime/LeaveGuild")]
+    [PublishOperation(typeof(LeaveGuildMessage),
+        Summary = "Leave a guild group.")]
+    public void LeaveGuild() { }
+
+    [Channel("hubs/realtime/JoinConversation")]
+    [PublishOperation(typeof(JoinConversationMessage),
+        Summary = "Join a direct conversation group to receive real-time messages.")]
+    public void JoinConversation() { }
+
+    [Channel("hubs/realtime/LeaveConversation")]
+    [PublishOperation(typeof(LeaveConversationMessage),
+        Summary = "Leave a direct conversation group.")]
+    public void LeaveConversation() { }
+
+    // ── Server → Client (Subscribe) ───────────────────────────────
+
+    [Channel("hubs/realtime/MessageCreated")]
+    [SubscribeOperation(typeof(MessageCreatedEvent),
+        Summary = "Received when a new message is posted in a text channel.")]
+    public void OnMessageCreated() { }
+
+    [Channel("hubs/realtime/MessageUpdated")]
+    [SubscribeOperation(typeof(MessageUpdatedEvent),
+        Summary = "Received when a message is edited in a text channel.")]
+    public void OnMessageUpdated() { }
+
+    [Channel("hubs/realtime/MessageDeleted")]
+    [SubscribeOperation(typeof(MessageDeletedEvent),
+        Summary = "Received when a message is deleted in a text channel.")]
+    public void OnMessageDeleted() { }
+
+    [Channel("hubs/realtime/ConversationMessageCreated")]
+    [SubscribeOperation(typeof(ConversationMessageCreatedEvent),
+        Summary = "Received when a new message is posted in a direct conversation.")]
+    public void OnConversationMessageCreated() { }
+
+    [Channel("hubs/realtime/ConversationMessageUpdated")]
+    [SubscribeOperation(typeof(ConversationMessageUpdatedEvent),
+        Summary = "Received when a message is edited in a direct conversation.")]
+    public void OnConversationMessageUpdated() { }
+
+    [Channel("hubs/realtime/ConversationMessageDeleted")]
+    [SubscribeOperation(typeof(ConversationMessageDeletedEvent),
+        Summary = "Received when a message is deleted in a direct conversation.")]
+    public void OnConversationMessageDeleted() { }
+
+    [Channel("hubs/realtime/VoiceParticipantJoined")]
+    [SubscribeOperation(typeof(VoiceParticipantJoinedEvent),
+        Summary = "Received when a user joins a voice channel.")]
+    public void OnVoiceParticipantJoined() { }
+
+    [Channel("hubs/realtime/VoiceParticipantLeft")]
+    [SubscribeOperation(typeof(VoiceParticipantLeftEvent),
+        Summary = "Received when a user leaves a voice channel.")]
+    public void OnVoiceParticipantLeft() { }
+
+    [Channel("hubs/realtime/GuildDeleted")]
+    [SubscribeOperation(typeof(GuildDeletedEvent),
+        Summary = "Received when a guild is deleted.")]
+    public void OnGuildDeleted() { }
+}
+
+// ── Client → Server payload types ─────────────────────────────────
+
+public sealed record JoinChannelMessage(Guid ChannelId);
+public sealed record LeaveChannelMessage(Guid ChannelId);
+public sealed record JoinGuildMessage(Guid GuildId);
+public sealed record LeaveGuildMessage(Guid GuildId);
+public sealed record JoinConversationMessage(Guid ConversationId);
+public sealed record LeaveConversationMessage(Guid ConversationId);


### PR DESCRIPTION
## Summary
- Integrate **Saunter 0.13.0** to generate an AsyncAPI 2.1 specification for the `RealtimeHub`
- Document all 6 client→server hub methods (`JoinChannel`, `LeaveChannel`, `JoinGuild`, `LeaveGuild`, `JoinConversation`, `LeaveConversation`)
- Document all 9 server→client events (`MessageCreated/Updated/Deleted`, `ConversationMessageCreated/Updated/Deleted`, `VoiceParticipantJoined/Left`, `GuildDeleted`)
- Expose `/asyncapi/asyncapi.json` and `/asyncapi/ui/` in development mode

Closes #219

## Test plan
- [ ] Run the API locally and verify `/asyncapi/asyncapi.json` returns a valid AsyncAPI document
- [ ] Verify `/asyncapi/ui/` renders the interactive documentation
- [ ] Confirm all hub methods and server events are listed with correct payload schemas
- [ ] Verify endpoints are not exposed in production