### PR TITLE
feat: send SignalR notification when a member is banned (#286)

### DIFF
--- a/src/Harmonie.API/RealTime/Common/RealtimeHubDocumentation.cs
+++ b/src/Harmonie.API/RealTime/Common/RealtimeHubDocumentation.cs
@@ -110,6 +110,16 @@ public class RealtimeHubDocumentation
         Summary = "Received when a member voluntarily leaves a guild.")]
     public void OnMemberLeft() { }
 
+    [Channel("hubs/realtime/MemberBanned")]
+    [SubscribeOperation(typeof(MemberBannedEvent),
+        Summary = "Received when a guild member is banned. Broadcast to all remaining guild members.")]
+    public void OnMemberBanned() { }
+
+    [Channel("hubs/realtime/YouWereBanned")]
+    [SubscribeOperation(typeof(YouWereBannedEvent),
+        Summary = "Received by the banned user when they are removed from a guild via a ban.")]
+    public void OnYouWereBanned() { }
+
     [Channel("hubs/realtime/UserTyping")]
     [SubscribeOperation(typeof(UserTypingEvent),
         Summary = "Received when a user starts typing in a guild text channel.")]

--- a/src/Harmonie.API/RealTime/Guilds/SignalRGuildNotifier.cs
+++ b/src/Harmonie.API/RealTime/Guilds/SignalRGuildNotifier.cs
@@ -1,4 +1,5 @@
 using Harmonie.API.RealTime.Common;
+using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Guilds;
 using Microsoft.AspNetCore.SignalR;
 
@@ -7,10 +8,12 @@ namespace Harmonie.API.RealTime.Guilds;
 public sealed class SignalRGuildNotifier : IGuildNotifier
 {
     private readonly IHubContext<RealtimeHub> _hubContext;
+    private readonly IConnectionTracker _connectionTracker;
 
-    public SignalRGuildNotifier(IHubContext<RealtimeHub> hubContext)
+    public SignalRGuildNotifier(IHubContext<RealtimeHub> hubContext, IConnectionTracker connectionTracker)
     {
         _hubContext = hubContext;
+        _connectionTracker = connectionTracker;
     }
 
     public async Task NotifyGuildDeletedAsync(
@@ -141,6 +144,32 @@ public sealed class SignalRGuildNotifier : IGuildNotifier
             .Group(RealtimeHub.GetGuildGroupName(notification.GuildId))
             .SendAsync("MemberLeft", payload, cancellationToken);
     }
+
+    public async Task NotifyMemberBannedAsync(
+        MemberBannedNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var memberBannedPayload = new MemberBannedEvent(
+            GuildId: notification.GuildId.Value,
+            UserId: notification.BannedUserId.Value);
+
+        await _hubContext.Clients
+            .Group(RealtimeHub.GetGuildGroupName(notification.GuildId))
+            .SendAsync("MemberBanned", memberBannedPayload, cancellationToken);
+
+        var connectionIds = _connectionTracker.GetConnectionIds(notification.BannedUserId);
+        if (connectionIds.Count > 0)
+        {
+            var youWereBannedPayload = new YouWereBannedEvent(
+                GuildId: notification.GuildId.Value);
+
+            await _hubContext.Clients
+                .Clients(connectionIds)
+                .SendAsync("YouWereBanned", youWereBannedPayload, cancellationToken);
+        }
+    }
 }
 
 public sealed record GuildDeletedEvent(
@@ -185,3 +214,10 @@ public sealed record MemberJoinedEvent(
 public sealed record MemberLeftEvent(
     Guid GuildId,
     Guid UserId);
+
+public sealed record MemberBannedEvent(
+    Guid GuildId,
+    Guid UserId);
+
+public sealed record YouWereBannedEvent(
+    Guid GuildId);

--- a/src/Harmonie.Application/Features/Guilds/BanMember/BanMemberHandler.cs
+++ b/src/Harmonie.Application/Features/Guilds/BanMember/BanMemberHandler.cs
@@ -19,6 +19,7 @@ public sealed class BanMemberHandler : IAuthenticatedHandler<BanMemberInput, Ban
     private readonly IGuildBanRepository _guildBanRepository;
     private readonly IMessageRepository _messageRepository;
     private readonly IRealtimeGroupManager _realtimeGroupManager;
+    private readonly IGuildNotifier _guildNotifier;
     private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<BanMemberHandler> _logger;
 
@@ -28,6 +29,7 @@ public sealed class BanMemberHandler : IAuthenticatedHandler<BanMemberInput, Ban
         IGuildBanRepository guildBanRepository,
         IMessageRepository messageRepository,
         IRealtimeGroupManager realtimeGroupManager,
+        IGuildNotifier guildNotifier,
         IUnitOfWork unitOfWork,
         ILogger<BanMemberHandler> logger)
     {
@@ -36,6 +38,7 @@ public sealed class BanMemberHandler : IAuthenticatedHandler<BanMemberInput, Ban
         _guildBanRepository = guildBanRepository;
         _messageRepository = messageRepository;
         _realtimeGroupManager = realtimeGroupManager;
+        _guildNotifier = guildNotifier;
         _unitOfWork = unitOfWork;
         _logger = logger;
     }
@@ -119,6 +122,18 @@ public sealed class BanMemberHandler : IAuthenticatedHandler<BanMemberInput, Ban
                 "Failed to unsubscribe banned user {UserId} from guild {GuildId} SignalR groups",
                 request.TargetId,
                 request.GuildId);
