### PR TITLE
feat(presence): auto-presence via SignalR connection lifecycle

### DIFF
--- a/src/Harmonie.API/Harmonie.API.csproj
+++ b/src/Harmonie.API/Harmonie.API.csproj
@@ -6,6 +6,9 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Harmonie.API.IntegrationTests" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Harmonie.Application\Harmonie.Application.csproj" />
     <ProjectReference Include="..\Harmonie.Infrastructure\Harmonie.Infrastructure.csproj" />
   </ItemGroup>

--- a/src/Harmonie.API/Program.cs
+++ b/src/Harmonie.API/Program.cs
@@ -118,6 +118,7 @@ builder.Services.AddScoped<IGuildNotifier, SignalRGuildNotifier>();
 builder.Services.AddScoped<IVoicePresenceNotifier, SignalRVoicePresenceNotifier>();
 builder.Services.AddScoped<IConversationMessageNotifier, SignalRConversationMessageNotifier>();
 builder.Services.AddScoped<IUserPresenceNotifier, SignalRUserPresenceNotifier>();
+builder.Services.AddSingleton<IConnectionTracker, ConnectionTracker>();
 builder.Services.AddHealthChecks()
     .AddCheck<PostgresHealthCheck>("postgres")
     .AddCheck<LiveKitHealthCheck>("livekit");

