### PR TITLE
feat: delete uploaded file (#271)

### DIFF
--- a/src/Harmonie.API/Endpoints/UploadEndpoints.cs
+++ b/src/Harmonie.API/Endpoints/UploadEndpoints.cs
@@ -1,3 +1,4 @@
+using Harmonie.Application.Features.Uploads.DeleteFile;
 using Harmonie.Application.Features.Uploads.DownloadFile;
 using Harmonie.Application.Features.Uploads.UploadFile;
 
@@ -9,5 +10,6 @@ public static class UploadEndpoints
     {
         UploadFileEndpoint.Map(app);
         DownloadFileEndpoint.Map(app);
+        DeleteFileEndpoint.Map(app);
     }
 }

--- a/src/Harmonie.Application/Features/Uploads/DeleteFile/DeleteFileEndpoint.cs
+++ b/src/Harmonie.Application/Features/Uploads/DeleteFile/DeleteFileEndpoint.cs
@@ -1,0 +1,42 @@
+using Harmonie.Application.Common;
+using Harmonie.Domain.ValueObjects.Uploads;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Harmonie.Application.Features.Uploads.DeleteFile;
+
+public static class DeleteFileEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        app.MapDelete("/api/files/{fileId}", HandleAsync)
+            .WithName("DeleteFile")
+            .WithTags("Files")
+            .RequireAuthorization()
+            .WithSummary("Delete an uploaded file")
+            .WithDescription("Permanently deletes an uploaded file from storage. Only the uploader can delete their own files.")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesErrors(
+                ApplicationErrorCodes.Auth.InvalidCredentials,
+                ApplicationErrorCodes.Upload.NotFound,
+                ApplicationErrorCodes.Upload.AccessDenied);
+    }
+
+    private static async Task<IResult> HandleAsync(
+        UploadedFileId fileId,
+        [FromServices] IAuthenticatedHandler<DeleteFileInput, bool> handler,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
+
+        var response = await handler.HandleAsync(new DeleteFileInput(fileId), currentUserId, cancellationToken);
+
+        if (response.Success)
+            return Results.NoContent();
+
+        return response.ToHttpResult();
+    }
+}

--- a/src/Harmonie.Application/Features/Uploads/DeleteFile/DeleteFileHandler.cs
+++ b/src/Harmonie.Application/Features/Uploads/DeleteFile/DeleteFileHandler.cs
@@ -1,0 +1,82 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Uploads;
+using Harmonie.Domain.ValueObjects.Uploads;
+using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging;
+
+namespace Harmonie.Application.Features.Uploads.DeleteFile;
+
+public sealed record DeleteFileInput(UploadedFileId FileId);
+
+public sealed class DeleteFileHandler : IAuthenticatedHandler<DeleteFileInput, bool>
+{
+    private readonly IUploadedFileRepository _uploadedFileRepository;
+    private readonly IObjectStorageService _objectStorageService;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<DeleteFileHandler> _logger;
+
+    public DeleteFileHandler(
+        IUploadedFileRepository uploadedFileRepository,
+        IObjectStorageService objectStorageService,
+        IUnitOfWork unitOfWork,
+        ILogger<DeleteFileHandler> logger)
+    {
+        _uploadedFileRepository = uploadedFileRepository;
+        _objectStorageService = objectStorageService;
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task<ApplicationResponse<bool>> HandleAsync(
+        DeleteFileInput request,
+        UserId currentUserId,
+        CancellationToken cancellationToken = default)
+    {
+        var uploadedFile = await _uploadedFileRepository.GetByIdAsync(request.FileId, cancellationToken);
+        if (uploadedFile is null)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Upload.NotFound,
+                "File was not found");
+        }
+
+        if (uploadedFile.UploaderUserId != currentUserId)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Upload.AccessDenied,
+                "You can only delete files you have uploaded");
+        }
+
+        var storageKey = uploadedFile.StorageKey;
+
+        await using (var transaction = await _unitOfWork.BeginAsync(cancellationToken))
+        {
+            await _uploadedFileRepository.DeleteAsync(request.FileId, cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+        }
+
+        await DeleteStoredObjectSafelyAsync(storageKey, request.FileId, cancellationToken);
+
+        return ApplicationResponse<bool>.Ok(true);
+    }
+
+    private async Task DeleteStoredObjectSafelyAsync(
+        string storageKey,
+        UploadedFileId fileId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _objectStorageService.DeleteIfExistsAsync(storageKey, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "DeleteFile storage cleanup failed. UploadedFileId={UploadedFileId}, StorageKey={StorageKey}",
+                fileId,
+                storageKey);
+        }
+    }
+}

