### PR TITLE
feat(presence): typing indicator — SignalR event

### DIFF
--- a/src/Harmonie.API/RealTime/RealtimeHub.cs
+++ b/src/Harmonie.API/RealTime/RealtimeHub.cs
@@ -148,7 +148,7 @@ public sealed class RealtimeHub : Hub
             Context.ConnectionAborted);
     }
 
-    public async Task StartTyping(Guid channelId)
+    public async Task StartTypingChannel(Guid channelId)
     {
         if (channelId == Guid.Empty)
             throw new HubException(ApplicationErrorCodes.Common.ValidationFailed);

--- a/src/Harmonie.API/RealTime/RealtimeHubDocumentation.cs
+++ b/src/Harmonie.API/RealTime/RealtimeHubDocumentation.cs
@@ -42,10 +42,10 @@ public class RealtimeHubDocumentation
         Summary = "Leave a direct conversation group.")]
     public void LeaveConversation() { }
 
-    [Channel("hubs/realtime/StartTyping")]
-    [PublishOperation(typeof(StartTypingMessage),
+    [Channel("hubs/realtime/StartTypingChannel")]
+    [PublishOperation(typeof(StartTypingChannelMessage),
         Summary = "Signal that the user is typing in a guild text channel. Throttled to 1 event per 5 seconds per user per channel.")]
-    public void StartTyping() { }
+    public void StartTypingChannel() { }
 
     [Channel("hubs/realtime/StartTypingConversation")]
     [PublishOperation(typeof(StartTypingConversationMessage),
@@ -118,5 +118,5 @@ public sealed record JoinGuildMessage(Guid GuildId);
 public sealed record LeaveGuildMessage(Guid GuildId);
 public sealed record JoinConversationMessage(Guid ConversationId);
 public sealed record LeaveConversationMessage(Guid ConversationId);
-public sealed record StartTypingMessage(Guid ChannelId);
+public sealed record StartTypingChannelMessage(Guid ChannelId);
 public sealed record StartTypingConversationMessage(Guid ConversationId);

--- a/tests/Harmonie.API.IntegrationTests/SignalRTypingIndicatorHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/SignalRTypingIndicatorHubTests.cs
@@ -31,7 +31,7 @@ public sealed class SignalRTypingIndicatorHubTests : IClassFixture<WebApplicatio
     // ── Guild text channel typing ─────────────────────────────────
 
     [Fact]
-    public async Task StartTyping_WhenUserIsNotMember_ShouldReturnAccessDeniedHubException()
+    public async Task StartTypingChannel_WhenUserIsNotMember_ShouldReturnAccessDeniedHubException()
     {
         var owner = await RegisterAsync();
         var outsider = await RegisterAsync();
@@ -60,14 +60,14 @@ public sealed class SignalRTypingIndicatorHubTests : IClassFixture<WebApplicatio
         await using var connection = CreateHubConnection(outsider.AccessToken);
         await connection.StartAsync();
 
-        var act = async () => await connection.InvokeAsync("StartTyping", textChannelId);
+        var act = async () => await connection.InvokeAsync("StartTypingChannel", textChannelId);
 
         var exception = await act.Should().ThrowAsync<HubException>();
         exception.Which.Message.Should().Contain(ApplicationErrorCodes.Channel.AccessDenied);
     }
 
     [Fact]
-    public async Task StartTyping_WhenMemberTypesInChannel_ShouldBroadcastToOtherMembers()
+    public async Task StartTypingChannel_WhenMemberTypesInChannel_ShouldBroadcastToOtherMembers()
     {
         var owner = await RegisterAsync();
         var member = await RegisterAsync();
@@ -114,7 +114,7 @@ public sealed class SignalRTypingIndicatorHubTests : IClassFixture<WebApplicatio
         await using var senderConnection = CreateHubConnection(owner.AccessToken);
         await senderConnection.StartAsync();
         await senderConnection.InvokeAsync("JoinChannel", textChannelId);
-        await senderConnection.InvokeAsync("StartTyping", textChannelId);
+        await senderConnection.InvokeAsync("StartTypingChannel", textChannelId);
 
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var completedTask = await Task.WhenAny(typingReceived.Task, Task.Delay(Timeout.InfiniteTimeSpan, timeout.Token));
@@ -127,7 +127,7 @@ public sealed class SignalRTypingIndicatorHubTests : IClassFixture<WebApplicatio
     }
 
     [Fact]
-    public async Task StartTyping_WhenCalledWithinThrottleWindow_ShouldNotBroadcastSecondEvent()
+    public async Task StartTypingChannel_WhenCalledWithinThrottleWindow_ShouldNotBroadcastSecondEvent()
     {
         var owner = await RegisterAsync();
         var member = await RegisterAsync();
@@ -173,9 +173,9 @@ public sealed class SignalRTypingIndicatorHubTests : IClassFixture<WebApplicatio
         await senderConnection.StartAsync();
         await senderConnection.InvokeAsync("JoinChannel", textChannelId);
 
-        await senderConnection.InvokeAsync("StartTyping", textChannelId);
-        await senderConnection.InvokeAsync("StartTyping", textChannelId);
-        await senderConnection.InvokeAsync("StartTyping", textChannelId);
+        await senderConnection.InvokeAsync("StartTypingChannel", textChannelId);
+        await senderConnection.InvokeAsync("StartTypingChannel", textChannelId);
+        await senderConnection.InvokeAsync("StartTypingChannel", textChannelId);
 
         await Task.Delay(TimeSpan.FromSeconds(1));
 


### PR DESCRIPTION
Closes #109

## Summary
- Add `StartTyping(Guid channelId)` hub method for guild text channels — broadcasts `UserTyping` event to channel group (excluding sender)
- Add `StartTypingConversation(Guid conversationId)` hub method for DM conversations — broadcasts `ConversationUserTyping` event to conversation group (excluding sender)
- In-memory throttle: max 1 event per 5 seconds per user per channel/conversation
- No persistence — typing is ephemeral
- AsyncAPI documentation updated for both publish and subscribe operations

## Test plan
- [x] `StartTyping` access denied when non-member calls
- [x] `StartTyping` broadcasts `UserTyping` to other channel members
- [x] `StartTyping` throttle suppresses duplicate events within 5s window
- [x] `StartTypingConversation` access denied when non-participant calls
- [x] `StartTypingConversation` broadcasts `ConversationUserTyping` to other participant
- [x] `StartTypingConversation` throttle suppresses duplicate events within 5s window
- [x] Full test suite passes (598 tests, 0 failures)