### PR TITLE
feat: send SignalR notification when guild settings are updated (#289)

### DIFF
--- a/src/Harmonie.API/RealTime/Common/RealtimeHubDocumentation.cs
+++ b/src/Harmonie.API/RealTime/Common/RealtimeHubDocumentation.cs
@@ -135,6 +135,11 @@ public class RealtimeHubDocumentation
         Summary = "Received when a guild member's role is changed by an admin. Broadcast to all guild members.")]
     public void OnMemberRoleUpdated() { }
 
+    [Channel("hubs/realtime/GuildUpdated")]
+    [SubscribeOperation(typeof(GuildUpdatedEvent),
+        Summary = "Received when guild settings (name or icon) are updated. Broadcast to all guild members.")]
+    public void OnGuildUpdated() { }
+
     [Channel("hubs/realtime/UserTyping")]
     [SubscribeOperation(typeof(UserTypingEvent),
         Summary = "Received when a user starts typing in a guild text channel.")]

--- a/src/Harmonie.API/RealTime/Guilds/SignalRGuildNotifier.cs
+++ b/src/Harmonie.API/RealTime/Guilds/SignalRGuildNotifier.cs
@@ -212,6 +212,22 @@ public sealed class SignalRGuildNotifier : IGuildNotifier
             .Group(RealtimeHub.GetGuildGroupName(notification.GuildId))
             .SendAsync("MemberRoleUpdated", payload, cancellationToken);
     }
+
+    public async Task NotifyGuildUpdatedAsync(
+        GuildUpdatedNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var payload = new GuildUpdatedEvent(
+            GuildId: notification.GuildId.Value,
+            Name: notification.Name,
+            IconFileId: notification.IconFileId?.Value);
+
+        await _hubContext.Clients
+            .Group(RealtimeHub.GetGuildGroupName(notification.GuildId))
+            .SendAsync("GuildUpdated", payload, cancellationToken);
+    }
 }
 
 public sealed record GuildDeletedEvent(
@@ -275,3 +291,8 @@ public sealed record MemberRoleUpdatedEvent(
     Guid GuildId,
     Guid UserId,
     string NewRole);
+
+public sealed record GuildUpdatedEvent(
+    Guid GuildId,
+    string Name,
+    Guid? IconFileId);

--- a/src/Harmonie.Application/Features/Guilds/DeleteGuildIcon/DeleteGuildIconHandler.cs
+++ b/src/Harmonie.Application/Features/Guilds/DeleteGuildIcon/DeleteGuildIconHandler.cs
@@ -5,6 +5,7 @@ using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging;
 
 namespace Harmonie.Application.Features.Guilds.DeleteGuildIcon;
 
@@ -16,17 +17,20 @@ public sealed class DeleteGuildIconHandler : IAuthenticatedHandler<DeleteGuildIc
     private readonly UploadedFileCleanupService _uploadedFileCleanupService;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IGuildNotifier _guildNotifier;
+    private readonly ILogger<DeleteGuildIconHandler> _logger;
 
     public DeleteGuildIconHandler(
         IGuildRepository guildRepository,
         UploadedFileCleanupService uploadedFileCleanupService,
         IUnitOfWork unitOfWork,
-        IGuildNotifier guildNotifier)
+        IGuildNotifier guildNotifier,
+        ILogger<DeleteGuildIconHandler> logger)
     {
         _guildRepository = guildRepository;
         _uploadedFileCleanupService = uploadedFileCleanupService;
         _unitOfWork = unitOfWork;
         _guildNotifier = guildNotifier;
+        _logger = logger;
     }
 
     public async Task<ApplicationResponse<bool>> HandleAsync(
@@ -75,9 +79,14 @@ public sealed class DeleteGuildIconHandler : IAuthenticatedHandler<DeleteGuildIc
 
         await _uploadedFileCleanupService.DeleteIfExistsAsync(previousIconFileId, cancellationToken);
 
-        await _guildNotifier.NotifyGuildUpdatedAsync(
-            new GuildUpdatedNotification(ctx.Guild.Id, ctx.Guild.Name.Value, null),
-            cancellationToken);
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            ct => _guildNotifier.NotifyGuildUpdatedAsync(
+                new GuildUpdatedNotification(ctx.Guild.Id, ctx.Guild.Name.Value, null),
+                ct),
+            TimeSpan.FromSeconds(5),
+            _logger,
+            "Failed to notify guild {GuildId} that icon was deleted",
+            ctx.Guild.Id);
 
         return ApplicationResponse<bool>.Ok(true);
     }

