### PR TITLE
feat(reactions): remove reaction — DELETE channels & conversations (#119)

### DIFF
--- a/src/Harmonie.API/Program.cs
+++ b/src/Harmonie.API/Program.cs
@@ -25,7 +25,9 @@ using Harmonie.Application.Features.Conversations.OpenConversation;
 using Harmonie.Application.Features.Conversations.SearchConversationMessages;
 using ConversationSendMessage = Harmonie.Application.Features.Conversations.SendMessage.SendMessageEndpoint;
 using ChannelAddReaction = Harmonie.Application.Features.Channels.AddReaction.AddReactionEndpoint;
+using ChannelRemoveReaction = Harmonie.Application.Features.Channels.RemoveReaction.RemoveReactionEndpoint;
 using ConversationAddReaction = Harmonie.Application.Features.Conversations.AddReaction.AddReactionEndpoint;
+using ConversationRemoveReaction = Harmonie.Application.Features.Conversations.RemoveReaction.RemoveReactionEndpoint;
 using Harmonie.Application.Features.Guilds.CreateChannel;
 using Harmonie.Application.Features.Guilds.CreateGuild;
 using Harmonie.Application.Features.Guilds.AcceptInvite;
@@ -328,7 +330,9 @@ ConversationDeleteMessage.Map(app);
 ConversationDeleteMessageAttachment.Map(app);
 ConversationSendMessage.Map(app);
 ChannelAddReaction.Map(app);
+ChannelRemoveReaction.Map(app);
 ConversationAddReaction.Map(app);
+ConversationRemoveReaction.Map(app);
 app.MapHub<RealtimeHub>("/hubs/realtime");
 
 // Future endpoints will be added here as features are developed

--- a/src/Harmonie.API/RealTime/RealtimeHubDocumentation.cs
+++ b/src/Harmonie.API/RealTime/RealtimeHubDocumentation.cs
@@ -118,6 +118,11 @@ public class RealtimeHubDocumentation
     [SubscribeOperation(typeof(ReactionAddedEvent),
         Summary = "Received when a user adds an emoji reaction to a message (channel or conversation).")]
     public void OnReactionAdded() { }
+
+    [Channel("hubs/realtime/ReactionRemoved")]
+    [SubscribeOperation(typeof(ReactionRemovedEvent),
+        Summary = "Received when a user removes an emoji reaction from a message (channel or conversation).")]
+    public void OnReactionRemoved() { }
 }
 
 // ── Client → Server payload types ─────────────────────────────────

--- a/src/Harmonie.API/RealTime/SignalRReactionNotifier.cs
+++ b/src/Harmonie.API/RealTime/SignalRReactionNotifier.cs
@@ -47,9 +47,52 @@ public sealed class SignalRReactionNotifier : IReactionNotifier
             .Group(RealtimeHub.GetConversationGroupName(notification.ConversationId))
             .SendAsync("ReactionAdded", payload, cancellationToken);
     }
+
+    public async Task NotifyReactionRemovedFromChannelAsync(
+        ChannelReactionRemovedNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var payload = new ReactionRemovedEvent(
+            MessageId: notification.MessageId.ToString(),
+            ChannelId: notification.ChannelId.ToString(),
+            ConversationId: null,
+            UserId: notification.UserId.ToString(),
+            Emoji: notification.Emoji);
+
+        await _hubContext.Clients
+            .Group(RealtimeHub.GetChannelGroupName(notification.ChannelId))
+            .SendAsync("ReactionRemoved", payload, cancellationToken);
+    }
+
+    public async Task NotifyReactionRemovedFromConversationAsync(
+        ConversationReactionRemovedNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var payload = new ReactionRemovedEvent(
+            MessageId: notification.MessageId.ToString(),
+            ChannelId: null,
+            ConversationId: notification.ConversationId.ToString(),
+            UserId: notification.UserId.ToString(),
+            Emoji: notification.Emoji);
+
+        await _hubContext.Clients
+            .Group(RealtimeHub.GetConversationGroupName(notification.ConversationId))
+            .SendAsync("ReactionRemoved", payload, cancellationToken);
+    }
 }
 
 public sealed record ReactionAddedEvent(
+    string MessageId,
+    string? ChannelId,
+    string? ConversationId,
+    string UserId,
+    string Emoji);
+
+public sealed record ReactionRemovedEvent(
     string MessageId,
     string? ChannelId,
     string? ConversationId,

--- a/src/Harmonie.Application/DependencyInjection.cs
+++ b/src/Harmonie.Application/DependencyInjection.cs
@@ -52,7 +52,9 @@ using Harmonie.Application.Features.Users.UploadMyAvatar;
 using Harmonie.Application.Features.Uploads.DownloadFile;
 using Harmonie.Application.Features.Uploads.UploadFile;
 using ChannelAddReactionHandler = Harmonie.Application.Features.Channels.AddReaction.AddReactionHandler;
+using ChannelRemoveReactionHandler = Harmonie.Application.Features.Channels.RemoveReaction.RemoveReactionHandler;
 using ConversationAddReactionHandler = Harmonie.Application.Features.Conversations.AddReaction.AddReactionHandler;
+using ConversationRemoveReactionHandler = Harmonie.Application.Features.Conversations.RemoveReaction.RemoveReactionHandler;
 using Harmonie.Application.Features.Voice.HandleLiveKitWebhook;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -126,7 +128,9 @@ public static class DependencyInjection
         services.AddScoped<ConversationDeleteMessageAttachmentHandler>();
         services.AddScoped<ConversationSendMessageHandler>();
         services.AddScoped<ChannelAddReactionHandler>();
+        services.AddScoped<ChannelRemoveReactionHandler>();
         services.AddScoped<ConversationAddReactionHandler>();
+        services.AddScoped<ConversationRemoveReactionHandler>();
         // Add more handlers as features are created
 
         return services;

--- a/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionEndpoint.cs
@@ -1,0 +1,70 @@
+using FluentValidation;
+using Harmonie.Application.Common;
+using Harmonie.Domain.ValueObjects;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Harmonie.Application.Features.Channels.RemoveReaction;
+
+public static class RemoveReactionEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        app.MapDelete("/api/channels/{channelId}/messages/{messageId}/reactions/{emoji}", HandleAsync)
+            .WithName("RemoveChannelMessageReaction")
+            .WithTags("Channels")
+            .RequireAuthorization()
+            .WithSummary("Remove a reaction from a channel message")
+            .WithDescription("Removes the caller's emoji reaction from a message. Idempotent — removing a non-existent reaction is a no-op.")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesErrors(
+                ApplicationErrorCodes.Common.ValidationFailed,
+                ApplicationErrorCodes.Auth.InvalidCredentials,
+                ApplicationErrorCodes.Channel.NotFound,
+                ApplicationErrorCodes.Channel.NotText,
+                ApplicationErrorCodes.Channel.AccessDenied,
+                ApplicationErrorCodes.Reaction.MessageNotFound);
+    }
+
+    private static async Task<IResult> HandleAsync(
+        [AsParameters] RemoveReactionRouteRequest routeRequest,
+        [FromServices] RemoveReactionHandler handler,
+        [FromServices] IValidator<RemoveReactionRouteRequest> routeValidator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var routeValidationError = await routeRequest.ValidateAsync(routeValidator, cancellationToken);
+        if (routeValidationError is not null)
+            return ApplicationResponse<bool>.Fail(routeValidationError).ToHttpResult();
+
+        if (routeRequest.ChannelId is not string channelIdStr
+            || !GuildChannelId.TryParse(channelIdStr, out var parsedChannelId)
+            || parsedChannelId is null)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Common.InvalidState,
+                "Route validation succeeded but channel ID parsing failed.").ToHttpResult();
+        }
+
+        if (routeRequest.MessageId is not string messageIdStr
+            || !MessageId.TryParse(messageIdStr, out var parsedMessageId)
+            || parsedMessageId is null)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Common.InvalidState,
+                "Route validation succeeded but message ID parsing failed.").ToHttpResult();
+        }
+
+        var emoji = routeRequest.Emoji!;
+        var callerId = httpContext.GetRequiredAuthenticatedUserId();
+
+        var response = await handler.HandleAsync(parsedChannelId, parsedMessageId, emoji, callerId, cancellationToken);
+
+        if (response.Success)
+            return Results.NoContent();
+
+        return response.ToHttpResult();
+    }
+}