--- a/src/Harmonie.Application/Registration/UploadRegistration.cs
+++ b/src/Harmonie.Application/Registration/UploadRegistration.cs
@@ -1,4 +1,5 @@
 using Harmonie.Application.Common;
+using Harmonie.Application.Features.Uploads.DeleteFile;
 using Harmonie.Application.Features.Uploads.DownloadFile;
 using Harmonie.Application.Features.Uploads.UploadFile;
 using Harmonie.Domain.ValueObjects.Uploads;
@@ -12,6 +13,7 @@ public static class UploadRegistration
     {
         services.AddAuthenticatedHandler<UploadFileInput, UploadFileResponse, UploadFileHandler>();
         services.AddAuthenticatedHandler<UploadedFileId, DownloadFileResult, DownloadFileHandler>();
+        services.AddAuthenticatedHandler<DeleteFileInput, bool, DeleteFileHandler>();
 
         return services;
     }

--- a/tests/Harmonie.API.IntegrationTests/Files/UploadsEndpointsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Files/UploadsEndpointsTests.cs
@@ -193,6 +193,80 @@ public sealed class UploadsEndpointsTests : IClassFixture<HarmonieWebApplication
         return content;
     }
 
+    [Fact]
+    public async Task DeleteFile_WithValidRequest_ShouldReturnNoContent()
+    {
+        var user = await AuthTestHelper.RegisterAsync(_client);
+        var fakeStorage = new FakeObjectStorageService();
+
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IObjectStorageService>();
+                services.AddSingleton<IObjectStorageService>(fakeStorage);
+            });
+        });
+
+        using var client = factory.CreateClient();
+        var fileId = await UploadTestHelper.UploadFileAsync(client, user.AccessToken, "doc.png", "image/png", "content");
+
+        var request = new HttpRequestMessage(HttpMethod.Delete, $"/api/files/{fileId}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", user.AccessToken);
+        var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        fakeStorage.UploadedObjects.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeleteFile_WhenFileNotFound_ShouldReturnNotFound()
+    {
+        var user = await AuthTestHelper.RegisterAsync(_client);
+        var unknownId = Guid.NewGuid();
+
+        var request = new HttpRequestMessage(HttpMethod.Delete, $"/api/files/{unknownId}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", user.AccessToken);
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteFile_WhenFileUploadedByAnotherUser_ShouldReturnForbidden()
+    {
+        var uploader = await AuthTestHelper.RegisterAsync(_client);
+        var otherUser = await AuthTestHelper.RegisterAsync(_client);
+        var fakeStorage = new FakeObjectStorageService();
+
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IObjectStorageService>();
+                services.AddSingleton<IObjectStorageService>(fakeStorage);
+            });
+        });
+
+        using var client = factory.CreateClient();
+        var fileId = await UploadTestHelper.UploadFileAsync(client, uploader.AccessToken, "doc.png", "image/png", "content");
+
+        var request = new HttpRequestMessage(HttpMethod.Delete, $"/api/files/{fileId}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", otherUser.AccessToken);
+        var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        fakeStorage.UploadedObjects.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task DeleteFile_WithoutAuthentication_ShouldReturnUnauthorized()
+    {
+        var response = await _client.DeleteAsync($"/api/files/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
     private static async Task<HttpResponseMessage> SendAuthorizedMultipartAsync(
         HttpClient client,
         string uri,

--- a/tests/Harmonie.Application.Tests/Uploads/DeleteFileHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Uploads/DeleteFileHandlerTests.cs
@@ -1,0 +1,116 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Uploads.DeleteFile;
+using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Uploads;
+using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.ValueObjects.Uploads;
+using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Uploads;
+
+public sealed class DeleteFileHandlerTests
+{
+    private readonly Mock<IUploadedFileRepository> _uploadedFileRepositoryMock;
+    private readonly Mock<IObjectStorageService> _objectStorageServiceMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly DeleteFileHandler _handler;
+
+    public DeleteFileHandlerTests()
+    {
+        _uploadedFileRepositoryMock = new Mock<IUploadedFileRepository>();
+        _objectStorageServiceMock = new Mock<IObjectStorageService>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _transactionMock = _unitOfWorkMock.SetupTransactionMock();
+
+        _handler = new DeleteFileHandler(
+            _uploadedFileRepositoryMock.Object,
+            _objectStorageServiceMock.Object,
+            _unitOfWorkMock.Object,
+            NullLogger<DeleteFileHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenFileDoesNotExist_ShouldReturnNotFound()
+    {
+        var userId = UserId.New();
+        var fileId = UploadedFileId.New();
+
+        _uploadedFileRepositoryMock
+            .Setup(x => x.GetByIdAsync(fileId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Domain.Entities.Uploads.UploadedFile?)null);
+
+        var response = await _handler.HandleAsync(new DeleteFileInput(fileId), userId);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Upload.NotFound);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenFileUploadedByAnotherUser_ShouldReturnAccessDenied()
+    {
+        var requestingUser = UserId.New();
+        var uploadedFile = ApplicationTestBuilders.CreateUploadedFile(uploaderUserId: UserId.New());
+
+        _uploadedFileRepositoryMock
+            .Setup(x => x.GetByIdAsync(uploadedFile.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(uploadedFile);
+
+        var response = await _handler.HandleAsync(new DeleteFileInput(uploadedFile.Id), requestingUser);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Upload.AccessDenied);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithValidRequest_ShouldDeleteFromRepositoryAndStorage()
+    {
+        var user = ApplicationTestBuilders.CreateUser();
+        var uploadedFile = ApplicationTestBuilders.CreateUploadedFile(uploaderUserId: user.Id);
+
+        _uploadedFileRepositoryMock
+            .Setup(x => x.GetByIdAsync(uploadedFile.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(uploadedFile);
+
+        _objectStorageServiceMock
+            .Setup(x => x.DeleteIfExistsAsync(uploadedFile.StorageKey, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var response = await _handler.HandleAsync(new DeleteFileInput(uploadedFile.Id), user.Id);
+
+        response.Success.Should().BeTrue();
+        _uploadedFileRepositoryMock.Verify(
+            x => x.DeleteAsync(uploadedFile.Id, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _objectStorageServiceMock.Verify(
+            x => x.DeleteIfExistsAsync(uploadedFile.StorageKey, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenStorageDeleteFails_ShouldStillReturnSuccessAndLogWarning()
+    {
+        var user = ApplicationTestBuilders.CreateUser();
+        var uploadedFile = ApplicationTestBuilders.CreateUploadedFile(uploaderUserId: user.Id);
+
+        _uploadedFileRepositoryMock
+            .Setup(x => x.GetByIdAsync(uploadedFile.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(uploadedFile);
+
+        _objectStorageServiceMock
+            .Setup(x => x.DeleteIfExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Storage unavailable"));
+
+        var response = await _handler.HandleAsync(new DeleteFileInput(uploadedFile.Id), user.Id);
+
+        response.Success.Should().BeTrue();
+        _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `DELETE /api/files/{fileId}` endpoint
- Handler checks ownership — only the uploader can delete their file (403 otherwise)
- DB record deleted in a transaction, then storage object removed best-effort (logged on failure)

## Test plan

- [ ] Unit tests: not found, access denied, happy path, storage failure is swallowed
- [ ] Integration tests: 204 on success, 404 on unknown file, 403 on wrong user, 401 without auth

Closes #271