--- a/src/Harmonie.Application/Features/Guilds/DeleteGuildIcon/DeleteGuildIconHandler.cs
+++ b/src/Harmonie.Application/Features/Guilds/DeleteGuildIcon/DeleteGuildIconHandler.cs
@@ -15,15 +15,18 @@ public sealed class DeleteGuildIconHandler : IAuthenticatedHandler<DeleteGuildIc
     private readonly IGuildRepository _guildRepository;
     private readonly UploadedFileCleanupService _uploadedFileCleanupService;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IGuildNotifier _guildNotifier;
 
     public DeleteGuildIconHandler(
         IGuildRepository guildRepository,
         UploadedFileCleanupService uploadedFileCleanupService,
-        IUnitOfWork unitOfWork)
+        IUnitOfWork unitOfWork,
+        IGuildNotifier guildNotifier)
     {
         _guildRepository = guildRepository;
         _uploadedFileCleanupService = uploadedFileCleanupService;
         _unitOfWork = unitOfWork;
+        _guildNotifier = guildNotifier;
     }
 
     public async Task<ApplicationResponse<bool>> HandleAsync(
@@ -71,6 +74,10 @@ public sealed class DeleteGuildIconHandler : IAuthenticatedHandler<DeleteGuildIc
         }
 
         await _uploadedFileCleanupService.DeleteIfExistsAsync(previousIconFileId, cancellationToken);
+
+        await _guildNotifier.NotifyGuildUpdatedAsync(
+            new GuildUpdatedNotification(ctx.Guild.Id, ctx.Guild.Name.Value, null),
+            cancellationToken);
 
         return ApplicationResponse<bool>.Ok(true);
     }

--- a/src/Harmonie.Application/Features/Guilds/UpdateGuild/UpdateGuildHandler.cs
+++ b/src/Harmonie.Application/Features/Guilds/UpdateGuild/UpdateGuildHandler.cs
@@ -9,6 +9,7 @@ using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging;
 
 namespace Harmonie.Application.Features.Guilds.UpdateGuild;
 
@@ -32,17 +33,20 @@ public sealed class UpdateGuildHandler
     private readonly UploadedFileCleanupService _uploadedFileCleanupService;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IGuildNotifier _guildNotifier;
+    private readonly ILogger<UpdateGuildHandler> _logger;
 
     public UpdateGuildHandler(
         IGuildRepository guildRepository,
         UploadedFileCleanupService uploadedFileCleanupService,
         IUnitOfWork unitOfWork,
-        IGuildNotifier guildNotifier)
+        IGuildNotifier guildNotifier,
+        ILogger<UpdateGuildHandler> logger)
     {
         _guildRepository = guildRepository;
         _uploadedFileCleanupService = uploadedFileCleanupService;
         _unitOfWork = unitOfWork;
         _guildNotifier = guildNotifier;
+        _logger = logger;
     }
 
     public async Task<ApplicationResponse<UpdateGuildResponse>> HandleAsync(
@@ -130,9 +134,14 @@ public sealed class UpdateGuildHandler
             await _guildRepository.UpdateAsync(guild, cancellationToken);
             await transaction.CommitAsync(cancellationToken);
 
-            await _guildNotifier.NotifyGuildUpdatedAsync(
-                new GuildUpdatedNotification(guild.Id, guild.Name.Value, guild.IconFileId),
-                cancellationToken);
+            await BestEffortNotificationHelper.TryNotifyAsync(
+                ct => _guildNotifier.NotifyGuildUpdatedAsync(
+                    new GuildUpdatedNotification(guild.Id, guild.Name.Value, guild.IconFileId),
+                    ct),
+                TimeSpan.FromSeconds(5),
+                _logger,
+                "Failed to notify guild {GuildId} that settings were updated",
+                guild.Id);
         }
 
         if (shouldDeletePreviousIconFile)