--- a/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionHandler.cs
@@ -1,0 +1,129 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Interfaces;
+using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects;
+using Microsoft.Extensions.Logging;
+
+namespace Harmonie.Application.Features.Channels.RemoveReaction;
+
+public sealed class RemoveReactionHandler
+{
+    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly IGuildChannelRepository _guildChannelRepository;
+    private readonly IMessageRepository _messageRepository;
+    private readonly IMessageReactionRepository _reactionRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IReactionNotifier _reactionNotifier;
+    private readonly ILogger<RemoveReactionHandler> _logger;
+
+    public RemoveReactionHandler(
+        IGuildChannelRepository guildChannelRepository,
+        IMessageRepository messageRepository,
+        IMessageReactionRepository reactionRepository,
+        IUnitOfWork unitOfWork,
+        IReactionNotifier reactionNotifier,
+        ILogger<RemoveReactionHandler> logger)
+    {
+        _guildChannelRepository = guildChannelRepository;
+        _messageRepository = messageRepository;
+        _reactionRepository = reactionRepository;
+        _unitOfWork = unitOfWork;
+        _reactionNotifier = reactionNotifier;
+        _logger = logger;
+    }
+
+    public async Task<ApplicationResponse<bool>> HandleAsync(
+        GuildChannelId channelId,
+        MessageId messageId,
+        string emoji,
+        UserId callerId,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation(
+            "RemoveChannelReaction started. ChannelId={ChannelId}, MessageId={MessageId}, Emoji={Emoji}, CallerId={CallerId}",
+            channelId,
+            messageId,
+            emoji,
+            callerId);
+
+        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(channelId, callerId, cancellationToken);
+        if (ctx is null)
+        {
+            _logger.LogWarning(
+                "RemoveChannelReaction failed because channel was not found. ChannelId={ChannelId}",
+                channelId);
+
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Channel.NotFound,
+                "Channel was not found");
+        }
+
+        if (ctx.Channel.Type != GuildChannelType.Text)
+        {
+            _logger.LogWarning(
+                "RemoveChannelReaction failed because channel is not text. ChannelId={ChannelId}, ChannelType={ChannelType}",
+                channelId,
+                ctx.Channel.Type);
+
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Channel.NotText,
+                "Reactions can only be removed from text channels");
+        }
+
+        if (ctx.CallerRole is null)
+        {
+            _logger.LogWarning(
+                "RemoveChannelReaction access denied because caller is not a member. ChannelId={ChannelId}, GuildId={GuildId}, CallerId={CallerId}",
+                channelId,
+                ctx.Channel.GuildId,
+                callerId);
+
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Channel.AccessDenied,
+                "You do not have access to this channel");
+        }
+
+        var message = await _messageRepository.GetByIdAsync(messageId, cancellationToken);
+        var messageChannelId = message?.ChannelId;
+        if (message is null || messageChannelId is null || messageChannelId != channelId)
+        {
+            _logger.LogWarning(
+                "RemoveChannelReaction failed because message was not found. ChannelId={ChannelId}, MessageId={MessageId}",
+                channelId,
+                messageId);
+
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Reaction.MessageNotFound,
+                "Message was not found");
+        }
+
+        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
+        await _reactionRepository.RemoveAsync(messageId, callerId, emoji, cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "RemoveChannelReaction succeeded. ChannelId={ChannelId}, MessageId={MessageId}, Emoji={Emoji}, CallerId={CallerId}",
+            channelId,
+            messageId,
+            emoji,
+            callerId);
+
+        await NotifyReactionRemovedSafelyAsync(
+            new ChannelReactionRemovedNotification(messageId, channelId, callerId, emoji));
+
+        return ApplicationResponse<bool>.Ok(true);
+    }
+
+    private async Task NotifyReactionRemovedSafelyAsync(
+        ChannelReactionRemovedNotification notification)
+    {
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            token => _reactionNotifier.NotifyReactionRemovedFromChannelAsync(notification, token),
+            NotificationTimeout,
+            _logger,
+            "RemoveChannelReaction notification failed (best-effort). MessageId={MessageId}, ChannelId={ChannelId}",
+            notification.MessageId,
+            notification.ChannelId);
+    }
+}

