### PR TITLE
feat: send SignalR notification when a member is kicked (#287)

### DIFF
--- a/src/Harmonie.API/RealTime/Common/RealtimeHubDocumentation.cs
+++ b/src/Harmonie.API/RealTime/Common/RealtimeHubDocumentation.cs
@@ -120,6 +120,16 @@ public class RealtimeHubDocumentation
         Summary = "Received by the banned user when they are removed from a guild via a ban.")]
     public void OnYouWereBanned() { }
 
+    [Channel("hubs/realtime/MemberRemoved")]
+    [SubscribeOperation(typeof(MemberRemovedEvent),
+        Summary = "Received when a guild member is kicked by an admin. Broadcast to all remaining guild members.")]
+    public void OnMemberRemoved() { }
+
+    [Channel("hubs/realtime/YouWereKicked")]
+    [SubscribeOperation(typeof(YouWereKickedEvent),
+        Summary = "Received by the kicked user when they are removed from a guild by an admin.")]
+    public void OnYouWereKicked() { }
+
     [Channel("hubs/realtime/UserTyping")]
     [SubscribeOperation(typeof(UserTypingEvent),
         Summary = "Received when a user starts typing in a guild text channel.")]

--- a/src/Harmonie.API/RealTime/Guilds/SignalRGuildNotifier.cs
+++ b/src/Harmonie.API/RealTime/Guilds/SignalRGuildNotifier.cs
@@ -170,6 +170,32 @@ public sealed class SignalRGuildNotifier : IGuildNotifier
                 .SendAsync("YouWereBanned", youWereBannedPayload, cancellationToken);
         }
     }
+
+    public async Task NotifyMemberRemovedAsync(
+        MemberRemovedNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var memberRemovedPayload = new MemberRemovedEvent(
+            GuildId: notification.GuildId.Value,
+            UserId: notification.RemovedUserId.Value);
+
+        await _hubContext.Clients
+            .Group(RealtimeHub.GetGuildGroupName(notification.GuildId))
+            .SendAsync("MemberRemoved", memberRemovedPayload, cancellationToken);
+
+        var connectionIds = _connectionTracker.GetConnectionIds(notification.RemovedUserId);
+        if (connectionIds.Count > 0)
+        {
+            var youWereKickedPayload = new YouWereKickedEvent(
+                GuildId: notification.GuildId.Value);
+
+            await _hubContext.Clients
+                .Clients(connectionIds)
+                .SendAsync("YouWereKicked", youWereKickedPayload, cancellationToken);
+        }
+    }
 }
 
 public sealed record GuildDeletedEvent(
@@ -220,4 +246,11 @@ public sealed record MemberBannedEvent(
     Guid UserId);
 
 public sealed record YouWereBannedEvent(
+    Guid GuildId);
+
+public sealed record MemberRemovedEvent(
+    Guid GuildId,
+    Guid UserId);
+
+public sealed record YouWereKickedEvent(
     Guid GuildId);

--- a/src/Harmonie.Application/Features/Guilds/RemoveMember/RemoveMemberHandler.cs
+++ b/src/Harmonie.Application/Features/Guilds/RemoveMember/RemoveMemberHandler.cs
@@ -15,17 +15,20 @@ public sealed class RemoveMemberHandler : IAuthenticatedHandler<RemoveMemberInpu
     private readonly IGuildRepository _guildRepository;
     private readonly IGuildMemberRepository _guildMemberRepository;
     private readonly IRealtimeGroupManager _realtimeGroupManager;
+    private readonly IGuildNotifier _guildNotifier;
     private readonly ILogger<RemoveMemberHandler> _logger;
 
     public RemoveMemberHandler(
         IGuildRepository guildRepository,
         IGuildMemberRepository guildMemberRepository,
         IRealtimeGroupManager realtimeGroupManager,
+        IGuildNotifier guildNotifier,
         ILogger<RemoveMemberHandler> logger)
     {
         _guildRepository = guildRepository;
         _guildMemberRepository = guildMemberRepository;
         _realtimeGroupManager = realtimeGroupManager;
+        _guildNotifier = guildNotifier;
         _logger = logger;
     }
 
@@ -73,6 +76,18 @@ public sealed class RemoveMemberHandler : IAuthenticatedHandler<RemoveMemberInpu
             "Failed to unsubscribe user {UserId} from guild {GuildId} SignalR groups",
             request.TargetId,
             request.GuildId);
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            ct => _guildNotifier.NotifyMemberRemovedAsync(
+                new MemberRemovedNotification(
+                    GuildId: request.GuildId,
+                    RemovedUserId: request.TargetId),
+                ct),
+            TimeSpan.FromSeconds(5),
+            _logger,
+            "Failed to notify guild {GuildId} that user {UserId} was removed",
+            request.GuildId,
+            request.TargetId);
 
         return ApplicationResponse<bool>.Ok(true);
     }

--- a/src/Harmonie.Application/Interfaces/Guilds/IGuildNotifier.cs
+++ b/src/Harmonie.Application/Interfaces/Guilds/IGuildNotifier.cs
@@ -43,6 +43,10 @@ public interface IGuildNotifier
     Task NotifyMemberBannedAsync(
         MemberBannedNotification notification,
         CancellationToken cancellationToken = default);