--- a/src/Harmonie.Application/Features/Guilds/UpdateGuild/UpdateGuildHandler.cs
+++ b/src/Harmonie.Application/Features/Guilds/UpdateGuild/UpdateGuildHandler.cs
@@ -31,15 +31,18 @@ public sealed class UpdateGuildHandler
     private readonly IGuildRepository _guildRepository;
     private readonly UploadedFileCleanupService _uploadedFileCleanupService;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IGuildNotifier _guildNotifier;
 
     public UpdateGuildHandler(
         IGuildRepository guildRepository,
         UploadedFileCleanupService uploadedFileCleanupService,
-        IUnitOfWork unitOfWork)
+        IUnitOfWork unitOfWork,
+        IGuildNotifier guildNotifier)
     {
         _guildRepository = guildRepository;
         _uploadedFileCleanupService = uploadedFileCleanupService;
         _unitOfWork = unitOfWork;
+        _guildNotifier = guildNotifier;
     }
 
     public async Task<ApplicationResponse<UpdateGuildResponse>> HandleAsync(
@@ -126,6 +129,10 @@ public sealed class UpdateGuildHandler
             await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
             await _guildRepository.UpdateAsync(guild, cancellationToken);
             await transaction.CommitAsync(cancellationToken);
+
+            await _guildNotifier.NotifyGuildUpdatedAsync(
+                new GuildUpdatedNotification(guild.Id, guild.Name.Value, guild.IconFileId),
+                cancellationToken);
         }
 
         if (shouldDeletePreviousIconFile)

--- a/src/Harmonie.Application/Interfaces/Guilds/IGuildNotifier.cs
+++ b/src/Harmonie.Application/Interfaces/Guilds/IGuildNotifier.cs
@@ -51,6 +51,10 @@ public interface IGuildNotifier
     Task NotifyMemberRoleUpdatedAsync(
         MemberRoleUpdatedNotification notification,
         CancellationToken cancellationToken = default);
+
+    Task NotifyGuildUpdatedAsync(
+        GuildUpdatedNotification notification,
+        CancellationToken cancellationToken = default);
 }
 
 public sealed record GuildDeletedNotification(
@@ -108,3 +112,8 @@ public sealed record MemberRoleUpdatedNotification(
     GuildId GuildId,
     UserId UserId,
     GuildRole NewRole);
+
+public sealed record GuildUpdatedNotification(
+    GuildId GuildId,
+    string Name,
+    UploadedFileId? IconFileId);

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRGuildHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRGuildHubTests.cs
@@ -535,6 +535,54 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
         eventPayload.NewRole.Should().Be("Admin");
     }
 
+    [Fact]
+    public async Task GuildUpdated_WhenMemberConnected_ShouldReceiveEvent()
+    {
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var member = await AuthTestHelper.RegisterAsync(_client);
+
+        var prefix = Guid.NewGuid().ToString("N")[..8];
+
+        var createGuildResponse = await _client.SendAuthorizedPostAsync(
+            "/api/guilds",
+            new CreateGuildRequest($"SignalR GuildUpdated Guild {prefix}"),
+            owner.AccessToken);
+        createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        createGuildPayload.Should().NotBeNull();
+
+        await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
+
+        await using var connection = CreateHubConnection(member.AccessToken);
+        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var eventReceived = new TaskCompletionSource<SignalRGuildUpdatedEvent>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        connection.On("Ready", () => ready.TrySetResult());
+        connection.On<SignalRGuildUpdatedEvent>("GuildUpdated", payload =>
+        {
+            eventReceived.TrySetResult(payload);
+        });
+
+        await connection.StartAsync();
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var updateResponse = await _client.SendAuthorizedPatchAsync(
+            $"/api/guilds/{createGuildPayload.GuildId}",
+            new { name = $"Updated Guild {prefix}" },
+            owner.AccessToken);
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var completedTask = await Task.WhenAny(eventReceived.Task, Task.Delay(Timeout.InfiniteTimeSpan, timeout.Token));
+        completedTask.Should().Be(eventReceived.Task);
+
+        var eventPayload = await eventReceived.Task;
+        eventPayload.GuildId.Should().Be(createGuildPayload.GuildId.ToString());
+        eventPayload.Name.Should().Be($"Updated Guild {prefix}");
+    }
+
     private sealed record SignalRMemberBannedEvent(
         string GuildId,
         string UserId);
