### PR TITLE
feat: send SignalR notification when a member's role is updated (#288)

### DIFF
--- a/src/Harmonie.API/RealTime/Common/RealtimeHubDocumentation.cs
+++ b/src/Harmonie.API/RealTime/Common/RealtimeHubDocumentation.cs
@@ -130,6 +130,11 @@ public class RealtimeHubDocumentation
         Summary = "Received by the kicked user when they are removed from a guild by an admin.")]
     public void OnYouWereKicked() { }
 
+    [Channel("hubs/realtime/MemberRoleUpdated")]
+    [SubscribeOperation(typeof(MemberRoleUpdatedEvent),
+        Summary = "Received when a guild member's role is changed by an admin. Broadcast to all guild members.")]
+    public void OnMemberRoleUpdated() { }
+
     [Channel("hubs/realtime/UserTyping")]
     [SubscribeOperation(typeof(UserTypingEvent),
         Summary = "Received when a user starts typing in a guild text channel.")]

--- a/src/Harmonie.API/RealTime/Guilds/SignalRGuildNotifier.cs
+++ b/src/Harmonie.API/RealTime/Guilds/SignalRGuildNotifier.cs
@@ -196,6 +196,22 @@ public sealed class SignalRGuildNotifier : IGuildNotifier
                 .SendAsync("YouWereKicked", youWereKickedPayload, cancellationToken);
         }
     }
+
+    public async Task NotifyMemberRoleUpdatedAsync(
+        MemberRoleUpdatedNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var payload = new MemberRoleUpdatedEvent(
+            GuildId: notification.GuildId.Value,
+            UserId: notification.UserId.Value,
+            NewRole: notification.NewRole.ToString());
+
+        await _hubContext.Clients
+            .Group(RealtimeHub.GetGuildGroupName(notification.GuildId))
+            .SendAsync("MemberRoleUpdated", payload, cancellationToken);
+    }
 }
 
 public sealed record GuildDeletedEvent(
@@ -254,3 +270,8 @@ public sealed record MemberRemovedEvent(
 
 public sealed record YouWereKickedEvent(
     Guid GuildId);
+
+public sealed record MemberRoleUpdatedEvent(
+    Guid GuildId,
+    Guid UserId,
+    string NewRole);

--- a/src/Harmonie.Application/Features/Guilds/UpdateMemberRole/UpdateMemberRoleHandler.cs
+++ b/src/Harmonie.Application/Features/Guilds/UpdateMemberRole/UpdateMemberRoleHandler.cs
@@ -13,13 +13,16 @@ public sealed class UpdateMemberRoleHandler
 {
     private readonly IGuildRepository _guildRepository;
     private readonly IGuildMemberRepository _guildMemberRepository;
+    private readonly IGuildNotifier _guildNotifier;
 
     public UpdateMemberRoleHandler(
         IGuildRepository guildRepository,
-        IGuildMemberRepository guildMemberRepository)
+        IGuildMemberRepository guildMemberRepository,
+        IGuildNotifier guildNotifier)
     {
         _guildRepository = guildRepository;
         _guildMemberRepository = guildMemberRepository;
+        _guildNotifier = guildNotifier;
     }
 
     public async Task<ApplicationResponse<bool>> HandleAsync(
@@ -58,6 +61,10 @@ public sealed class UpdateMemberRoleHandler
         }
 
         await _guildMemberRepository.UpdateRoleAsync(request.GuildId, request.TargetId, request.NewRole, cancellationToken);
+
+        await _guildNotifier.NotifyMemberRoleUpdatedAsync(
+            new MemberRoleUpdatedNotification(request.GuildId, request.TargetId, request.NewRole),
+            cancellationToken);
 
         return ApplicationResponse<bool>.Ok(true);
     }

--- a/src/Harmonie.Application/Interfaces/Guilds/IGuildNotifier.cs
+++ b/src/Harmonie.Application/Interfaces/Guilds/IGuildNotifier.cs
@@ -47,6 +47,10 @@ public interface IGuildNotifier
     Task NotifyMemberRemovedAsync(
         MemberRemovedNotification notification,
         CancellationToken cancellationToken = default);
+
+    Task NotifyMemberRoleUpdatedAsync(
+        MemberRoleUpdatedNotification notification,
+        CancellationToken cancellationToken = default);
 }
 
 public sealed record GuildDeletedNotification(
@@ -99,3 +103,8 @@ public sealed record MemberBannedNotification(
 public sealed record MemberRemovedNotification(
     GuildId GuildId,
     UserId RemovedUserId);
+
+public sealed record MemberRoleUpdatedNotification(
+    GuildId GuildId,
+    UserId UserId,
+    GuildRole NewRole);

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRGuildHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRGuildHubTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Harmonie.API.IntegrationTests.Common;
 using Harmonie.Application.Features.Guilds.CreateGuild;
 using Harmonie.Application.Features.Guilds.CreateChannel;
+using Harmonie.Application.Features.Guilds.UpdateMemberRole;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -483,6 +484,57 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
         eventPayload.UserId.Should().Be(targetMember.UserId.ToString());
     }
 
+    [Fact]
+    public async Task MemberRoleUpdated_WhenMemberConnected_ShouldReceiveEvent()
+    {
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var remainingMember = await AuthTestHelper.RegisterAsync(_client);
+        var targetMember = await AuthTestHelper.RegisterAsync(_client);
+
+        var prefix = Guid.NewGuid().ToString("N")[..8];
+
+        var createGuildResponse = await _client.SendAuthorizedPostAsync(
+            "/api/guilds",
+            new CreateGuildRequest($"SignalR MemberRoleUpdated Guild {prefix}"),
+            owner.AccessToken);
+        createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        createGuildPayload.Should().NotBeNull();
+
+        await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, remainingMember.AccessToken);
+        await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload.GuildId, owner.AccessToken, targetMember.AccessToken);
+
+        await using var connection = CreateHubConnection(remainingMember.AccessToken);
+        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var eventReceived = new TaskCompletionSource<SignalRMemberRoleUpdatedEvent>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        connection.On("Ready", () => ready.TrySetResult());
+        connection.On<SignalRMemberRoleUpdatedEvent>("MemberRoleUpdated", payload =>
+        {
+            eventReceived.TrySetResult(payload);
+        });
+
+        await connection.StartAsync();
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var updateRoleResponse = await _client.SendAuthorizedPutAsync(
+            $"/api/guilds/{createGuildPayload.GuildId}/members/{targetMember.UserId}/role",
+            new UpdateMemberRoleRequest(GuildRoleInput.Admin),
+            owner.AccessToken);
+        updateRoleResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var completedTask = await Task.WhenAny(eventReceived.Task, Task.Delay(Timeout.InfiniteTimeSpan, timeout.Token));
+        completedTask.Should().Be(eventReceived.Task);
+
+        var eventPayload = await eventReceived.Task;
+        eventPayload.GuildId.Should().Be(createGuildPayload.GuildId.ToString());
+        eventPayload.UserId.Should().Be(targetMember.UserId.ToString());
+        eventPayload.NewRole.Should().Be("Admin");
+    }
+
     private sealed record SignalRMemberBannedEvent(
         string GuildId,
         string UserId);