--- a/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionRouteRequest.cs
+++ b/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionRouteRequest.cs
@@ -1,0 +1,8 @@
+namespace Harmonie.Application.Features.Channels.RemoveReaction;
+
+public sealed class RemoveReactionRouteRequest
+{
+    public string? ChannelId { get; init; }
+    public string? MessageId { get; init; }
+    public string? Emoji { get; init; }
+}

--- a/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionRouteValidator.cs
+++ b/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionRouteValidator.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+
+namespace Harmonie.Application.Features.Channels.RemoveReaction;
+
+public sealed class RemoveReactionRouteValidator : AbstractValidator<RemoveReactionRouteRequest>
+{
+    public RemoveReactionRouteValidator()
+    {
+        RuleFor(x => x.ChannelId)
+            .NotEmpty()
+            .WithMessage("Channel ID is required")
+            .Must(id => Guid.TryParse(id, out var parsed) && parsed != Guid.Empty)
+            .WithMessage("Channel ID must be a valid non-empty GUID");
+
+        RuleFor(x => x.MessageId)
+            .NotEmpty()
+            .WithMessage("Message ID is required")
+            .Must(id => Guid.TryParse(id, out var parsed) && parsed != Guid.Empty)
+            .WithMessage("Message ID must be a valid non-empty GUID");
+
+        RuleFor(x => x.Emoji)
+            .NotEmpty()
+            .WithMessage("Emoji is required")
+            .MaximumLength(64)
+            .WithMessage("Emoji must not exceed 64 characters");
+    }
+}

--- a/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionEndpoint.cs
@@ -1,0 +1,69 @@
+using FluentValidation;
+using Harmonie.Application.Common;
+using Harmonie.Domain.ValueObjects;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Harmonie.Application.Features.Conversations.RemoveReaction;
+
+public static class RemoveReactionEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        app.MapDelete("/api/conversations/{conversationId}/messages/{messageId}/reactions/{emoji}", HandleAsync)
+            .WithName("RemoveConversationMessageReaction")
+            .WithTags("Conversations")
+            .RequireAuthorization()
+            .WithSummary("Remove a reaction from a conversation message")
+            .WithDescription("Removes the caller's emoji reaction from a conversation message. Idempotent — removing a non-existent reaction is a no-op.")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesErrors(
+                ApplicationErrorCodes.Common.ValidationFailed,
+                ApplicationErrorCodes.Auth.InvalidCredentials,
+                ApplicationErrorCodes.Conversation.NotFound,
+                ApplicationErrorCodes.Conversation.AccessDenied,
+                ApplicationErrorCodes.Reaction.MessageNotFound);
+    }
+
+    private static async Task<IResult> HandleAsync(
+        [AsParameters] RemoveReactionRouteRequest routeRequest,
+        [FromServices] RemoveReactionHandler handler,
+        [FromServices] IValidator<RemoveReactionRouteRequest> routeValidator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var routeValidationError = await routeRequest.ValidateAsync(routeValidator, cancellationToken);
+        if (routeValidationError is not null)
+            return ApplicationResponse<bool>.Fail(routeValidationError).ToHttpResult();
+
+        if (routeRequest.ConversationId is not string conversationIdStr
+            || !ConversationId.TryParse(conversationIdStr, out var parsedConversationId)
+            || parsedConversationId is null)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Common.InvalidState,
+                "Route validation succeeded but conversation ID parsing failed.").ToHttpResult();
+        }
+
+        if (routeRequest.MessageId is not string messageIdStr
+            || !MessageId.TryParse(messageIdStr, out var parsedMessageId)
+            || parsedMessageId is null)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Common.InvalidState,
+                "Route validation succeeded but message ID parsing failed.").ToHttpResult();
+        }
+
+        var emoji = routeRequest.Emoji!;
+        var callerId = httpContext.GetRequiredAuthenticatedUserId();
+
+        var response = await handler.HandleAsync(parsedConversationId, parsedMessageId, emoji, callerId, cancellationToken);
+
+        if (response.Success)
+            return Results.NoContent();
+
+        return response.ToHttpResult();
+    }
+}