+
+            await BestEffortNotificationHelper.TryNotifyAsync(
+                ct => _guildNotifier.NotifyMemberBannedAsync(
+                    new MemberBannedNotification(
+                        GuildId: request.GuildId,
+                        BannedUserId: request.TargetId),
+                    ct),
+                TimeSpan.FromSeconds(5),
+                _logger,
+                "Failed to notify guild {GuildId} that user {UserId} was banned",
+                request.GuildId,
+                request.TargetId);
         }
 
         var ban = banResult.Value;

--- a/src/Harmonie.Application/Interfaces/Guilds/IGuildNotifier.cs
+++ b/src/Harmonie.Application/Interfaces/Guilds/IGuildNotifier.cs
@@ -39,6 +39,10 @@ public interface IGuildNotifier
     Task NotifyMemberLeftAsync(
         MemberLeftNotification notification,
         CancellationToken cancellationToken = default);
+
+    Task NotifyMemberBannedAsync(
+        MemberBannedNotification notification,
+        CancellationToken cancellationToken = default);
 }
 
 public sealed record GuildDeletedNotification(
@@ -83,3 +87,7 @@ public sealed record MemberJoinedNotification(
 public sealed record MemberLeftNotification(
     GuildId GuildId,
     UserId UserId);
+
+public sealed record MemberBannedNotification(
+    GuildId GuildId,
+    UserId BannedUserId);

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRGuildHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRGuildHubTests.cs
@@ -339,6 +339,56 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
         eventPayload.UserId.Should().NotBeNullOrEmpty();
     }
 
+    [Fact]
+    public async Task MemberBanned_WhenMemberConnected_ShouldReceiveEvent()
+    {
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var remainingMember = await AuthTestHelper.RegisterAsync(_client);
+        var targetMember = await AuthTestHelper.RegisterAsync(_client);
+
+        var prefix = Guid.NewGuid().ToString("N")[..8];
+
+        var createGuildResponse = await _client.SendAuthorizedPostAsync(
+            "/api/guilds",
+            new CreateGuildRequest($"SignalR MemberBanned Guild {prefix}"),
+            owner.AccessToken);
+        createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        createGuildPayload.Should().NotBeNull();
+
+        await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, remainingMember.AccessToken);
+        await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload.GuildId, owner.AccessToken, targetMember.AccessToken);
+
+        await using var connection = CreateHubConnection(remainingMember.AccessToken);
+        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var eventReceived = new TaskCompletionSource<SignalRMemberBannedEvent>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        connection.On("Ready", () => ready.TrySetResult());
+        connection.On<SignalRMemberBannedEvent>("MemberBanned", payload =>
+        {
+            eventReceived.TrySetResult(payload);
+        });
+
+        await connection.StartAsync();
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var banResponse = await _client.SendAuthorizedPostAsync(
+            $"/api/guilds/{createGuildPayload.GuildId}/bans",
+            new { userId = targetMember.UserId, reason = (string?)null, purgeMessagesDays = 0 },
+            owner.AccessToken);
+        banResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var completedTask = await Task.WhenAny(eventReceived.Task, Task.Delay(Timeout.InfiniteTimeSpan, timeout.Token));
+        completedTask.Should().Be(eventReceived.Task);
+
+        var eventPayload = await eventReceived.Task;
+        eventPayload.GuildId.Should().Be(createGuildPayload.GuildId.ToString());
+        eventPayload.UserId.Should().NotBeNullOrEmpty();
+    }
+
     private HubConnection CreateHubConnection(string accessToken)
     {
         var baseAddress = _client.BaseAddress ?? new Uri("http://localhost");
@@ -381,6 +431,10 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
         string? AvatarFileId);
 
     private sealed record SignalRMemberLeftEvent(
+        string GuildId,
+        string UserId);
+
+    private sealed record SignalRMemberBannedEvent(
         string GuildId,
         string UserId);
 }

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRGuildHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRGuildHubTests.cs
@@ -386,7 +386,7 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
 
         var eventPayload = await eventReceived.Task;
         eventPayload.GuildId.Should().Be(createGuildPayload.GuildId.ToString());