@@ -490,4 +542,9 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
     private sealed record SignalRMemberRemovedEvent(
         string GuildId,
         string UserId);
+
+    private sealed record SignalRMemberRoleUpdatedEvent(
+        string GuildId,
+        string UserId,
+        string NewRole);
 }

--- a/tests/Harmonie.Application.Tests/Guilds/UpdateMemberRoleHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/UpdateMemberRoleHandlerTests.cs
@@ -17,16 +17,19 @@ public sealed class UpdateMemberRoleHandlerTests
 {
     private readonly Mock<IGuildRepository> _guildRepositoryMock;
     private readonly Mock<IGuildMemberRepository> _guildMemberRepositoryMock;
+    private readonly Mock<IGuildNotifier> _guildNotifierMock;
     private readonly UpdateMemberRoleHandler _handler;
 
     public UpdateMemberRoleHandlerTests()
     {
         _guildRepositoryMock = new Mock<IGuildRepository>();
         _guildMemberRepositoryMock = new Mock<IGuildMemberRepository>();
+        _guildNotifierMock = new Mock<IGuildNotifier>();
 
         _handler = new UpdateMemberRoleHandler(
             _guildRepositoryMock.Object,
-            _guildMemberRepositoryMock.Object);
+            _guildMemberRepositoryMock.Object,
+            _guildNotifierMock.Object);
     }
 
     [Fact]
@@ -184,6 +187,41 @@ public sealed class UpdateMemberRoleHandlerTests
 
         _guildMemberRepositoryMock.Verify(
             x => x.UpdateRoleAsync(guild.Id, targetId, GuildRole.Member, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenRoleUpdated_ShouldCallNotifyMemberRoleUpdatedAsync()
+    {
+        var guild = ApplicationTestBuilders.CreateGuild();
+        var callerId = UserId.New();
+        var targetId = UserId.New();
+
+        _guildRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Admin));
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.GetRoleAsync(guild.Id, targetId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GuildRole.Member);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.UpdateRoleAsync(guild.Id, targetId, GuildRole.Admin, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _guildNotifierMock
+            .Setup(x => x.NotifyMemberRoleUpdatedAsync(It.IsAny<MemberRoleUpdatedNotification>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await _handler.HandleAsync(new UpdateMemberRoleInput(guild.Id, targetId, GuildRole.Admin), callerId);
+
+        _guildNotifierMock.Verify(
+            x => x.NotifyMemberRoleUpdatedAsync(
+                It.Is<MemberRoleUpdatedNotification>(n =>
+                    n.GuildId == guild.Id &&
+                    n.UserId == targetId &&
+                    n.NewRole == GuildRole.Admin),
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 


### PR DESCRIPTION
## Summary
- Add `NotifyMemberRoleUpdatedAsync` to `IGuildNotifier` with `MemberRoleUpdatedNotification` record
- Implement in `SignalRGuildNotifier` — broadcasts `MemberRoleUpdated` event to `guild:{guildId}` group with guild id, user id, and new role
- Call from `UpdateMemberRoleHandler` after role is persisted
- Add `MemberRoleUpdated` AsyncAPI channel entry in `RealtimeHubDocumentation`

## Test plan
- [x] Unit test: `HandleAsync_WhenRoleUpdated_ShouldCallNotifyMemberRoleUpdatedAsync` in `UpdateMemberRoleHandlerTests`
- [x] Integration test: `MemberRoleUpdated_WhenMemberConnected_ShouldReceiveEvent` in `SignalRGuildHubTests`
- [x] All existing tests pass

Closes #288