@@ -547,4 +595,9 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
         string GuildId,
         string UserId,
         string NewRole);
+
+    private sealed record SignalRGuildUpdatedEvent(
+        string GuildId,
+        string Name,
+        string? IconFileId);
 }

--- a/tests/Harmonie.Application.Tests/Guilds/UpdateGuildHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/UpdateGuildHandlerTests.cs
@@ -46,7 +46,8 @@ public sealed class UpdateGuildHandlerTests
                 _objectStorageServiceMock.Object,
                 NullLogger<UploadedFileCleanupService>.Instance),
             _unitOfWorkMock.Object,
-            _guildNotifierMock.Object);
+            _guildNotifierMock.Object,
+            NullLogger<UpdateGuildHandler>.Instance);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Guilds/UpdateGuildHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/UpdateGuildHandlerTests.cs
@@ -25,6 +25,7 @@ public sealed class UpdateGuildHandlerTests
     private readonly Mock<IObjectStorageService> _objectStorageServiceMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly Mock<IGuildNotifier> _guildNotifierMock;
     private readonly UpdateGuildHandler _handler;
 
     public UpdateGuildHandlerTests()
@@ -34,6 +35,7 @@ public sealed class UpdateGuildHandlerTests
         _objectStorageServiceMock = new Mock<IObjectStorageService>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
+        _guildNotifierMock = new Mock<IGuildNotifier>();
 
         _transactionMock = _unitOfWorkMock.SetupTransactionMock();
 
@@ -43,7 +45,8 @@ public sealed class UpdateGuildHandlerTests
                 _uploadedFileRepositoryMock.Object,
                 _objectStorageServiceMock.Object,
                 NullLogger<UploadedFileCleanupService>.Instance),
-            _unitOfWorkMock.Object);
+            _unitOfWorkMock.Object,
+            _guildNotifierMock.Object);
     }
 
     [Fact]