+
+    Task NotifyMemberRemovedAsync(
+        MemberRemovedNotification notification,
+        CancellationToken cancellationToken = default);
 }
 
 public sealed record GuildDeletedNotification(
@@ -91,3 +95,7 @@ public sealed record MemberLeftNotification(
 public sealed record MemberBannedNotification(
     GuildId GuildId,
     UserId BannedUserId);
+
+public sealed record MemberRemovedNotification(
+    GuildId GuildId,
+    UserId RemovedUserId);

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRGuildHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRGuildHubTests.cs
@@ -434,7 +434,60 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
         string GuildId,
         string UserId);
 
+    [Fact]
+    public async Task MemberRemoved_WhenMemberConnected_ShouldReceiveEvent()
+    {
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var remainingMember = await AuthTestHelper.RegisterAsync(_client);
+        var targetMember = await AuthTestHelper.RegisterAsync(_client);
+
+        var prefix = Guid.NewGuid().ToString("N")[..8];
+
+        var createGuildResponse = await _client.SendAuthorizedPostAsync(
+            "/api/guilds",
+            new CreateGuildRequest($"SignalR MemberRemoved Guild {prefix}"),
+            owner.AccessToken);
+        createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        createGuildPayload.Should().NotBeNull();
+
+        await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, remainingMember.AccessToken);
+        await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload.GuildId, owner.AccessToken, targetMember.AccessToken);
+
+        await using var connection = CreateHubConnection(remainingMember.AccessToken);
+        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var eventReceived = new TaskCompletionSource<SignalRMemberRemovedEvent>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        connection.On("Ready", () => ready.TrySetResult());
+        connection.On<SignalRMemberRemovedEvent>("MemberRemoved", payload =>
+        {
+            eventReceived.TrySetResult(payload);
+        });
+
+        await connection.StartAsync();
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var removeResponse = await _client.SendAuthorizedDeleteAsync(
+            $"/api/guilds/{createGuildPayload.GuildId}/members/{targetMember.UserId}",
+            owner.AccessToken);
+        removeResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var completedTask = await Task.WhenAny(eventReceived.Task, Task.Delay(Timeout.InfiniteTimeSpan, timeout.Token));
+        completedTask.Should().Be(eventReceived.Task);
+
+        var eventPayload = await eventReceived.Task;
+        eventPayload.GuildId.Should().Be(createGuildPayload.GuildId.ToString());
+        eventPayload.UserId.Should().Be(targetMember.UserId.ToString());
+    }
+
     private sealed record SignalRMemberBannedEvent(
+        string GuildId,
+        string UserId);
+
+    private sealed record SignalRMemberRemovedEvent(
         string GuildId,
         string UserId);
 }

--- a/tests/Harmonie.Application.Tests/Guilds/RemoveMemberHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/RemoveMemberHandlerTests.cs
@@ -18,17 +18,20 @@ public sealed class RemoveMemberHandlerTests
 {
     private readonly Mock<IGuildRepository> _guildRepositoryMock;
     private readonly Mock<IGuildMemberRepository> _guildMemberRepositoryMock;
+    private readonly Mock<IGuildNotifier> _guildNotifierMock;
     private readonly RemoveMemberHandler _handler;
 
     public RemoveMemberHandlerTests()
     {
         _guildRepositoryMock = new Mock<IGuildRepository>();
         _guildMemberRepositoryMock = new Mock<IGuildMemberRepository>();
+        _guildNotifierMock = new Mock<IGuildNotifier>();
 
         _handler = new RemoveMemberHandler(
             _guildRepositoryMock.Object,
             _guildMemberRepositoryMock.Object,
             new Mock<IRealtimeGroupManager>().Object,
+            _guildNotifierMock.Object,
             NullLogger<RemoveMemberHandler>.Instance);
     }
 
@@ -158,6 +161,39 @@ public sealed class RemoveMemberHandlerTests
 
         _guildMemberRepositoryMock.Verify(
             x => x.RemoveAsync(guild.Id, targetId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenAdminRemovesRegularMember_ShouldCallNotifyMemberRemovedAsync()
+    {
+        var ownerId = UserId.New();
+        var callerId = UserId.New();
+        var targetId = UserId.New();
+        var guild = ApplicationTestBuilders.CreateGuild(ownerId);
+
+        _guildRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Admin));
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.GetRoleAsync(guild.Id, targetId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GuildRole.Member);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.RemoveAsync(guild.Id, targetId, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _guildNotifierMock
+            .Setup(x => x.NotifyMemberRemovedAsync(It.IsAny<MemberRemovedNotification>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await _handler.HandleAsync(new RemoveMemberInput(guild.Id, targetId), callerId);
+
+        _guildNotifierMock.Verify(
+            x => x.NotifyMemberRemovedAsync(
+                It.Is<MemberRemovedNotification>(n => n.GuildId == guild.Id && n.RemovedUserId == targetId),
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 


### PR DESCRIPTION
## Summary
- Add `NotifyMemberRemovedAsync` to `IGuildNotifier` + `MemberRemovedNotification` record
- `SignalRGuildNotifier` broadcasts `MemberRemoved` to the guild group and `YouWereKicked` to the kicked user's personal connections
- `RemoveMemberHandler` calls the notifier after removing the member (best-effort, same pattern as BanMember)
- AsyncAPI documentation entries for `MemberRemoved` and `YouWereKicked`
- Unit test asserting `NotifyMemberRemovedAsync` is called with the correct `UserId`
- SignalR integration test verifying remaining members receive `MemberRemoved`

## Test plan
- [ ] `dotnet test tests/Harmonie.Application.Tests/` — 341 unit tests pass
- [ ] `dotnet test tests/Harmonie.API.IntegrationTests/ --filter MemberRemoved` — integration test passes

Closes #287