--- a/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionHandler.cs
@@ -1,0 +1,115 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Interfaces;
+using Harmonie.Domain.ValueObjects;
+using Microsoft.Extensions.Logging;
+
+namespace Harmonie.Application.Features.Conversations.RemoveReaction;
+
+public sealed class RemoveReactionHandler
+{
+    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly IConversationRepository _conversationRepository;
+    private readonly IMessageRepository _messageRepository;
+    private readonly IMessageReactionRepository _reactionRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IReactionNotifier _reactionNotifier;
+    private readonly ILogger<RemoveReactionHandler> _logger;
+
+    public RemoveReactionHandler(
+        IConversationRepository conversationRepository,
+        IMessageRepository messageRepository,
+        IMessageReactionRepository reactionRepository,
+        IUnitOfWork unitOfWork,
+        IReactionNotifier reactionNotifier,
+        ILogger<RemoveReactionHandler> logger)
+    {
+        _conversationRepository = conversationRepository;
+        _messageRepository = messageRepository;
+        _reactionRepository = reactionRepository;
+        _unitOfWork = unitOfWork;
+        _reactionNotifier = reactionNotifier;
+        _logger = logger;
+    }
+
+    public async Task<ApplicationResponse<bool>> HandleAsync(
+        ConversationId conversationId,
+        MessageId messageId,
+        string emoji,
+        UserId callerId,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation(
+            "RemoveConversationReaction started. ConversationId={ConversationId}, MessageId={MessageId}, Emoji={Emoji}, CallerId={CallerId}",
+            conversationId,
+            messageId,
+            emoji,
+            callerId);
+
+        var conversation = await _conversationRepository.GetByIdAsync(conversationId, cancellationToken);
+        if (conversation is null)
+        {
+            _logger.LogWarning(
+                "RemoveConversationReaction failed because conversation was not found. ConversationId={ConversationId}",
+                conversationId);
+
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Conversation.NotFound,
+                "Conversation was not found");
+        }
+
+        if (conversation.User1Id != callerId && conversation.User2Id != callerId)
+        {
+            _logger.LogWarning(
+                "RemoveConversationReaction access denied because caller is not a participant. ConversationId={ConversationId}, CallerId={CallerId}",
+                conversationId,
+                callerId);
+
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Conversation.AccessDenied,
+                "You do not have access to this conversation");
+        }
+
+        var message = await _messageRepository.GetByIdAsync(messageId, cancellationToken);
+        var messageConversationId = message?.ConversationId;
+        if (message is null || messageConversationId is null || messageConversationId != conversationId)
+        {
+            _logger.LogWarning(
+                "RemoveConversationReaction failed because message was not found. ConversationId={ConversationId}, MessageId={MessageId}",
+                conversationId,
+                messageId);
+
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Reaction.MessageNotFound,
+                "Message was not found");
+        }
+
+        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
+        await _reactionRepository.RemoveAsync(messageId, callerId, emoji, cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "RemoveConversationReaction succeeded. ConversationId={ConversationId}, MessageId={MessageId}, Emoji={Emoji}, CallerId={CallerId}",
+            conversationId,
+            messageId,
+            emoji,
+            callerId);
+
+        await NotifyReactionRemovedSafelyAsync(
+            new ConversationReactionRemovedNotification(messageId, conversationId, callerId, emoji));
+
+        return ApplicationResponse<bool>.Ok(true);
+    }
+
+    private async Task NotifyReactionRemovedSafelyAsync(
+        ConversationReactionRemovedNotification notification)
+    {
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            token => _reactionNotifier.NotifyReactionRemovedFromConversationAsync(notification, token),
+            NotificationTimeout,
+            _logger,
+            "RemoveConversationReaction notification failed (best-effort). MessageId={MessageId}, ConversationId={ConversationId}",
+            notification.MessageId,
+            notification.ConversationId);
+    }
+}

--- a/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionRouteRequest.cs
+++ b/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionRouteRequest.cs
@@ -1,0 +1,8 @@
+namespace Harmonie.Application.Features.Conversations.RemoveReaction;
+
+public sealed class RemoveReactionRouteRequest
+{
+    public string? ConversationId { get; init; }
+    public string? MessageId { get; init; }
+    public string? Emoji { get; init; }
+}

--- a/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionRouteValidator.cs
+++ b/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionRouteValidator.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+
+namespace Harmonie.Application.Features.Conversations.RemoveReaction;
+
+public sealed class RemoveReactionRouteValidator : AbstractValidator<RemoveReactionRouteRequest>
+{
+    public RemoveReactionRouteValidator()
+    {
+        RuleFor(x => x.ConversationId)
+            .NotEmpty()
+            .WithMessage("Conversation ID is required")
+            .Must(id => Guid.TryParse(id, out var parsed) && parsed != Guid.Empty)
+            .WithMessage("Conversation ID must be a valid non-empty GUID");
+
+        RuleFor(x => x.MessageId)
+            .NotEmpty()
+            .WithMessage("Message ID is required")
+            .Must(id => Guid.TryParse(id, out var parsed) && parsed != Guid.Empty)
+            .WithMessage("Message ID must be a valid non-empty GUID");
+
+        RuleFor(x => x.Emoji)
+            .NotEmpty()
+            .WithMessage("Emoji is required")
+            .MaximumLength(64)
+            .WithMessage("Emoji must not exceed 64 characters");
+    }
+}

--- a/src/Harmonie.Application/Interfaces/IMessageReactionRepository.cs
+++ b/src/Harmonie.Application/Interfaces/IMessageReactionRepository.cs
@@ -16,4 +16,10 @@ public interface IMessageReactionRepository
         string emoji,
         DateTime createdAtUtc,
         CancellationToken cancellationToken = default);
+
+    Task RemoveAsync(
+        MessageId messageId,
+        UserId userId,
+        string emoji,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Harmonie.Application/Interfaces/IReactionNotifier.cs
+++ b/src/Harmonie.Application/Interfaces/IReactionNotifier.cs
@@ -11,6 +11,14 @@ public interface IReactionNotifier
     Task NotifyReactionAddedToConversationAsync(
         ConversationReactionAddedNotification notification,
         CancellationToken cancellationToken = default);
+
+    Task NotifyReactionRemovedFromChannelAsync(
+        ChannelReactionRemovedNotification notification,
+        CancellationToken cancellationToken = default);
+
+    Task NotifyReactionRemovedFromConversationAsync(
+        ConversationReactionRemovedNotification notification,
+        CancellationToken cancellationToken = default);
 }
 
 public sealed record ChannelReactionAddedNotification(
@@ -20,6 +28,18 @@ public sealed record ChannelReactionAddedNotification(
     string Emoji);
 
 public sealed record ConversationReactionAddedNotification(
+    MessageId MessageId,
+    ConversationId ConversationId,
+    UserId UserId,
+    string Emoji);
+
+public sealed record ChannelReactionRemovedNotification(
+    MessageId MessageId,
+    GuildChannelId ChannelId,
+    UserId UserId,
+    string Emoji);
+
+public sealed record ConversationReactionRemovedNotification(
     MessageId MessageId,
     ConversationId ConversationId,
     UserId UserId,

--- a/src/Harmonie.Infrastructure/Persistence/MessageReactionRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/MessageReactionRepository.cs
@@ -72,4 +72,32 @@ public sealed class MessageReactionRepository : IMessageReactionRepository
 
         await connection.ExecuteAsync(command);
     }
+
+    public async Task RemoveAsync(
+        MessageId messageId,
+        UserId userId,
+        string emoji,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+                           DELETE FROM message_reactions
+                           WHERE message_id = @MessageId
+                             AND user_id    = @UserId
+                             AND emoji      = @Emoji
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new
+            {
+                MessageId = messageId.Value,
+                UserId = userId.Value,
+                Emoji = emoji
+            },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        await connection.ExecuteAsync(command);
+    }
 }