@@ -245,6 +248,56 @@ public sealed class UpdateGuildHandlerTests
         _objectStorageServiceMock.Verify(
             x => x.DeleteIfExistsAsync(oldUploadedFile.StorageKey, It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenGuildUpdated_ShouldCallNotifyGuildUpdatedAsync()
+    {
+        var guild = ApplicationTestBuilders.CreateGuild();
+        var ownerId = guild.OwnerUserId;
+
+        _guildRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(guild.Id, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
+
+        _guildNotifierMock
+            .Setup(x => x.NotifyGuildUpdatedAsync(It.IsAny<GuildUpdatedNotification>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var response = await _handler.HandleAsync(
+            new UpdateGuildInput(guild.Id, "Updated Name", null, null, null, null, true, false, false, false, false),
+            ownerId);
+
+        response.Success.Should().BeTrue();
+
+        _guildNotifierMock.Verify(
+            x => x.NotifyGuildUpdatedAsync(
+                It.Is<GuildUpdatedNotification>(n =>
+                    n.GuildId == guild.Id
+                    && n.Name == "Updated Name"
+                    && n.IconFileId == null),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenNoFieldsSet_ShouldNotCallNotifyGuildUpdatedAsync()
+    {
+        var guild = ApplicationTestBuilders.CreateGuild();
+        var ownerId = guild.OwnerUserId;
+
+        _guildRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(guild.Id, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
+
+        var response = await _handler.HandleAsync(
+            new UpdateGuildInput(guild.Id, null, null, null, null, null, false, false, false, false, false),
+            ownerId);
+
+        response.Success.Should().BeTrue();
+        _guildNotifierMock.Verify(
+            x => x.NotifyGuildUpdatedAsync(It.IsAny<GuildUpdatedNotification>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
 }

--- a/tests/Harmonie.Application.Tests/Uploads/DeleteGuildIconHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Uploads/DeleteGuildIconHandlerTests.cs
@@ -52,7 +52,8 @@ public sealed class DeleteGuildIconHandlerTests
                 _objectStorageServiceMock.Object,
                 NullLogger<UploadedFileCleanupService>.Instance),
             _unitOfWorkMock.Object,
-            _guildNotifierMock.Object);
+            _guildNotifierMock.Object,
+            NullLogger<DeleteGuildIconHandler>.Instance);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Uploads/DeleteGuildIconHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Uploads/DeleteGuildIconHandlerTests.cs
@@ -25,6 +25,7 @@ public sealed class DeleteGuildIconHandlerTests
     private readonly Mock<IObjectStorageService> _objectStorageServiceMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly Mock<IGuildNotifier> _guildNotifierMock;
     private readonly DeleteGuildIconHandler _handler;
 
     public DeleteGuildIconHandlerTests()
@@ -34,6 +35,7 @@ public sealed class DeleteGuildIconHandlerTests
         _objectStorageServiceMock = new Mock<IObjectStorageService>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
+        _guildNotifierMock = new Mock<IGuildNotifier>();
 
         _unitOfWorkMock
             .Setup(x => x.BeginAsync(It.IsAny<CancellationToken>()))
@@ -49,7 +51,8 @@ public sealed class DeleteGuildIconHandlerTests
                 _uploadedFileRepositoryMock.Object,
                 _objectStorageServiceMock.Object,
                 NullLogger<UploadedFileCleanupService>.Instance),
-            _unitOfWorkMock.Object);
+            _unitOfWorkMock.Object,
+            _guildNotifierMock.Object);
     }
 
     [Fact]
@@ -158,6 +161,45 @@ public sealed class DeleteGuildIconHandlerTests
         _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
         _uploadedFileRepositoryMock.Verify(
             x => x.DeleteAsync(iconFileId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenIconDeleted_ShouldCallNotifyGuildUpdatedAsyncWithNullIconFileId()
+    {
+        var iconFileId = UploadedFileId.From(Guid.Parse("08f8d69f-5b34-4037-8fb0-ccf6d98af75d"));
+        var guild = ApplicationTestBuilders.CreateGuild(iconFileId: iconFileId);
+        var ownerId = guild.OwnerUserId;
+        var uploadedFile = ApplicationTestBuilders.CreateUploadedFile(
+            id: iconFileId,
+            fileName: "guild-icon.png",
+            contentType: "image/png",
+            sizeBytes: 512,
+            storageKey: "guild-icons/icon.png",
+            purpose: UploadPurpose.GuildIcon);
+
+        _guildRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(guild.Id, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
+
+        _uploadedFileRepositoryMock
+            .Setup(x => x.GetByIdAsync(iconFileId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(uploadedFile);
+
+        _guildNotifierMock
+            .Setup(x => x.NotifyGuildUpdatedAsync(It.IsAny<GuildUpdatedNotification>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var response = await _handler.HandleAsync(new DeleteGuildIconInput(guild.Id), ownerId);
+
+        response.Success.Should().BeTrue();
+
+        _guildNotifierMock.Verify(
+            x => x.NotifyGuildUpdatedAsync(
+                It.Is<GuildUpdatedNotification>(n =>
+                    n.GuildId == guild.Id
+                    && n.IconFileId == null),
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 


### PR DESCRIPTION
## Summary
- Add `NotifyGuildUpdatedAsync` to `IGuildNotifier` with a `GuildUpdatedNotification(GuildId, Name, IconFileId?)` payload
- Call it from `UpdateGuildHandler` (after commit, only when at least one field is updated) and `DeleteGuildIconHandler` (after icon deletion, with `IconFileId = null`)
- Broadcast `GuildUpdated` event to the `guild:{guildId}` SignalR group

## Test plan
- [ ] Unit tests: `UpdateGuildHandlerTests` — notification sent when fields updated, not sent when no fields set
- [ ] Unit tests: `DeleteGuildIconHandlerTests` — notification sent with `IconFileId = null`
- [ ] Integration test: `SignalRGuildHubTests.GuildUpdated_WhenMemberConnected_ShouldReceiveEvent`

Closes #289