### PR TITLE
refactor: remove domain rule duplication from FluentValidation validators (#259)

### DIFF
--- a/src/Harmonie.Application/Features/Auth/Login/LoginValidator.cs
+++ b/src/Harmonie.Application/Features/Auth/Login/LoginValidator.cs
@@ -2,19 +2,6 @@ using FluentValidation;
 
 namespace Harmonie.Application.Features.Auth.Login;
 
-/// <summary>
-/// Validator for LoginRequest
-/// </summary>
 public sealed class LoginValidator : AbstractValidator<LoginRequest>
 {
-    public LoginValidator()
-    {
-        RuleFor(x => x.EmailOrUsername)
-            .NotEmpty()
-            .WithMessage("Email or username is required");
-
-        RuleFor(x => x.Password)
-            .NotEmpty()
-            .WithMessage("Password is required");
-    }
 }

--- a/src/Harmonie.Application/Features/Auth/Register/RegisterValidator.cs
+++ b/src/Harmonie.Application/Features/Auth/Register/RegisterValidator.cs
@@ -11,21 +11,11 @@ public sealed class RegisterValidator : AbstractValidator<RegisterRequest>
     {
         RuleFor(x => x.Email)
             .NotEmpty()
-            .WithMessage("Email is required")
-            .EmailAddress()
-            .WithMessage("Email format is invalid")
-            .MaximumLength(320)
-            .WithMessage("Email is too long");
+            .WithMessage("Email is required");
 
         RuleFor(x => x.Username)
             .NotEmpty()
-            .WithMessage("Username is required")
-            .MinimumLength(3)
-            .WithMessage("Username must be at least 3 characters")
-            .MaximumLength(32)
-            .WithMessage("Username cannot exceed 32 characters")
-            .Matches(@"^[a-zA-Z0-9_-]+$")
-            .WithMessage("Username can only contain letters, numbers, underscores, and hyphens");
+            .WithMessage("Username is required");
 
         RuleFor(x => x.Password)
             .NotEmpty()

--- a/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageValidator.cs
+++ b/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageValidator.cs
@@ -1,16 +1,7 @@
 using FluentValidation;
-using Harmonie.Domain.ValueObjects.Messages;
 
 namespace Harmonie.Application.Features.Channels.EditMessage;
 
 public sealed class EditMessageValidator : AbstractValidator<EditMessageRequest>
 {
-    public EditMessageValidator()
-    {
-        RuleFor(x => x.Content)
-            .NotNull()
-            .WithMessage("Message content is required")
-            .MaximumLength(MessageContent.MaxLength)
-            .WithMessage($"Message content cannot exceed {MessageContent.MaxLength} characters");
-    }
 }

--- a/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageValidator.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageValidator.cs
@@ -1,5 +1,4 @@
 using FluentValidation;
-using Harmonie.Domain.ValueObjects.Messages;
 
 namespace Harmonie.Application.Features.Channels.SendMessage;
 
@@ -7,12 +6,6 @@ public sealed class SendMessageValidator : AbstractValidator<SendMessageRequest>
 {
     public SendMessageValidator()
     {
-        RuleFor(x => x.Content)
-            .NotNull()
-            .WithMessage("Message content is required")
-            .MaximumLength(MessageContent.MaxLength)
-            .WithMessage($"Message content cannot exceed {MessageContent.MaxLength} characters");
-
         RuleForEach(x => x.AttachmentFileIds)
             .Must(id => Guid.TryParse(id, out var parsedId) && parsedId != Guid.Empty)
             .WithMessage("Attachment file IDs must be valid non-empty GUIDs")

--- a/src/Harmonie.Application/Features/Channels/UpdateChannel/UpdateChannelValidator.cs
+++ b/src/Harmonie.Application/Features/Channels/UpdateChannel/UpdateChannelValidator.cs
@@ -4,18 +4,4 @@ namespace Harmonie.Application.Features.Channels.UpdateChannel;
 
 public sealed class UpdateChannelValidator : AbstractValidator<UpdateChannelRequest>
 {
-    public UpdateChannelValidator()
-    {
-        RuleFor(x => x.Name)
-            .NotEmpty()
-            .WithMessage("Channel name cannot be empty")
-            .MaximumLength(100)
-            .WithMessage("Channel name cannot exceed 100 characters")
-            .When(x => x.Name is not null);
-
-        RuleFor(x => x.Position)
-            .GreaterThanOrEqualTo(0)
-            .WithMessage("Channel position cannot be negative")
-            .When(x => x.Position is not null);
-    }
 }

--- a/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageValidator.cs
+++ b/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageValidator.cs
@@ -1,16 +1,7 @@
 using FluentValidation;
-using Harmonie.Domain.ValueObjects.Messages;
 
 namespace Harmonie.Application.Features.Conversations.EditMessage;
 
 public sealed class EditMessageValidator : AbstractValidator<EditMessageRequest>
 {
-    public EditMessageValidator()
-    {
-        RuleFor(x => x.Content)
-            .NotNull()
-            .WithMessage("Message content is required")
-            .MaximumLength(MessageContent.MaxLength)
-            .WithMessage($"Message content cannot exceed {MessageContent.MaxLength} characters");
-    }
 }

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageValidator.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageValidator.cs
@@ -1,5 +1,4 @@
 using FluentValidation;
-using Harmonie.Domain.ValueObjects.Messages;
 
 namespace Harmonie.Application.Features.Conversations.SendMessage;
 
@@ -7,12 +6,6 @@ public sealed class SendMessageValidator : AbstractValidator<SendMessageRequest>
 {
     public SendMessageValidator()
     {
-        RuleFor(x => x.Content)
-            .NotEmpty()
-            .WithMessage("Content is required")
-            .MaximumLength(MessageContent.MaxLength)
-            .WithMessage($"Content cannot exceed {MessageContent.MaxLength} characters");
-
         RuleForEach(x => x.AttachmentFileIds)
             .Must(id => Guid.TryParse(id, out var parsedId) && parsedId != Guid.Empty)
             .WithMessage("Attachment file IDs must be valid non-empty GUIDs")

--- a/src/Harmonie.Application/Features/Guilds/CreateChannel/CreateChannelValidator.cs
+++ b/src/Harmonie.Application/Features/Guilds/CreateChannel/CreateChannelValidator.cs
@@ -6,18 +6,8 @@ public sealed class CreateChannelValidator : AbstractValidator<CreateChannelRequ
 {
     public CreateChannelValidator()
     {
-        RuleFor(x => x.Name)
-            .NotEmpty()
-            .WithMessage("Channel name is required")
-            .MaximumLength(100)
-            .WithMessage("Channel name cannot exceed 100 characters");
-
         RuleFor(x => x.Type)
             .IsInEnum()
             .WithMessage("Channel type must be 'Text' or 'Voice'");
-
-        RuleFor(x => x.Position)
-            .GreaterThanOrEqualTo(0)
-            .WithMessage("Channel position cannot be negative");
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/CreateGuild/CreateGuildValidator.cs
+++ b/src/Harmonie.Application/Features/Guilds/CreateGuild/CreateGuildValidator.cs
@@ -8,11 +8,7 @@ public sealed class CreateGuildValidator : AbstractValidator<CreateGuildRequest>
     {
         RuleFor(x => x.Name)
             .NotEmpty()
-            .WithMessage("Guild name is required")
-            .MinimumLength(3)
-            .WithMessage("Guild name must be at least 3 characters")
-            .MaximumLength(100)
-            .WithMessage("Guild name cannot exceed 100 characters");
+            .WithMessage("Guild name is required");
 
         RuleFor(x => x.IconFileId)
             .Must(fileId => fileId is null || Guid.TryParse(fileId, out _))

--- a/src/Harmonie.Application/Features/Guilds/UpdateGuild/UpdateGuildValidator.cs
+++ b/src/Harmonie.Application/Features/Guilds/UpdateGuild/UpdateGuildValidator.cs
@@ -8,10 +8,6 @@ public sealed class UpdateGuildValidator : AbstractValidator<UpdateGuildRequest>
         RuleFor(x => x.Name)
             .NotEmpty()
             .WithMessage("Guild name is required")
-            .MinimumLength(3)
-            .WithMessage("Guild name must be at least 3 characters")
-            .MaximumLength(100)
-            .WithMessage("Guild name cannot exceed 100 characters")
             .When(x => x.NameIsSet);
 
         RuleFor(x => x.IconFileId)

--- a/tests/Harmonie.API.IntegrationTests/Channels/UpdateChannelTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Channels/UpdateChannelTests.cs
@@ -183,7 +183,7 @@ public sealed class UpdateChannelTests : IClassFixture<HarmonieWebApplicationFac
 
         var error = await updateResponse.Content.ReadFromJsonAsync<ApplicationError>();
         error.Should().NotBeNull();
-        error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
+        error!.Code.Should().Be(ApplicationErrorCodes.Common.DomainRuleViolation);
     }
 
     // ─── Helpers ───────────────────────────────────────────────────────────────

--- a/tests/Harmonie.API.IntegrationTests/Guilds/GuildChannelsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/GuildChannelsTests.cs
@@ -205,7 +205,7 @@ public sealed class GuildChannelsTests : IClassFixture<HarmonieWebApplicationFac
 
         var error = await createChannelResponse.Content.ReadFromJsonAsync<ApplicationError>();
         error.Should().NotBeNull();
-        error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
+        error!.Code.Should().Be(ApplicationErrorCodes.Common.DomainRuleViolation);
     }
 
     private async Task<HttpResponseMessage> SendAuthorizedPostRawAsync(


### PR DESCRIPTION
## Summary

- Validators now guard the HTTP boundary only (presence checks, enum safety, GUID format)
- Domain value objects and entity factories are the single source of truth for business rules
- 92 lines deleted, 5 added

## Changes

**Validators stripped of domain-duplicate rules:**
- `LoginValidator` — emptied (`Email.Create` / `Username.Create` both check for empty)
- `RegisterValidator` — removed Email format/length and Username length/regex; kept `NotEmpty` and all password rules (no `Password` VO exists)
- `CreateGuildValidator` — removed `MinLength(3)` + `MaxLength(100)` on Name (`GuildName.Create` covers them)
- `UpdateGuildValidator` — same
- `Conversations/EditMessageValidator` — emptied (`MessageContent.Create` covers null + empty + max length)
- `Channels/EditMessageValidator` — same
- `Conversations/SendMessageValidator` — removed `NotEmpty` + `MaxLength` on Content
- `Channels/SendMessageValidator` — same

**Validators kept with one boundary guard:**
- `CreateChannelValidator` — keeps `IsInEnum()` on `Type` to prevent `InvalidOperationException` in `ChannelTypeInput.ToDomain()` when the field is missing from the request body (default enum value `0` is not a valid `ChannelTypeInput`)
- `UpdateChannelValidator` — emptied (`UpdateName` / `UpdatePosition` handle all validation)

**Tests updated (2):**
- `CreateChannel_WhenNegativePosition_ShouldReturn400` → expects `DomainRuleViolation` (was `ValidationFailed`)
- `UpdateChannel_WhenNameIsEmpty_ShouldReturn400` → same

This reflects the goal of the issue: domain errors now surface directly to the client instead of being masked by FluentValidation.

## Test plan

- [x] All 680 tests pass (132 domain, 328 application, 8 infrastructure, 352 integration)

Closes #259