--- a/tests/Harmonie.API.IntegrationTests/RemoveReactionEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RemoveReactionEndpointTests.cs
@@ -1,0 +1,343 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Auth.Register;
+using Harmonie.Application.Features.Channels.SendMessage;
+using Harmonie.Application.Features.Conversations.OpenConversation;
+using Harmonie.Application.Features.Guilds.CreateChannel;
+using Harmonie.Application.Features.Guilds.CreateGuild;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+using ConversationSendMessageRequest = Harmonie.Application.Features.Conversations.SendMessage.SendMessageRequest;
+using ConversationSendMessageResponse = Harmonie.Application.Features.Conversations.SendMessage.SendMessageResponse;
+
+namespace Harmonie.API.IntegrationTests;
+
+public sealed class RemoveReactionEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public RemoveReactionEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    // ─── Channel reaction tests ─────────────────────────────────────
+
+    [Fact]
+    public async Task RemoveChannelReaction_WhenCallerIsMember_ShouldReturn204()
+    {
+        var owner = await RegisterAsync();
+        var (_, channelId) = await CreateGuildAndChannelAsync(owner.AccessToken);
+        var message = await SendChannelMessageAsync(channelId, "react then remove", owner.AccessToken);
+
+        await SendAuthorizedPutAsync(
+            $"/api/channels/{channelId}/messages/{message.MessageId}/reactions/%F0%9F%91%8D",
+            owner.AccessToken);
+
+        var response = await SendAuthorizedDeleteAsync(
+            $"/api/channels/{channelId}/messages/{message.MessageId}/reactions/%F0%9F%91%8D",
+            owner.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task RemoveChannelReaction_WhenReactionDoesNotExist_ShouldBeIdempotent()
+    {
+        var owner = await RegisterAsync();
+        var (_, channelId) = await CreateGuildAndChannelAsync(owner.AccessToken);
+        var message = await SendChannelMessageAsync(channelId, "no reaction here", owner.AccessToken);
+
+        var response = await SendAuthorizedDeleteAsync(
+            $"/api/channels/{channelId}/messages/{message.MessageId}/reactions/%F0%9F%91%8D",
+            owner.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task RemoveChannelReaction_WhenChannelDoesNotExist_ShouldReturnNotFound()
+    {
+        var caller = await RegisterAsync();
+
+        var response = await SendAuthorizedDeleteAsync(
+            $"/api/channels/{Guid.NewGuid()}/messages/{Guid.NewGuid()}/reactions/%F0%9F%91%8D",
+            caller.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotFound);
+    }
+
+    [Fact]
+    public async Task RemoveChannelReaction_WhenCallerIsNotMember_ShouldReturnForbidden()
+    {
+        var owner = await RegisterAsync();
+        var outsider = await RegisterAsync();
+        var (_, channelId) = await CreateGuildAndChannelAsync(owner.AccessToken);
+        var message = await SendChannelMessageAsync(channelId, "can't remove", owner.AccessToken);
+
+        var response = await SendAuthorizedDeleteAsync(
+            $"/api/channels/{channelId}/messages/{message.MessageId}/reactions/%F0%9F%91%8D",
+            outsider.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Channel.AccessDenied);
+    }
+
+    [Fact]
+    public async Task RemoveChannelReaction_WhenMessageDoesNotExist_ShouldReturnNotFound()
+    {
+        var owner = await RegisterAsync();
+        var (_, channelId) = await CreateGuildAndChannelAsync(owner.AccessToken);
+
+        var response = await SendAuthorizedDeleteAsync(
+            $"/api/channels/{channelId}/messages/{Guid.NewGuid()}/reactions/%F0%9F%91%8D",
+            owner.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
+    }
+
+    [Fact]
+    public async Task RemoveChannelReaction_WithoutAuthentication_ShouldReturnUnauthorized()
+    {
+        var response = await _client.DeleteAsync(
+            $"/api/channels/{Guid.NewGuid()}/messages/{Guid.NewGuid()}/reactions/%F0%9F%91%8D");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ─── Conversation reaction tests ────────────────────────────────
+
+    [Fact]
+    public async Task RemoveConversationReaction_WhenCallerIsParticipant_ShouldReturn204()
+    {
+        var caller = await RegisterAsync();
+        var target = await RegisterAsync();
+        var conversationId = await OpenConversationAsync(caller.AccessToken, target.UserId);
+        var message = await SendConversationMessageAsync(conversationId, "react then remove dm", caller.AccessToken);
+
+        await SendAuthorizedPutAsync(
+            $"/api/conversations/{conversationId}/messages/{message.MessageId}/reactions/%E2%9D%A4",
+            caller.AccessToken);
+
+        var response = await SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}/messages/{message.MessageId}/reactions/%E2%9D%A4",
+            caller.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task RemoveConversationReaction_WhenReactionDoesNotExist_ShouldBeIdempotent()
+    {
+        var caller = await RegisterAsync();
+        var target = await RegisterAsync();
+        var conversationId = await OpenConversationAsync(caller.AccessToken, target.UserId);
+        var message = await SendConversationMessageAsync(conversationId, "no reaction dm", caller.AccessToken);
+
+        var response = await SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}/messages/{message.MessageId}/reactions/%E2%9D%A4",
+            caller.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task RemoveConversationReaction_WhenConversationDoesNotExist_ShouldReturnNotFound()
+    {
+        var caller = await RegisterAsync();
+
+        var response = await SendAuthorizedDeleteAsync(
+            $"/api/conversations/{Guid.NewGuid()}/messages/{Guid.NewGuid()}/reactions/%E2%9D%A4",
+            caller.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
+    }
+
+    [Fact]
+    public async Task RemoveConversationReaction_WhenCallerIsNotParticipant_ShouldReturnForbidden()
+    {
+        var participantOne = await RegisterAsync();
+        var participantTwo = await RegisterAsync();
+        var outsider = await RegisterAsync();
+        var conversationId = await OpenConversationAsync(participantOne.AccessToken, participantTwo.UserId);
+        var message = await SendConversationMessageAsync(conversationId, "private dm", participantOne.AccessToken);
+
+        var response = await SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}/messages/{message.MessageId}/reactions/%E2%9D%A4",
+            outsider.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
+    }
+
+    [Fact]
+    public async Task RemoveConversationReaction_WhenMessageDoesNotExist_ShouldReturnNotFound()
+    {
+        var caller = await RegisterAsync();
+        var target = await RegisterAsync();
+        var conversationId = await OpenConversationAsync(caller.AccessToken, target.UserId);
+
+        var response = await SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}/messages/{Guid.NewGuid()}/reactions/%E2%9D%A4",
+            caller.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
+    }
+
+    [Fact]
+    public async Task RemoveConversationReaction_WithoutAuthentication_ShouldReturnUnauthorized()
+    {
+        var response = await _client.DeleteAsync(
+            $"/api/conversations/{Guid.NewGuid()}/messages/{Guid.NewGuid()}/reactions/%E2%9D%A4");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────
+
+    private async Task<RegisterResponse> RegisterAsync()
+    {
+        var request = new RegisterRequest(
+            Email: $"test{Guid.NewGuid():N}@harmonie.chat",
+            Username: $"user{Guid.NewGuid():N}"[..20],
+            Password: "Test123!@#");
+
+        var response = await _client.PostAsJsonAsync("/api/auth/register", request);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var payload = await response.Content.ReadFromJsonAsync<RegisterResponse>();
+        payload.Should().NotBeNull();
+        return payload!;
+    }
+
+    private async Task<(string GuildId, string ChannelId)> CreateGuildAndChannelAsync(string accessToken)
+    {
+        var guildName = $"guild{Guid.NewGuid():N}"[..16];
+        var createGuildResponse = await SendAuthorizedPostAsync(
+            "/api/guilds",
+            new CreateGuildRequest(guildName),
+            accessToken);
+        createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var guildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        guildPayload.Should().NotBeNull();
+
+        var createChannelResponse = await SendAuthorizedPostAsync(
+            $"/api/guilds/{guildPayload!.GuildId}/channels",
+            new CreateChannelRequest($"chan{Guid.NewGuid():N}"[..16], ChannelTypeInput.Text, 1),
+            accessToken);
+        createChannelResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var channelPayload = await createChannelResponse.Content.ReadFromJsonAsync<CreateChannelResponse>();
+        channelPayload.Should().NotBeNull();
+
+        return (guildPayload.GuildId, channelPayload!.ChannelId);
+    }
+
+    private async Task<SendMessageResponse> SendChannelMessageAsync(
+        string channelId,
+        string content,
+        string accessToken)
+    {
+        var response = await SendAuthorizedPostAsync(
+            $"/api/channels/{channelId}/messages",
+            new SendMessageRequest(content),
+            accessToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var payload = await response.Content.ReadFromJsonAsync<SendMessageResponse>();
+        payload.Should().NotBeNull();
+        return payload!;
+    }
+
+    private async Task<string> OpenConversationAsync(string accessToken, string targetUserId)
+    {
+        var response = await SendAuthorizedPostAsync(
+            "/api/conversations",
+            new OpenConversationRequest(targetUserId),
+            accessToken);
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Created, HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<OpenConversationResponse>();
+        payload.Should().NotBeNull();
+        return payload!.ConversationId;
+    }
+
+    private async Task<ConversationSendMessageResponse> SendConversationMessageAsync(
+        string conversationId,
+        string content,
+        string accessToken)
+    {
+        var response = await SendAuthorizedPostAsync(
+            $"/api/conversations/{conversationId}/messages",
+            new ConversationSendMessageRequest(content),
+            accessToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var payload = await response.Content.ReadFromJsonAsync<ConversationSendMessageResponse>();
+        payload.Should().NotBeNull();
+        return payload!;
+    }
+
+    private async Task<HttpResponseMessage> SendAuthorizedPostAsync<TRequest>(
+        string uri,
+        TRequest payload,
+        string accessToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, uri)
+        {
+            Content = JsonContent.Create(payload, options: JsonOptions)
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        return await _client.SendAsync(request);
+    }
+
+    private async Task<HttpResponseMessage> SendAuthorizedPutAsync(
+        string uri,
+        string accessToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Put, uri);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        return await _client.SendAsync(request);
+    }
+
+    private async Task<HttpResponseMessage> SendAuthorizedDeleteAsync(
+        string uri,
+        string accessToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Delete, uri);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        return await _client.SendAsync(request);
+    }
+}

--- a/tests/Harmonie.Application.Tests/RemoveChannelReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/RemoveChannelReactionHandlerTests.cs
@@ -1,0 +1,270 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Channels.RemoveReaction;
+using Harmonie.Application.Interfaces;
+using Harmonie.Domain.Entities;
+using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests;
+
+public sealed class RemoveChannelReactionHandlerTests
+{
+    private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
+    private readonly Mock<IMessageRepository> _messageRepositoryMock;
+    private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly Mock<IReactionNotifier> _reactionNotifierMock;
+    private readonly RemoveReactionHandler _handler;
+
+    public RemoveChannelReactionHandlerTests()
+    {
+        _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
+        _messageRepositoryMock = new Mock<IMessageRepository>();
+        _reactionRepositoryMock = new Mock<IMessageReactionRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _transactionMock = new Mock<IUnitOfWorkTransaction>();
+        _reactionNotifierMock = new Mock<IReactionNotifier>();
+
+        _unitOfWorkMock
+            .Setup(x => x.BeginAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_transactionMock.Object);
+
+        _transactionMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _transactionMock
+            .Setup(x => x.DisposeAsync())
+            .Returns(ValueTask.CompletedTask);
+
+        _reactionNotifierMock
+            .Setup(x => x.NotifyReactionRemovedFromChannelAsync(It.IsAny<ChannelReactionRemovedNotification>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _handler = new RemoveReactionHandler(
+            _guildChannelRepositoryMock.Object,
+            _messageRepositoryMock.Object,
+            _reactionRepositoryMock.Object,
+            _unitOfWorkMock.Object,
+            _reactionNotifierMock.Object,
+            NullLogger<RemoveReactionHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenChannelDoesNotExist_ShouldReturnChannelNotFound()
+    {
+        var channelId = GuildChannelId.New();
+        var callerId = UserId.New();
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(channelId, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ChannelAccessContext?)null);
+
+        var response = await _handler.HandleAsync(channelId, MessageId.New(), "👍", callerId);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotFound);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenChannelIsVoice_ShouldReturnChannelNotText()
+    {
+        var channel = CreateChannel(GuildChannelType.Voice);
+        var callerId = UserId.New();
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
+
+        var response = await _handler.HandleAsync(channel.Id, MessageId.New(), "👍", callerId);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotText);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCallerIsNotMember_ShouldReturnChannelAccessDenied()
+    {
+        var channel = CreateChannel(GuildChannelType.Text);
+        var callerId = UserId.New();
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelAccessContext(channel, CallerRole: null));
+
+        var response = await _handler.HandleAsync(channel.Id, MessageId.New(), "👍", callerId);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Channel.AccessDenied);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenMessageDoesNotExist_ShouldReturnReactionMessageNotFound()
+    {
+        var channel = CreateChannel(GuildChannelType.Text);
+        var callerId = UserId.New();
+        var messageId = MessageId.New();
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
+
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Message?)null);
+
+        var response = await _handler.HandleAsync(channel.Id, messageId, "👍", callerId);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenMessageBelongsToAnotherChannel_ShouldReturnReactionMessageNotFound()
+    {
+        var channel = CreateChannel(GuildChannelType.Text);
+        var callerId = UserId.New();
+        var messageId = MessageId.New();
+        var messageFromOtherChannel = CreateMessage(GuildChannelId.New(), callerId);
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
+
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(messageFromOtherChannel);
+
+        var response = await _handler.HandleAsync(channel.Id, messageId, "👍", callerId);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenMemberRemovesReaction_ShouldReturnSuccess()
+    {
+        var channel = CreateChannel(GuildChannelType.Text);
+        var callerId = UserId.New();
+        var messageId = MessageId.New();
+        var message = CreateMessage(channel.Id, callerId);
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
+
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        var response = await _handler.HandleAsync(channel.Id, messageId, "👍", callerId);
+
+        response.Success.Should().BeTrue();
+        response.Error.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenMemberRemovesReaction_ShouldDeleteCommitAndNotify()
+    {
+        var channel = CreateChannel(GuildChannelType.Text);
+        var callerId = UserId.New();
+        var messageId = MessageId.New();
+        var message = CreateMessage(channel.Id, callerId);
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
+
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        await _handler.HandleAsync(channel.Id, messageId, "👍", callerId);
+
+        _reactionRepositoryMock.Verify(
+            x => x.RemoveAsync(messageId, callerId, "👍", It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _transactionMock.Verify(
+            x => x.CommitAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _reactionNotifierMock.Verify(
+            x => x.NotifyReactionRemovedFromChannelAsync(
+                It.Is<ChannelReactionRemovedNotification>(n =>
+                    n.ChannelId == channel.Id &&
+                    n.MessageId == messageId &&
+                    n.UserId == callerId &&
+                    n.Emoji == "👍"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenNotifierThrows_ShouldStillSucceed()
+    {
+        var channel = CreateChannel(GuildChannelType.Text);
+        var callerId = UserId.New();
+        var messageId = MessageId.New();
+        var message = CreateMessage(channel.Id, callerId);
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
+
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        _reactionNotifierMock
+            .Setup(x => x.NotifyReactionRemovedFromChannelAsync(It.IsAny<ChannelReactionRemovedNotification>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("SignalR unavailable"));
+
+        var response = await _handler.HandleAsync(channel.Id, messageId, "👍", callerId);
+
+        response.Success.Should().BeTrue();
+        _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static GuildChannel CreateChannel(GuildChannelType type)
+    {
+        var result = GuildChannel.Create(
+            GuildId.New(),
+            "general",
+            type,
+            isDefault: false,
+            position: 0);
+
+        if (result.IsFailure)
+            throw new InvalidOperationException("Failed to create channel for tests.");
+
+        return result.Value!;
+    }
+
+    private static Message CreateMessage(GuildChannelId channelId, UserId authorId)
+    {
+        var contentResult = MessageContent.Create("original content");
+        if (contentResult.IsFailure || contentResult.Value is null)
+            throw new InvalidOperationException("Failed to create message content for tests.");
+
+        return Message.Rehydrate(
+            id: MessageId.New(),
+            channelId: channelId,
+            conversationId: null,
+            authorUserId: authorId,
+            content: contentResult.Value,
+            createdAtUtc: DateTime.UtcNow,
+            updatedAtUtc: null,
+            deletedAtUtc: null);
+    }
+}

--- a/tests/Harmonie.Application.Tests/RemoveConversationReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/RemoveConversationReactionHandlerTests.cs
@@ -1,0 +1,253 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Conversations.RemoveReaction;
+using Harmonie.Application.Interfaces;
+using Harmonie.Domain.Entities;
+using Harmonie.Domain.ValueObjects;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests;
+
+public sealed class RemoveConversationReactionHandlerTests
+{
+    private readonly Mock<IConversationRepository> _conversationRepositoryMock;
+    private readonly Mock<IMessageRepository> _messageRepositoryMock;
+    private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly Mock<IReactionNotifier> _reactionNotifierMock;
+    private readonly RemoveReactionHandler _handler;
+
+    public RemoveConversationReactionHandlerTests()
+    {
+        _conversationRepositoryMock = new Mock<IConversationRepository>();
+        _messageRepositoryMock = new Mock<IMessageRepository>();
+        _reactionRepositoryMock = new Mock<IMessageReactionRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _transactionMock = new Mock<IUnitOfWorkTransaction>();
+        _reactionNotifierMock = new Mock<IReactionNotifier>();
+
+        _unitOfWorkMock
+            .Setup(x => x.BeginAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_transactionMock.Object);
+
+        _transactionMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _transactionMock
+            .Setup(x => x.DisposeAsync())
+            .Returns(ValueTask.CompletedTask);
+
+        _reactionNotifierMock
+            .Setup(x => x.NotifyReactionRemovedFromConversationAsync(It.IsAny<ConversationReactionRemovedNotification>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _handler = new RemoveReactionHandler(
+            _conversationRepositoryMock.Object,
+            _messageRepositoryMock.Object,
+            _reactionRepositoryMock.Object,
+            _unitOfWorkMock.Object,
+            _reactionNotifierMock.Object,
+            NullLogger<RemoveReactionHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenConversationDoesNotExist_ShouldReturnConversationNotFound()
+    {
+        var conversationId = ConversationId.New();
+        var callerId = UserId.New();
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdAsync(conversationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Conversation?)null);
+
+        var response = await _handler.HandleAsync(conversationId, MessageId.New(), "👍", callerId);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCallerIsNotParticipant_ShouldReturnConversationAccessDenied()
+    {
+        var participantOne = UserId.New();
+        var participantTwo = UserId.New();
+        var outsider = UserId.New();
+        var conversation = CreateConversation(participantOne, participantTwo);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdAsync(conversation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(conversation);
+
+        var response = await _handler.HandleAsync(conversation.Id, MessageId.New(), "👍", outsider);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenMessageDoesNotExist_ShouldReturnReactionMessageNotFound()
+    {
+        var participantOne = UserId.New();
+        var participantTwo = UserId.New();
+        var conversation = CreateConversation(participantOne, participantTwo);
+        var messageId = MessageId.New();
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdAsync(conversation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(conversation);
+
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Message?)null);
+
+        var response = await _handler.HandleAsync(conversation.Id, messageId, "👍", participantOne);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenMessageBelongsToAnotherConversation_ShouldReturnReactionMessageNotFound()
+    {
+        var participantOne = UserId.New();
+        var participantTwo = UserId.New();
+        var conversation = CreateConversation(participantOne, participantTwo);
+        var messageId = MessageId.New();
+        var message = CreateConversationMessage(ConversationId.New(), participantOne);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdAsync(conversation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(conversation);
+
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        var response = await _handler.HandleAsync(conversation.Id, messageId, "👍", participantOne);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenParticipantRemovesReaction_ShouldReturnSuccess()
+    {
+        var participantOne = UserId.New();
+        var participantTwo = UserId.New();
+        var conversation = CreateConversation(participantOne, participantTwo);
+        var messageId = MessageId.New();
+        var message = CreateConversationMessage(conversation.Id, participantOne);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdAsync(conversation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(conversation);
+
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        var response = await _handler.HandleAsync(conversation.Id, messageId, "❤", participantOne);
+
+        response.Success.Should().BeTrue();
+        response.Error.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenParticipantRemovesReaction_ShouldDeleteCommitAndNotify()
+    {
+        var participantOne = UserId.New();
+        var participantTwo = UserId.New();
+        var conversation = CreateConversation(participantOne, participantTwo);
+        var messageId = MessageId.New();
+        var message = CreateConversationMessage(conversation.Id, participantOne);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdAsync(conversation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(conversation);
+
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        await _handler.HandleAsync(conversation.Id, messageId, "❤", participantOne);
+
+        _reactionRepositoryMock.Verify(
+            x => x.RemoveAsync(messageId, participantOne, "❤", It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _transactionMock.Verify(
+            x => x.CommitAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _reactionNotifierMock.Verify(
+            x => x.NotifyReactionRemovedFromConversationAsync(
+                It.Is<ConversationReactionRemovedNotification>(n =>
+                    n.ConversationId == conversation.Id &&
+                    n.MessageId == messageId &&
+                    n.UserId == participantOne &&
+                    n.Emoji == "❤"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenNotifierThrows_ShouldStillSucceed()
+    {
+        var participantOne = UserId.New();
+        var participantTwo = UserId.New();
+        var conversation = CreateConversation(participantOne, participantTwo);
+        var messageId = MessageId.New();
+        var message = CreateConversationMessage(conversation.Id, participantOne);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdAsync(conversation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(conversation);
+
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        _reactionNotifierMock
+            .Setup(x => x.NotifyReactionRemovedFromConversationAsync(It.IsAny<ConversationReactionRemovedNotification>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("SignalR unavailable"));
+
+        var response = await _handler.HandleAsync(conversation.Id, messageId, "👍", participantOne);
+
+        response.Success.Should().BeTrue();
+        _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static Conversation CreateConversation(UserId user1Id, UserId user2Id)
+    {
+        var result = Conversation.Create(user1Id, user2Id);
+        if (result.IsFailure || result.Value is null)
+            throw new InvalidOperationException("Failed to create test conversation.");
+
+        return result.Value;
+    }
+
+    private static Message CreateConversationMessage(ConversationId conversationId, UserId authorUserId)
+    {
+        var contentResult = MessageContent.Create("original content");
+        if (contentResult.IsFailure || contentResult.Value is null)
+            throw new InvalidOperationException("Failed to create test conversation message.");
+
+        return Message.Rehydrate(
+            id: MessageId.New(),
+            channelId: null,
+            conversationId: conversationId,
+            authorUserId: authorUserId,
+            content: contentResult.Value,
+            createdAtUtc: DateTime.UtcNow.AddMinutes(-1),
+            updatedAtUtc: null,
+            deletedAtUtc: null);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `DELETE /api/channels/{channelId}/messages/{messageId}/reactions/{emoji}` endpoint to remove caller's reaction from a channel message
- Add `DELETE /api/conversations/{conversationId}/messages/{messageId}/reactions/{emoji}` endpoint to remove caller's reaction from a conversation message
- Broadcast `ReactionRemoved` SignalR event on successful removal
- Only own reactions can be removed; caller must be channel member or conversation participant
- Idempotent — removing a non-existent reaction is a no-op (returns 204)

## Test plan
- [x] Unit tests for channel handler (8 tests): auth checks, message validation, success, notification best-effort
- [x] Unit tests for conversation handler (7 tests): same coverage
- [x] Integration tests for both endpoints (12 tests): 204 on success, idempotency, 401/403/404 error paths

Closes #119