--- a/src/Harmonie.API/RealTime/ConnectionTracker.cs
+++ b/src/Harmonie.API/RealTime/ConnectionTracker.cs
@@ -1,0 +1,245 @@
+using System.Collections.Concurrent;
+using Harmonie.Application.Interfaces;
+using Harmonie.Domain.ValueObjects;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Harmonie.API.RealTime;
+
+public sealed class ConnectionTracker : IConnectionTracker, IDisposable
+{
+    private readonly ConcurrentDictionary<string, UserConnectionState> _states = new();
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<ConnectionTracker> _logger;
+    private readonly TimeSpan _gracePeriod;
+
+    public ConnectionTracker(
+        IServiceScopeFactory scopeFactory,
+        ILogger<ConnectionTracker> logger)
+        : this(scopeFactory, logger, TimeSpan.FromSeconds(30))
+    {
+    }
+
+    internal ConnectionTracker(
+        IServiceScopeFactory scopeFactory,
+        ILogger<ConnectionTracker> logger,
+        TimeSpan gracePeriod)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+        _gracePeriod = gracePeriod;
+    }
+
+    public async Task HandleConnectedAsync(
+        UserId userId,
+        string connectionId,
+        CancellationToken cancellationToken = default)
+    {
+        var userKey = userId.ToString();
+        var state = _states.GetOrAdd(userKey, _ => new UserConnectionState());
+        bool isFirstConnection;
+
+        lock (state.Lock)
+        {
+            isFirstConnection = state.ConnectionIds.Count == 0;
+            state.ConnectionIds.Add(connectionId);
+
+            if (state.GracePeriodCts is not null)
+            {
+                state.GracePeriodCts.Cancel();
+                state.GracePeriodCts.Dispose();
+                state.GracePeriodCts = null;
+            }
+        }
+
+        if (isFirstConnection)
+        {
+            _logger.LogInformation(
+                "User {UserId} connected (first connection), broadcasting presence",
+                userId);
+            await BroadcastUserStatusAsync(userId, cancellationToken);
+        }
+        else
+        {
+            _logger.LogDebug(
+                "User {UserId} added connection {ConnectionId}",
+                userId, connectionId);
+        }
+    }
+
+    public Task HandleDisconnectedAsync(
+        UserId userId,
+        string connectionId,
+        CancellationToken cancellationToken = default)
+    {
+        var userKey = userId.ToString();
+
+        if (!_states.TryGetValue(userKey, out var state))
+            return Task.CompletedTask;
+
+        bool isLastConnection;
+
+        lock (state.Lock)
+        {
+            state.ConnectionIds.Remove(connectionId);
+            isLastConnection = state.ConnectionIds.Count == 0;
+        }
+
+        if (isLastConnection)
+        {
+            _logger.LogInformation(
+                "User {UserId} lost last connection, starting {GracePeriod}s grace period",
+                userId, _gracePeriod.TotalSeconds);
+            StartGracePeriod(userId, state);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public bool IsOnline(UserId userId)
+    {
+        var userKey = userId.ToString();
+        return _states.TryGetValue(userKey, out var state)
+            && state.ConnectionIds.Count > 0;
+    }
+
+    private void StartGracePeriod(UserId userId, UserConnectionState state)
+    {
+        var cts = new CancellationTokenSource();
+
+        lock (state.Lock)
+        {
+            if (state.GracePeriodCts is not null)
+            {
+                state.GracePeriodCts.Cancel();
+                state.GracePeriodCts.Dispose();
+            }
+
+            state.GracePeriodCts = cts;
+        }
+
+        _ = RunGracePeriodAsync(userId, state, cts);
+    }
+
+    private async Task RunGracePeriodAsync(
+        UserId userId,
+        UserConnectionState state,
+        CancellationTokenSource cts)
+    {
+        try
+        {
+            await Task.Delay(_gracePeriod, cts.Token);
+
+            bool stillOffline;
+            lock (state.Lock)
+            {
+                stillOffline = state.ConnectionIds.Count == 0;
+            }
+
+            if (!stillOffline)
+                return;
+
+            _logger.LogInformation(
+                "Grace period expired for user {UserId}, broadcasting offline",
+                userId);
+
+            await BroadcastOfflineAsync(userId, CancellationToken.None);
+        }
+        catch (TaskCanceledException)
+        {
+            // Grace period cancelled — user reconnected
+        }
+        finally
+        {
+            lock (state.Lock)
+            {
+                if (state.GracePeriodCts == cts)
+                    state.GracePeriodCts = null;
+            }
+
+            cts.Dispose();
+        }
+    }
+
+    private async Task BroadcastUserStatusAsync(UserId userId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var userRepository = scope.ServiceProvider.GetRequiredService<IUserRepository>();
+            var guildMemberRepository = scope.ServiceProvider.GetRequiredService<IGuildMemberRepository>();
+            var presenceNotifier = scope.ServiceProvider.GetRequiredService<IUserPresenceNotifier>();
+
+            var user = await userRepository.GetByIdAsync(userId, cancellationToken);
+            if (user is null)
+                return;
+
+            var broadcastStatus = string.Equals(user.Status, "invisible", StringComparison.OrdinalIgnoreCase)
+                ? "offline"
+                : user.Status;
+
+            var memberships = await guildMemberRepository.GetUserGuildMembershipsAsync(userId, cancellationToken);
+            var guildIds = memberships.Select(m => m.Guild.Id).ToList();
+
+            if (guildIds.Count > 0)
+            {
+                await presenceNotifier.NotifyStatusChangedAsync(
+                    new UserPresenceChangedNotification(userId, broadcastStatus, guildIds),
+                    cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to broadcast presence for user {UserId}", userId);
+        }
+    }
+
+    private async Task BroadcastOfflineAsync(UserId userId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var guildMemberRepository = scope.ServiceProvider.GetRequiredService<IGuildMemberRepository>();
+            var presenceNotifier = scope.ServiceProvider.GetRequiredService<IUserPresenceNotifier>();
+
+            var memberships = await guildMemberRepository.GetUserGuildMembershipsAsync(userId, cancellationToken);
+            var guildIds = memberships.Select(m => m.Guild.Id).ToList();
+
+            if (guildIds.Count > 0)
+            {
+                await presenceNotifier.NotifyStatusChangedAsync(
+                    new UserPresenceChangedNotification(userId, "offline", guildIds),
+                    cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to broadcast offline for user {UserId}", userId);
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var state in _states.Values)
+        {
+            lock (state.Lock)
+            {
+                if (state.GracePeriodCts is not null)
+                {
+                    state.GracePeriodCts.Cancel();
+                    state.GracePeriodCts.Dispose();
+                    state.GracePeriodCts = null;
+                }
+            }
+        }
+
+        _states.Clear();
+    }
+
+    private sealed class UserConnectionState
+    {
+        public readonly HashSet<string> ConnectionIds = new();
+        public CancellationTokenSource? GracePeriodCts;
+        public readonly object Lock = new();
+    }
+}

--- a/src/Harmonie.API/RealTime/RealtimeHub.cs
+++ b/src/Harmonie.API/RealTime/RealtimeHub.cs
@@ -19,17 +19,42 @@ public sealed class RealtimeHub : Hub
     private readonly IGuildMemberRepository _guildMemberRepository;
     private readonly IGuildRepository _guildRepository;
     private readonly IConversationRepository _conversationRepository;
+    private readonly IConnectionTracker _connectionTracker;
 
     public RealtimeHub(
         IGuildChannelRepository guildChannelRepository,
         IGuildMemberRepository guildMemberRepository,
         IGuildRepository guildRepository,
-        IConversationRepository conversationRepository)
+        IConversationRepository conversationRepository,
+        IConnectionTracker connectionTracker)
     {
         _guildChannelRepository = guildChannelRepository;
         _guildMemberRepository = guildMemberRepository;
         _guildRepository = guildRepository;
         _conversationRepository = conversationRepository;
+        _connectionTracker = connectionTracker;
+    }
+
+    public override async Task OnConnectedAsync()
+    {
+        if (TryGetAuthenticatedUserId(out var userId) && userId is not null)
+        {
+            await _connectionTracker.HandleConnectedAsync(
+                userId, Context.ConnectionId, Context.ConnectionAborted);
+        }
+
+        await base.OnConnectedAsync();
+    }
+
+    public override async Task OnDisconnectedAsync(Exception? exception)
+    {
+        if (TryGetAuthenticatedUserId(out var userId) && userId is not null)
+        {
+            await _connectionTracker.HandleDisconnectedAsync(
+                userId, Context.ConnectionId, Context.ConnectionAborted);
+        }
+
+        await base.OnDisconnectedAsync(exception);
     }
 
     public async Task JoinChannel(Guid channelId)

--- a/src/Harmonie.Application/Interfaces/IConnectionTracker.cs
+++ b/src/Harmonie.Application/Interfaces/IConnectionTracker.cs
@@ -1,0 +1,10 @@
+using Harmonie.Domain.ValueObjects;
+
+namespace Harmonie.Application.Interfaces;
+
+public interface IConnectionTracker
+{
+    Task HandleConnectedAsync(UserId userId, string connectionId, CancellationToken cancellationToken = default);
+    Task HandleDisconnectedAsync(UserId userId, string connectionId, CancellationToken cancellationToken = default);
+    bool IsOnline(UserId userId);
+}

--- a/tests/Harmonie.API.IntegrationTests/ConnectionTrackerTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/ConnectionTrackerTests.cs
@@ -1,0 +1,338 @@
+using FluentAssertions;
+using Harmonie.API.RealTime;
+using Harmonie.Application.Interfaces;
+using Harmonie.Domain.Entities;
+using Harmonie.Domain.ValueObjects;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Harmonie.API.IntegrationTests;
+
+public sealed class ConnectionTrackerTests : IDisposable
+{
+    private static readonly TimeSpan TestGracePeriod = TimeSpan.FromMilliseconds(200);
+
+    private readonly Mock<IUserRepository> _userRepositoryMock;
+    private readonly Mock<IGuildMemberRepository> _guildMemberRepositoryMock;
+    private readonly Mock<IUserPresenceNotifier> _presenceNotifierMock;
+    private readonly ConnectionTracker _tracker;
+
+    public ConnectionTrackerTests()
+    {
+        _userRepositoryMock = new Mock<IUserRepository>();
+        _guildMemberRepositoryMock = new Mock<IGuildMemberRepository>();
+        _presenceNotifierMock = new Mock<IUserPresenceNotifier>();
+
+        var services = new ServiceCollection();
+        services.AddScoped(_ => _userRepositoryMock.Object);
+        services.AddScoped(_ => _guildMemberRepositoryMock.Object);
+        services.AddScoped(_ => _presenceNotifierMock.Object);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var scopeFactory = serviceProvider.GetRequiredService<IServiceScopeFactory>();
+
+        _tracker = new ConnectionTracker(
+            scopeFactory,
+            NullLogger<ConnectionTracker>.Instance,
+            TestGracePeriod);
+    }
+
+    public void Dispose()
+    {
+        _tracker.Dispose();
+    }
+
+    [Fact]
+    public async Task HandleConnectedAsync_FirstConnection_ShouldMarkUserOnline()
+    {
+        var userId = UserId.New();
+        var user = CreateUser(userId);
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<UserGuildMembership>());
+
+        await _tracker.HandleConnectedAsync(userId, "conn-1");
+
+        _tracker.IsOnline(userId).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleConnectedAsync_FirstConnection_ShouldBroadcastUserStatus()
+    {
+        var userId = UserId.New();
+        var user = CreateUser(userId);
+        var guildId = GuildId.New();
+        var guild = CreateGuild(guildId, userId);
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow)
+            });
+
+        await _tracker.HandleConnectedAsync(userId, "conn-1");
+
+        _presenceNotifierMock.Verify(
+            x => x.NotifyStatusChangedAsync(
+                It.Is<UserPresenceChangedNotification>(n =>
+                    n.UserId == userId &&
+                    n.Status == "online" &&
+                    n.GuildIds.Count == 1 &&
+                    n.GuildIds[0] == guildId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleConnectedAsync_SecondConnection_ShouldNotBroadcastAgain()
+    {
+        var userId = UserId.New();
+        var user = CreateUser(userId);
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<UserGuildMembership>());
+
+        await _tracker.HandleConnectedAsync(userId, "conn-1");
+        await _tracker.HandleConnectedAsync(userId, "conn-2");
+
+        _tracker.IsOnline(userId).Should().BeTrue();
+
+        _userRepositoryMock.Verify(
+            x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleDisconnectedAsync_NotLastConnection_ShouldRemainOnline()
+    {
+        var userId = UserId.New();
+        var user = CreateUser(userId);
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<UserGuildMembership>());
+
+        await _tracker.HandleConnectedAsync(userId, "conn-1");
+        await _tracker.HandleConnectedAsync(userId, "conn-2");
+        await _tracker.HandleDisconnectedAsync(userId, "conn-1");
+
+        _tracker.IsOnline(userId).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleDisconnectedAsync_LastConnection_ShouldBroadcastOfflineAfterGracePeriod()
+    {
+        var userId = UserId.New();
+        var user = CreateUser(userId);
+        var guildId = GuildId.New();
+        var guild = CreateGuild(guildId, userId);
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow)
+            });
+
+        await _tracker.HandleConnectedAsync(userId, "conn-1");
+        _presenceNotifierMock.Invocations.Clear();
+
+        await _tracker.HandleDisconnectedAsync(userId, "conn-1");
+
+        // Should not broadcast immediately
+        _presenceNotifierMock.Verify(
+            x => x.NotifyStatusChangedAsync(
+                It.IsAny<UserPresenceChangedNotification>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Wait for grace period to expire
+        await Task.Delay(TestGracePeriod + TimeSpan.FromMilliseconds(200));
+
+        _presenceNotifierMock.Verify(
+            x => x.NotifyStatusChangedAsync(
+                It.Is<UserPresenceChangedNotification>(n =>
+                    n.UserId == userId &&
+                    n.Status == "offline"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleConnectedAsync_DuringGracePeriod_ShouldCancelOfflineBroadcast()
+    {
+        var userId = UserId.New();
+        var user = CreateUser(userId);
+        var guildId = GuildId.New();
+        var guild = CreateGuild(guildId, userId);
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow)
+            });
+
+        await _tracker.HandleConnectedAsync(userId, "conn-1");
+        _presenceNotifierMock.Invocations.Clear();
+
+        await _tracker.HandleDisconnectedAsync(userId, "conn-1");
+
+        // Reconnect before grace period expires
+        await Task.Delay(TestGracePeriod / 2);
+        await _tracker.HandleConnectedAsync(userId, "conn-2");
+
+        // Wait for grace period to fully expire
+        await Task.Delay(TestGracePeriod + TimeSpan.FromMilliseconds(200));
+
+        // Should have broadcast online on reconnect, not offline
+        _presenceNotifierMock.Verify(
+            x => x.NotifyStatusChangedAsync(
+                It.Is<UserPresenceChangedNotification>(n =>
+                    n.Status == "offline"),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _presenceNotifierMock.Verify(
+            x => x.NotifyStatusChangedAsync(
+                It.Is<UserPresenceChangedNotification>(n =>
+                    n.Status == "online"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleConnectedAsync_InvisibleUser_ShouldBroadcastOffline()
+    {
+        var userId = UserId.New();
+        var user = CreateUser(userId, "invisible");
+        var guildId = GuildId.New();
+        var guild = CreateGuild(guildId, userId);
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow)
+            });
+
+        await _tracker.HandleConnectedAsync(userId, "conn-1");
+
+        _presenceNotifierMock.Verify(
+            x => x.NotifyStatusChangedAsync(
+                It.Is<UserPresenceChangedNotification>(n =>
+                    n.UserId == userId &&
+                    n.Status == "offline"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task IsOnline_WhenNoConnections_ShouldReturnFalse()
+    {
+        var userId = UserId.New();
+        _tracker.IsOnline(userId).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HandleDisconnectedAsync_UnknownUser_ShouldNotThrow()
+    {
+        var userId = UserId.New();
+        await _tracker.HandleDisconnectedAsync(userId, "conn-1");
+    }
+
+    [Fact]
+    public async Task HandleConnectedAsync_UserWithNoGuilds_ShouldNotBroadcast()
+    {
+        var userId = UserId.New();
+        var user = CreateUser(userId);
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<UserGuildMembership>());
+
+        await _tracker.HandleConnectedAsync(userId, "conn-1");
+
+        _presenceNotifierMock.Verify(
+            x => x.NotifyStatusChangedAsync(
+                It.IsAny<UserPresenceChangedNotification>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static User CreateUser(UserId? userId = null, string status = "online")
+    {
+        var id = userId ?? UserId.New();
+        var emailResult = Email.Create($"test-{Guid.NewGuid():N}@harmonie.chat");
+        var usernameResult = Username.Create($"user{Guid.NewGuid():N}"[..20]);
+
+        return User.Rehydrate(
+            id,
+            emailResult.Value!,
+            usernameResult.Value!,
+            "hashed_password",
+            avatarFileId: null,
+            isEmailVerified: true,
+            isActive: true,
+            lastLoginAtUtc: DateTime.UtcNow,
+            displayName: null,
+            bio: null,
+            avatarColor: null,
+            avatarIcon: null,
+            avatarBg: null,
+            theme: "default",
+            language: null,
+            status: status,
+            statusUpdatedAtUtc: DateTime.UtcNow,
+            createdAtUtc: DateTime.UtcNow,
+            updatedAtUtc: null);
+    }
+
+    private static Guild CreateGuild(GuildId guildId, UserId ownerId)
+    {
+        var nameResult = GuildName.Create($"guild-{Guid.NewGuid():N}"[..20]);
+        return Guild.Rehydrate(
+            guildId,
+            nameResult.Value!,
+            ownerId,
+            createdAtUtc: DateTime.UtcNow,
+            updatedAtUtc: DateTime.UtcNow);
+    }
+}

--- a/tests/Harmonie.API.IntegrationTests/Harmonie.API.IntegrationTests.csproj
+++ b/tests/Harmonie.API.IntegrationTests/Harmonie.API.IntegrationTests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Harmonie.API\Harmonie.API.csproj" />


### PR DESCRIPTION
## Summary
- Track user online/offline status based on SignalR hub connection lifecycle
- `ConnectionTracker` singleton manages userId → connectionIds mapping with per-user locking
- On first connection: broadcast saved user status (invisible → "offline") to guild members via `UserPresenceChanged`
- On last disconnect: 30-second grace period before broadcasting "offline" — reconnecting within the window cancels the offline broadcast
- Supports multiple connections per user (online as long as ≥1 active connection)

## Test plan
- [x] Unit tests for `ConnectionTracker` (10 tests covering first/second connection, disconnect, grace period, reconnect during grace, invisible user, no guilds, unknown user)
- [x] All existing tests pass (260 application + 79 domain)
- [ ] Manual: connect to hub → verify `UserPresenceChanged` with saved status
- [ ] Manual: disconnect all tabs → verify offline broadcast after ~30s
- [ ] Manual: disconnect and reconnect within 30s → verify no offline broadcast

Closes #111