-        eventPayload.UserId.Should().NotBeNullOrEmpty();
+        eventPayload.UserId.Should().Be(targetMember.UserId.ToString());
     }
 
     private HubConnection CreateHubConnection(string accessToken)

--- a/tests/Harmonie.Application.Tests/Guilds/BanMemberHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/BanMemberHandlerTests.cs
@@ -21,6 +21,7 @@ public sealed class BanMemberHandlerTests
     private readonly Mock<IGuildMemberRepository> _guildMemberRepositoryMock;
     private readonly Mock<IGuildBanRepository> _guildBanRepositoryMock;
     private readonly Mock<IMessageRepository> _messageRepositoryMock;
+    private readonly Mock<IGuildNotifier> _guildNotifierMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly BanMemberHandler _handler;
@@ -31,6 +32,7 @@ public sealed class BanMemberHandlerTests
         _guildMemberRepositoryMock = new Mock<IGuildMemberRepository>();
         _guildBanRepositoryMock = new Mock<IGuildBanRepository>();
         _messageRepositoryMock = new Mock<IMessageRepository>();
+        _guildNotifierMock = new Mock<IGuildNotifier>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
 
@@ -42,6 +44,7 @@ public sealed class BanMemberHandlerTests
             _guildBanRepositoryMock.Object,
             _messageRepositoryMock.Object,
             new Mock<IRealtimeGroupManager>().Object,
+            _guildNotifierMock.Object,
             _unitOfWorkMock.Object,
             NullLogger<BanMemberHandler>.Instance);
     }
@@ -224,6 +227,36 @@ public sealed class BanMemberHandlerTests
 
         _transactionMock.Verify(
             x => x.CommitAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenBanMember_ShouldNotifyGuildNotifier()
+    {
+        var ownerId = UserId.New();
+        var targetId = UserId.New();
+        var guild = ApplicationTestBuilders.CreateGuild(ownerId);
+
+        _guildRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(guild.Id, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Admin));
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.GetRoleAsync(guild.Id, targetId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GuildRole.Member);
+
+        _guildBanRepositoryMock
+            .Setup(x => x.TryAddAsync(It.IsAny<GuildBan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, null, 0), ownerId);
+
+        response.Success.Should().BeTrue();
+
+        _guildNotifierMock.Verify(
+            x => x.NotifyMemberBannedAsync(
+                It.Is<MemberBannedNotification>(n => n.GuildId == guild.Id && n.BannedUserId == targetId),
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 


### PR DESCRIPTION
## Summary
- Adds `NotifyMemberBannedAsync` to `IGuildNotifier` with a `MemberBannedNotification` record
- Broadcasts `MemberBanned` to the guild group so remaining members can update their member list
- Sends `YouWereBanned` directly to the banned user's connections via `IConnectionTracker` so the client can redirect them immediately
- Injects `IGuildNotifier` into `BanMemberHandler` and fires notifications after group removal (best-effort, only when the target was a member)

## Test plan
- [ ] New unit test: `HandleAsync_WhenBanMember_ShouldNotifyGuildNotifier` verifies `NotifyMemberBannedAsync` is called with correct args
- [ ] New integration test: `MemberBanned_WhenMemberConnected_ShouldReceiveEvent` verifies a remaining guild member receives the `MemberBanned` SignalR event
- [ ] All 340 unit tests pass
- [ ] Integration test passes

Closes #286