### PR TITLE
feat: send SignalR notification when a user updates their profile (#290)

### DIFF
--- a/src/Harmonie.API/Configuration/RealTimeConfiguration.cs
+++ b/src/Harmonie.API/Configuration/RealTimeConfiguration.cs
@@ -47,6 +47,7 @@ public static class RealTimeConfiguration
         services.AddScoped<IVoicePresenceNotifier, SignalRVoicePresenceNotifier>();
         services.AddScoped<IConversationMessageNotifier, SignalRConversationMessageNotifier>();
         services.AddScoped<IUserPresenceNotifier, SignalRUserPresenceNotifier>();
+        services.AddScoped<IUserProfileNotifier, SignalRUserProfileNotifier>();
         services.AddScoped<IReactionNotifier, SignalRReactionNotifier>();
         services.AddSingleton<IConnectionTracker, ConnectionTracker>();
         services.AddScoped<IRealtimeGroupManager, SignalRRealtimeGroupManager>();

--- a/src/Harmonie.API/RealTime/Common/RealtimeHubDocumentation.cs
+++ b/src/Harmonie.API/RealTime/Common/RealtimeHubDocumentation.cs
@@ -155,6 +155,11 @@ public class RealtimeHubDocumentation
         Summary = "Received when a user changes their presence status. Invisible users appear as 'offline'.")]
     public void OnUserPresenceChanged() { }
 
+    [Channel("hubs/realtime/UserProfileUpdated")]
+    [SubscribeOperation(typeof(UserProfileUpdatedEvent),
+        Summary = "Received when a user updates their display name or avatar. Broadcast to all guild members and conversation participants who share a guild or conversation with the updated user.")]
+    public void OnUserProfileUpdated() { }
+
     [Channel("hubs/realtime/ReactionAdded")]
     [SubscribeOperation(typeof(ReactionAddedEvent),
         Summary = "Received when a user adds an emoji reaction to a message (channel or conversation).")]

--- a/src/Harmonie.API/RealTime/Users/SignalRUserProfileNotifier.cs
+++ b/src/Harmonie.API/RealTime/Users/SignalRUserProfileNotifier.cs
@@ -1,0 +1,45 @@
+using Harmonie.API.RealTime.Common;
+using Harmonie.Application.Interfaces.Users;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Harmonie.API.RealTime.Users;
+
+public sealed class SignalRUserProfileNotifier : IUserProfileNotifier
+{
+    private readonly IHubContext<RealtimeHub> _hubContext;
+
+    public SignalRUserProfileNotifier(IHubContext<RealtimeHub> hubContext)
+    {
+        _hubContext = hubContext;
+    }
+
+    public async Task NotifyProfileUpdatedAsync(
+        UserProfileUpdatedNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var payload = new UserProfileUpdatedEvent(
+            UserId: notification.UserId.Value,
+            DisplayName: notification.DisplayName,
+            AvatarFileId: notification.AvatarFileId?.Value);
+
+        var broadcastTasks = notification.GuildIds
+            .Select(guildId =>
+                _hubContext.Clients
+                    .Group(RealtimeHub.GetGuildGroupName(guildId))
+                    .SendAsync("UserProfileUpdated", payload, cancellationToken))
+            .Concat(notification.ConversationIds
+                .Select(conversationId =>
+                    _hubContext.Clients
+                        .Group(RealtimeHub.GetConversationGroupName(conversationId))
+                        .SendAsync("UserProfileUpdated", payload, cancellationToken)));
+
+        await Task.WhenAll(broadcastTasks);
+    }
+}
+
+public sealed record UserProfileUpdatedEvent(
+    Guid UserId,
+    string? DisplayName,
+    Guid? AvatarFileId);

--- a/src/Harmonie.Application/Features/Users/DeleteMyAvatar/DeleteMyAvatarHandler.cs
+++ b/src/Harmonie.Application/Features/Users/DeleteMyAvatar/DeleteMyAvatarHandler.cs
@@ -80,14 +80,11 @@ public sealed class DeleteMyAvatarHandler : IAuthenticatedHandler<Unit, bool>
 
         await _uploadedFileCleanupService.DeleteIfExistsAsync(previousAvatarFileId, cancellationToken);
 
-        var notificationContexts = await _userRepository.GetUserNotificationContextAsync(
+        var notificationContext = await _userRepository.GetUserNotificationContextAsync(
             currentUserId, cancellationToken);
 
-        var firstContext = notificationContexts.FirstOrDefault();
-        var guildIds = (firstContext?.GuildIds ?? Array.Empty<Guid>())
-            .Select(id => GuildId.From(id)).ToArray();
-        var conversationIds = (firstContext?.ConversationIds ?? Array.Empty<Guid>())
-            .Select(id => ConversationId.From(id)).ToArray();
+        var guildIds = notificationContext.GuildIds.Select(id => GuildId.From(id)).ToArray();
+        var conversationIds = notificationContext.ConversationIds.Select(id => ConversationId.From(id)).ToArray();
 
         await BestEffortNotificationHelper.TryNotifyAsync(
             ct => _userProfileNotifier.NotifyProfileUpdatedAsync(

--- a/src/Harmonie.Application/Features/Users/DeleteMyAvatar/DeleteMyAvatarHandler.cs
+++ b/src/Harmonie.Application/Features/Users/DeleteMyAvatar/DeleteMyAvatarHandler.cs
@@ -1,8 +1,11 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging;
 
 namespace Harmonie.Application.Features.Users.DeleteMyAvatar;
 
@@ -11,15 +14,27 @@ public sealed class DeleteMyAvatarHandler : IAuthenticatedHandler<Unit, bool>
     private readonly IUserRepository _userRepository;
     private readonly UploadedFileCleanupService _uploadedFileCleanupService;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IGuildMemberRepository _guildMemberRepository;
+    private readonly IConversationRepository _conversationRepository;
+    private readonly IUserProfileNotifier _userProfileNotifier;
+    private readonly ILogger<DeleteMyAvatarHandler> _logger;
 
     public DeleteMyAvatarHandler(
         IUserRepository userRepository,
         UploadedFileCleanupService uploadedFileCleanupService,
-        IUnitOfWork unitOfWork)
+        IUnitOfWork unitOfWork,
+        IGuildMemberRepository guildMemberRepository,
+        IConversationRepository conversationRepository,
+        IUserProfileNotifier userProfileNotifier,
+        ILogger<DeleteMyAvatarHandler> logger)
     {
         _userRepository = userRepository;
         _uploadedFileCleanupService = uploadedFileCleanupService;
         _unitOfWork = unitOfWork;
+        _guildMemberRepository = guildMemberRepository;
+        _conversationRepository = conversationRepository;
+        _userProfileNotifier = userProfileNotifier;
+        _logger = logger;
     }
 
     public async Task<ApplicationResponse<bool>> HandleAsync(
@@ -70,6 +85,25 @@ public sealed class DeleteMyAvatarHandler : IAuthenticatedHandler<Unit, bool>
         }
 
         await _uploadedFileCleanupService.DeleteIfExistsAsync(previousAvatarFileId, cancellationToken);
+
+        var memberships = await _guildMemberRepository.GetUserGuildMembershipsAsync(
+            currentUserId, cancellationToken);
+        var conversations = await _conversationRepository.GetUserConversationsAsync(
+            currentUserId, cancellationToken);
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            ct => _userProfileNotifier.NotifyProfileUpdatedAsync(
+                new UserProfileUpdatedNotification(
+                    UserId: user.Id,
+                    DisplayName: user.DisplayName,
+                    AvatarFileId: user.AvatarFileId,
+                    GuildIds: memberships.Select(m => m.Guild.Id).ToList(),
+                    ConversationIds: conversations.Select(c => c.ConversationId).ToList()),
+                ct),
+            TimeSpan.FromSeconds(5),
+            _logger,
+            "Failed to notify profile update for user {UserId}",
+            user.Id);
 
         return ApplicationResponse<bool>.Ok(true);
     }

--- a/src/Harmonie.Application/Features/Users/DeleteMyAvatar/DeleteMyAvatarHandler.cs
+++ b/src/Harmonie.Application/Features/Users/DeleteMyAvatar/DeleteMyAvatarHandler.cs
@@ -1,9 +1,9 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Interfaces.Common;
-using Harmonie.Application.Interfaces.Conversations;
-using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Users;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Users;
 using Microsoft.Extensions.Logging;
 
@@ -14,8 +14,6 @@ public sealed class DeleteMyAvatarHandler : IAuthenticatedHandler<Unit, bool>
     private readonly IUserRepository _userRepository;
     private readonly UploadedFileCleanupService _uploadedFileCleanupService;
     private readonly IUnitOfWork _unitOfWork;
-    private readonly IGuildMemberRepository _guildMemberRepository;
-    private readonly IConversationRepository _conversationRepository;
     private readonly IUserProfileNotifier _userProfileNotifier;
     private readonly ILogger<DeleteMyAvatarHandler> _logger;
 
@@ -23,16 +21,12 @@ public sealed class DeleteMyAvatarHandler : IAuthenticatedHandler<Unit, bool>
         IUserRepository userRepository,
         UploadedFileCleanupService uploadedFileCleanupService,
         IUnitOfWork unitOfWork,
-        IGuildMemberRepository guildMemberRepository,
-        IConversationRepository conversationRepository,
         IUserProfileNotifier userProfileNotifier,
         ILogger<DeleteMyAvatarHandler> logger)
     {
         _userRepository = userRepository;
         _uploadedFileCleanupService = uploadedFileCleanupService;
         _unitOfWork = unitOfWork;
-        _guildMemberRepository = guildMemberRepository;
-        _conversationRepository = conversationRepository;
         _userProfileNotifier = userProfileNotifier;
         _logger = logger;
     }
@@ -86,10 +80,14 @@ public sealed class DeleteMyAvatarHandler : IAuthenticatedHandler<Unit, bool>
 
         await _uploadedFileCleanupService.DeleteIfExistsAsync(previousAvatarFileId, cancellationToken);
 
-        var memberships = await _guildMemberRepository.GetUserGuildMembershipsAsync(
+        var notificationContexts = await _userRepository.GetUserNotificationContextAsync(
             currentUserId, cancellationToken);
-        var conversations = await _conversationRepository.GetUserConversationsAsync(
-            currentUserId, cancellationToken);
+
+        var firstContext = notificationContexts.FirstOrDefault();
+        var guildIds = (firstContext?.GuildIds ?? Array.Empty<Guid>())
+            .Select(id => GuildId.From(id)).ToArray();
+        var conversationIds = (firstContext?.ConversationIds ?? Array.Empty<Guid>())
+            .Select(id => ConversationId.From(id)).ToArray();
 
         await BestEffortNotificationHelper.TryNotifyAsync(
             ct => _userProfileNotifier.NotifyProfileUpdatedAsync(
@@ -97,8 +95,8 @@ public sealed class DeleteMyAvatarHandler : IAuthenticatedHandler<Unit, bool>
                     UserId: user.Id,
                     DisplayName: user.DisplayName,
                     AvatarFileId: user.AvatarFileId,
-                    GuildIds: memberships.Select(m => m.Guild.Id).ToList(),
-                    ConversationIds: conversations.Select(c => c.ConversationId).ToList()),
+                    GuildIds: guildIds,
+                    ConversationIds: conversationIds),
                 ct),
             TimeSpan.FromSeconds(5),
             _logger,

--- a/src/Harmonie.Application/Features/Users/DeleteMyAvatar/DeleteMyAvatarHandler.cs
+++ b/src/Harmonie.Application/Features/Users/DeleteMyAvatar/DeleteMyAvatarHandler.cs
@@ -83,17 +83,14 @@ public sealed class DeleteMyAvatarHandler : IAuthenticatedHandler<Unit, bool>
         var notificationContext = await _userRepository.GetUserNotificationContextAsync(
             currentUserId, cancellationToken);
 
-        var guildIds = notificationContext.GuildIds.Select(id => GuildId.From(id)).ToArray();
-        var conversationIds = notificationContext.ConversationIds.Select(id => ConversationId.From(id)).ToArray();
-
         await BestEffortNotificationHelper.TryNotifyAsync(
             ct => _userProfileNotifier.NotifyProfileUpdatedAsync(
                 new UserProfileUpdatedNotification(
                     UserId: user.Id,
                     DisplayName: user.DisplayName,
                     AvatarFileId: user.AvatarFileId,
-                    GuildIds: guildIds,
-                    ConversationIds: conversationIds),
+                    GuildIds: notificationContext.GuildIds,
+                    ConversationIds: notificationContext.ConversationIds),
                 ct),
             TimeSpan.FromSeconds(5),
             _logger,

--- a/src/Harmonie.Application/Features/Users/UpdateMyProfile/UpdateMyProfileHandler.cs
+++ b/src/Harmonie.Application/Features/Users/UpdateMyProfile/UpdateMyProfileHandler.cs
@@ -145,14 +145,11 @@ public sealed class UpdateMyProfileHandler
 
         if (shouldNotifyProfile)
         {
-            var notificationContexts = await _userRepository.GetUserNotificationContextAsync(
+            var notificationContext = await _userRepository.GetUserNotificationContextAsync(
                 currentUserId, cancellationToken);
 
-            var firstContext = notificationContexts.FirstOrDefault();
-            var guildIds = (firstContext?.GuildIds ?? Array.Empty<Guid>())
-                .Select(id => GuildId.From(id)).ToArray();
-            var conversationIds = (firstContext?.ConversationIds ?? Array.Empty<Guid>())
-                .Select(id => ConversationId.From(id)).ToArray();
+            var guildIds = notificationContext.GuildIds.Select(id => GuildId.From(id)).ToArray();
+            var conversationIds = notificationContext.ConversationIds.Select(id => ConversationId.From(id)).ToArray();
 
             await BestEffortNotificationHelper.TryNotifyAsync(
                 ct => _userProfileNotifier.NotifyProfileUpdatedAsync(

--- a/src/Harmonie.Application/Features/Users/UpdateMyProfile/UpdateMyProfileHandler.cs
+++ b/src/Harmonie.Application/Features/Users/UpdateMyProfile/UpdateMyProfileHandler.cs
@@ -1,10 +1,10 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Features.Users;
-using Harmonie.Application.Interfaces.Conversations;
-using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Domain.Common;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
 using Microsoft.Extensions.Logging;
@@ -16,23 +16,17 @@ public sealed class UpdateMyProfileHandler
 {
     private readonly IUserRepository _userRepository;
     private readonly UploadedFileCleanupService _uploadedFileCleanupService;
-    private readonly IGuildMemberRepository _guildMemberRepository;
-    private readonly IConversationRepository _conversationRepository;
     private readonly IUserProfileNotifier _userProfileNotifier;
     private readonly ILogger<UpdateMyProfileHandler> _logger;
 
     public UpdateMyProfileHandler(
         IUserRepository userRepository,
         UploadedFileCleanupService uploadedFileCleanupService,
-        IGuildMemberRepository guildMemberRepository,
-        IConversationRepository conversationRepository,
         IUserProfileNotifier userProfileNotifier,
         ILogger<UpdateMyProfileHandler> logger)
     {
         _userRepository = userRepository;
         _uploadedFileCleanupService = uploadedFileCleanupService;
-        _guildMemberRepository = guildMemberRepository;
-        _conversationRepository = conversationRepository;
         _userProfileNotifier = userProfileNotifier;
         _logger = logger;
     }
@@ -151,10 +145,14 @@ public sealed class UpdateMyProfileHandler
 
         if (shouldNotifyProfile)
         {
-            var memberships = await _guildMemberRepository.GetUserGuildMembershipsAsync(
+            var notificationContexts = await _userRepository.GetUserNotificationContextAsync(
                 currentUserId, cancellationToken);
-            var conversations = await _conversationRepository.GetUserConversationsAsync(
-                currentUserId, cancellationToken);
+
+            var firstContext = notificationContexts.FirstOrDefault();
+            var guildIds = (firstContext?.GuildIds ?? Array.Empty<Guid>())
+                .Select(id => GuildId.From(id)).ToArray();
+            var conversationIds = (firstContext?.ConversationIds ?? Array.Empty<Guid>())
+                .Select(id => ConversationId.From(id)).ToArray();
 
             await BestEffortNotificationHelper.TryNotifyAsync(
                 ct => _userProfileNotifier.NotifyProfileUpdatedAsync(
@@ -162,8 +160,8 @@ public sealed class UpdateMyProfileHandler
                         UserId: user.Id,
                         DisplayName: user.DisplayName,
                         AvatarFileId: user.AvatarFileId,
-                        GuildIds: memberships.Select(m => m.Guild.Id).ToList(),
-                        ConversationIds: conversations.Select(c => c.ConversationId).ToList()),
+                        GuildIds: guildIds,
+                        ConversationIds: conversationIds),
                     ct),
                 TimeSpan.FromSeconds(5),
                 _logger,

--- a/src/Harmonie.Application/Features/Users/UpdateMyProfile/UpdateMyProfileHandler.cs
+++ b/src/Harmonie.Application/Features/Users/UpdateMyProfile/UpdateMyProfileHandler.cs
@@ -148,17 +148,14 @@ public sealed class UpdateMyProfileHandler
             var notificationContext = await _userRepository.GetUserNotificationContextAsync(
                 currentUserId, cancellationToken);
 
-            var guildIds = notificationContext.GuildIds.Select(id => GuildId.From(id)).ToArray();
-            var conversationIds = notificationContext.ConversationIds.Select(id => ConversationId.From(id)).ToArray();
-
             await BestEffortNotificationHelper.TryNotifyAsync(
                 ct => _userProfileNotifier.NotifyProfileUpdatedAsync(
                     new UserProfileUpdatedNotification(
                         UserId: user.Id,
                         DisplayName: user.DisplayName,
                         AvatarFileId: user.AvatarFileId,
-                        GuildIds: guildIds,
-                        ConversationIds: conversationIds),
+                        GuildIds: notificationContext.GuildIds,
+                        ConversationIds: notificationContext.ConversationIds),
                     ct),
                 TimeSpan.FromSeconds(5),
                 _logger,

--- a/src/Harmonie.Application/Features/Users/UpdateMyProfile/UpdateMyProfileHandler.cs
+++ b/src/Harmonie.Application/Features/Users/UpdateMyProfile/UpdateMyProfileHandler.cs
@@ -1,10 +1,13 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Features.Users;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Domain.Common;
 using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging;
 
 namespace Harmonie.Application.Features.Users.UpdateMyProfile;
 
@@ -13,13 +16,25 @@ public sealed class UpdateMyProfileHandler
 {
     private readonly IUserRepository _userRepository;
     private readonly UploadedFileCleanupService _uploadedFileCleanupService;
+    private readonly IGuildMemberRepository _guildMemberRepository;
+    private readonly IConversationRepository _conversationRepository;
+    private readonly IUserProfileNotifier _userProfileNotifier;
+    private readonly ILogger<UpdateMyProfileHandler> _logger;
 
     public UpdateMyProfileHandler(
         IUserRepository userRepository,
-        UploadedFileCleanupService uploadedFileCleanupService)
+        UploadedFileCleanupService uploadedFileCleanupService,
+        IGuildMemberRepository guildMemberRepository,
+        IConversationRepository conversationRepository,
+        IUserProfileNotifier userProfileNotifier,
+        ILogger<UpdateMyProfileHandler> logger)
     {
         _userRepository = userRepository;
         _uploadedFileCleanupService = uploadedFileCleanupService;
+        _guildMemberRepository = guildMemberRepository;
+        _conversationRepository = conversationRepository;
+        _userProfileNotifier = userProfileNotifier;
+        _logger = logger;
     }
 
     public async Task<ApplicationResponse<UpdateMyProfileResponse>> HandleAsync(
@@ -104,6 +119,7 @@ public sealed class UpdateMyProfileHandler
         var anyFieldSet = request.DisplayNameIsSet || request.BioIsSet || request.AvatarFileIdIsSet
             || request.AvatarColorIsSet || request.AvatarIconIsSet || request.AvatarBgIsSet
             || request.ThemeIsSet || request.LanguageIsSet;
+        var shouldNotifyProfile = request.DisplayNameIsSet || request.BioIsSet || request.AvatarFileIdIsSet;
         var shouldDeletePreviousAvatar = request.AvatarFileIdIsSet
             && previousAvatarFileId is not null
             && previousAvatarFileId != user.AvatarFileId;
@@ -131,6 +147,28 @@ public sealed class UpdateMyProfileHandler
                 UpdatedAtUtc: user.UpdatedAtUtc);
 
             await _userRepository.UpdateProfileAsync(parameters, cancellationToken);
+        }
+
+        if (shouldNotifyProfile)
+        {
+            var memberships = await _guildMemberRepository.GetUserGuildMembershipsAsync(
+                currentUserId, cancellationToken);
+            var conversations = await _conversationRepository.GetUserConversationsAsync(
+                currentUserId, cancellationToken);
+
+            await BestEffortNotificationHelper.TryNotifyAsync(
+                ct => _userProfileNotifier.NotifyProfileUpdatedAsync(
+                    new UserProfileUpdatedNotification(
+                        UserId: user.Id,
+                        DisplayName: user.DisplayName,
+                        AvatarFileId: user.AvatarFileId,
+                        GuildIds: memberships.Select(m => m.Guild.Id).ToList(),
+                        ConversationIds: conversations.Select(c => c.ConversationId).ToList()),
+                    ct),
+                TimeSpan.FromSeconds(5),
+                _logger,
+                "Failed to notify profile update for user {UserId}",
+                user.Id);
         }
 
         if (shouldDeletePreviousAvatar)

--- a/src/Harmonie.Application/Features/Users/UploadMyAvatar/UploadMyAvatarHandler.cs
+++ b/src/Harmonie.Application/Features/Users/UploadMyAvatar/UploadMyAvatarHandler.cs
@@ -131,14 +131,11 @@ public sealed class UploadMyAvatarHandler
         if (previousAvatarFileId is not null && previousAvatarFileId != uploadedFileResult.Value.Id)
             await _uploadedFileCleanupService.DeleteIfExistsAsync(previousAvatarFileId, cancellationToken);
 
-        var notificationContexts = await _userRepository.GetUserNotificationContextAsync(
+        var notificationContext = await _userRepository.GetUserNotificationContextAsync(
             currentUserId, cancellationToken);
 
-        var firstContext = notificationContexts.FirstOrDefault();
-        var guildIds = (firstContext?.GuildIds ?? Array.Empty<Guid>())
-            .Select(id => GuildId.From(id)).ToArray();
-        var conversationIds = (firstContext?.ConversationIds ?? Array.Empty<Guid>())
-            .Select(id => ConversationId.From(id)).ToArray();
+        var guildIds = notificationContext.GuildIds.Select(id => GuildId.From(id)).ToArray();
+        var conversationIds = notificationContext.ConversationIds.Select(id => ConversationId.From(id)).ToArray();
 
         await BestEffortNotificationHelper.TryNotifyAsync(
             ct => _userProfileNotifier.NotifyProfileUpdatedAsync(

--- a/src/Harmonie.Application/Features/Users/UploadMyAvatar/UploadMyAvatarHandler.cs
+++ b/src/Harmonie.Application/Features/Users/UploadMyAvatar/UploadMyAvatarHandler.cs
@@ -134,17 +134,14 @@ public sealed class UploadMyAvatarHandler
         var notificationContext = await _userRepository.GetUserNotificationContextAsync(
             currentUserId, cancellationToken);
 
-        var guildIds = notificationContext.GuildIds.Select(id => GuildId.From(id)).ToArray();
-        var conversationIds = notificationContext.ConversationIds.Select(id => ConversationId.From(id)).ToArray();
-
         await BestEffortNotificationHelper.TryNotifyAsync(
             ct => _userProfileNotifier.NotifyProfileUpdatedAsync(
                 new UserProfileUpdatedNotification(
                     UserId: user.Id,
                     DisplayName: user.DisplayName,
                     AvatarFileId: user.AvatarFileId,
-                    GuildIds: guildIds,
-                    ConversationIds: conversationIds),
+                    GuildIds: notificationContext.GuildIds,
+                    ConversationIds: notificationContext.ConversationIds),
                 ct),
             TimeSpan.FromSeconds(5),
             _logger,

--- a/src/Harmonie.Application/Features/Users/UploadMyAvatar/UploadMyAvatarHandler.cs
+++ b/src/Harmonie.Application/Features/Users/UploadMyAvatar/UploadMyAvatarHandler.cs
@@ -1,6 +1,8 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Domain.Entities.Uploads;
@@ -24,6 +26,9 @@ public sealed class UploadMyAvatarHandler
     private readonly IObjectStorageService _objectStorageService;
     private readonly UploadedFileCleanupService _uploadedFileCleanupService;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IGuildMemberRepository _guildMemberRepository;
+    private readonly IConversationRepository _conversationRepository;
+    private readonly IUserProfileNotifier _userProfileNotifier;
     private readonly ILogger<UploadMyAvatarHandler> _logger;
 
     public UploadMyAvatarHandler(
@@ -32,6 +37,9 @@ public sealed class UploadMyAvatarHandler
         IObjectStorageService objectStorageService,
         UploadedFileCleanupService uploadedFileCleanupService,
         IUnitOfWork unitOfWork,
+        IGuildMemberRepository guildMemberRepository,
+        IConversationRepository conversationRepository,
+        IUserProfileNotifier userProfileNotifier,
         ILogger<UploadMyAvatarHandler> logger)
     {
         _userRepository = userRepository;
@@ -39,6 +47,9 @@ public sealed class UploadMyAvatarHandler
         _objectStorageService = objectStorageService;
         _uploadedFileCleanupService = uploadedFileCleanupService;
         _unitOfWork = unitOfWork;
+        _guildMemberRepository = guildMemberRepository;
+        _conversationRepository = conversationRepository;
+        _userProfileNotifier = userProfileNotifier;
         _logger = logger;
     }
 
@@ -125,6 +136,25 @@ public sealed class UploadMyAvatarHandler
 
         if (previousAvatarFileId is not null && previousAvatarFileId != uploadedFileResult.Value.Id)
             await _uploadedFileCleanupService.DeleteIfExistsAsync(previousAvatarFileId, cancellationToken);
+
+        var memberships = await _guildMemberRepository.GetUserGuildMembershipsAsync(
+            currentUserId, cancellationToken);
+        var conversations = await _conversationRepository.GetUserConversationsAsync(
+            currentUserId, cancellationToken);
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            ct => _userProfileNotifier.NotifyProfileUpdatedAsync(
+                new UserProfileUpdatedNotification(
+                    UserId: user.Id,
+                    DisplayName: user.DisplayName,
+                    AvatarFileId: user.AvatarFileId,
+                    GuildIds: memberships.Select(m => m.Guild.Id).ToList(),
+                    ConversationIds: conversations.Select(c => c.ConversationId).ToList()),
+                ct),
+            TimeSpan.FromSeconds(5),
+            _logger,
+            "Failed to notify profile update for user {UserId}",
+            user.Id);
 
         return ApplicationResponse<UploadMyAvatarResponse>.Ok(
             new UploadMyAvatarResponse(uploadedFileResult.Value.Id.Value));

--- a/src/Harmonie.Application/Features/Users/UploadMyAvatar/UploadMyAvatarHandler.cs
+++ b/src/Harmonie.Application/Features/Users/UploadMyAvatar/UploadMyAvatarHandler.cs
@@ -1,12 +1,12 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Interfaces.Common;
-using Harmonie.Application.Interfaces.Conversations;
-using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Domain.Entities.Uploads;
 using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Users;
 using Microsoft.Extensions.Logging;
 using SixLabors.ImageSharp;
@@ -26,8 +26,6 @@ public sealed class UploadMyAvatarHandler
     private readonly IObjectStorageService _objectStorageService;
     private readonly UploadedFileCleanupService _uploadedFileCleanupService;
     private readonly IUnitOfWork _unitOfWork;
-    private readonly IGuildMemberRepository _guildMemberRepository;
-    private readonly IConversationRepository _conversationRepository;
     private readonly IUserProfileNotifier _userProfileNotifier;
     private readonly ILogger<UploadMyAvatarHandler> _logger;
 
@@ -37,8 +35,6 @@ public sealed class UploadMyAvatarHandler
         IObjectStorageService objectStorageService,
         UploadedFileCleanupService uploadedFileCleanupService,
         IUnitOfWork unitOfWork,
-        IGuildMemberRepository guildMemberRepository,
-        IConversationRepository conversationRepository,
         IUserProfileNotifier userProfileNotifier,
         ILogger<UploadMyAvatarHandler> logger)
     {
@@ -47,8 +43,6 @@ public sealed class UploadMyAvatarHandler
         _objectStorageService = objectStorageService;
         _uploadedFileCleanupService = uploadedFileCleanupService;
         _unitOfWork = unitOfWork;
-        _guildMemberRepository = guildMemberRepository;
-        _conversationRepository = conversationRepository;
         _userProfileNotifier = userProfileNotifier;
         _logger = logger;
     }
@@ -137,10 +131,14 @@ public sealed class UploadMyAvatarHandler
         if (previousAvatarFileId is not null && previousAvatarFileId != uploadedFileResult.Value.Id)
             await _uploadedFileCleanupService.DeleteIfExistsAsync(previousAvatarFileId, cancellationToken);
 
-        var memberships = await _guildMemberRepository.GetUserGuildMembershipsAsync(
+        var notificationContexts = await _userRepository.GetUserNotificationContextAsync(
             currentUserId, cancellationToken);
-        var conversations = await _conversationRepository.GetUserConversationsAsync(
-            currentUserId, cancellationToken);
+
+        var firstContext = notificationContexts.FirstOrDefault();
+        var guildIds = (firstContext?.GuildIds ?? Array.Empty<Guid>())
+            .Select(id => GuildId.From(id)).ToArray();
+        var conversationIds = (firstContext?.ConversationIds ?? Array.Empty<Guid>())
+            .Select(id => ConversationId.From(id)).ToArray();
 
         await BestEffortNotificationHelper.TryNotifyAsync(
             ct => _userProfileNotifier.NotifyProfileUpdatedAsync(
@@ -148,8 +146,8 @@ public sealed class UploadMyAvatarHandler
                     UserId: user.Id,
                     DisplayName: user.DisplayName,
                     AvatarFileId: user.AvatarFileId,
-                    GuildIds: memberships.Select(m => m.Guild.Id).ToList(),
-                    ConversationIds: conversations.Select(c => c.ConversationId).ToList()),
+                    GuildIds: guildIds,
+                    ConversationIds: conversationIds),
                 ct),
             TimeSpan.FromSeconds(5),
             _logger,

--- a/src/Harmonie.Application/Interfaces/Users/IUserProfileNotifier.cs
+++ b/src/Harmonie.Application/Interfaces/Users/IUserProfileNotifier.cs
@@ -1,0 +1,20 @@
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Guilds;
+using Harmonie.Domain.ValueObjects.Uploads;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Interfaces.Users;
+
+public interface IUserProfileNotifier
+{
+    Task NotifyProfileUpdatedAsync(
+        UserProfileUpdatedNotification notification,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record UserProfileUpdatedNotification(
+    UserId UserId,
+    string? DisplayName,
+    UploadedFileId? AvatarFileId,
+    IReadOnlyList<GuildId> GuildIds,
+    IReadOnlyList<ConversationId> ConversationIds);

--- a/src/Harmonie.Application/Interfaces/Users/IUserRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Users/IUserRepository.cs
@@ -105,7 +105,7 @@ public interface IUserRepository
     /// <summary>
     /// Get the notification context for a user (guilds and conversations they belong to).
     /// </summary>
-    Task<IReadOnlyList<UserNotificationContext>> GetUserNotificationContextAsync(
+    Task<UserNotificationContext> GetUserNotificationContextAsync(
         UserId userId,
         CancellationToken cancellationToken = default);
 }

--- a/src/Harmonie.Application/Interfaces/Users/IUserRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Users/IUserRepository.cs
@@ -1,4 +1,5 @@
 using Harmonie.Domain.Entities.Users;
+using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
@@ -111,5 +112,5 @@ public interface IUserRepository
 }
 
 public sealed record UserNotificationContext(
-    IReadOnlyList<Guid> GuildIds,
-    IReadOnlyList<Guid> ConversationIds);
+    IReadOnlyList<GuildId> GuildIds,
+    IReadOnlyList<ConversationId> ConversationIds);

--- a/src/Harmonie.Application/Interfaces/Users/IUserRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Users/IUserRepository.cs
@@ -101,4 +101,15 @@ public interface IUserRepository
     /// Delete a user (soft delete recommended)
     /// </summary>
     Task DeleteAsync(UserId userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get the notification context for a user (guilds and conversations they belong to).
+    /// </summary>
+    Task<IReadOnlyList<UserNotificationContext>> GetUserNotificationContextAsync(
+        UserId userId,
+        CancellationToken cancellationToken = default);
 }
+
+public sealed record UserNotificationContext(
+    IReadOnlyList<Guid> GuildIds,
+    IReadOnlyList<Guid> ConversationIds);

--- a/src/Harmonie.Infrastructure/Persistence/Users/UserRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Users/UserRepository.cs
@@ -362,7 +362,7 @@ public sealed class UserRepository : IUserRepository
         await conn.ExecuteAsync(cmd);
     }
 
-    public async Task<IReadOnlyList<UserNotificationContext>> GetUserNotificationContextAsync(
+  public async Task<UserNotificationContext> GetUserNotificationContextAsync(
         UserId userId,
         CancellationToken ct = default)
     {
@@ -387,6 +387,7 @@ public sealed class UserRepository : IUserRepository
         var conn = await _dbSession.GetOpenConnectionAsync(ct);
         var cmd = new CommandDefinition(
             sql,
+
             new { UserId = userId.Value },
             transaction: _dbSession.Transaction,
             cancellationToken: ct);
@@ -396,7 +397,7 @@ public sealed class UserRepository : IUserRepository
         var guildIds = rows.Select(r => r.GuildId).Where(id => id is not null).Select(id => id!.Value).ToArray();
         var conversationIds = rows.Select(r => r.ConversationId).Where(id => id is not null).Select(id => id!.Value).ToArray();
 
-        return new[] { new UserNotificationContext(guildIds, conversationIds) };
+        return new UserNotificationContext(guildIds, conversationIds);
     }
 
     private static User MapToUser(UserRow userRow)

--- a/src/Harmonie.Infrastructure/Persistence/Users/UserRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Users/UserRepository.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Dapper;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Domain.Entities.Users;
+using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
@@ -384,8 +385,8 @@ public sealed class UserRepository : IUserRepository
             cancellationToken: ct);
 
         using var multi = await conn.QueryMultipleAsync(cmd);
-        var guildIds = (await multi.ReadAsync<Guid>()).ToArray();
-        var conversationIds = (await multi.ReadAsync<Guid>()).ToArray();
+        var guildIds = (await multi.ReadAsync<Guid>()).Select(GuildId.From).ToArray();
+        var conversationIds = (await multi.ReadAsync<Guid>()).Select(ConversationId.From).ToArray();
 
         return new UserNotificationContext(guildIds, conversationIds);
     }

--- a/src/Harmonie.Infrastructure/Persistence/Users/UserRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Users/UserRepository.cs
@@ -362,6 +362,43 @@ public sealed class UserRepository : IUserRepository
         await conn.ExecuteAsync(cmd);
     }
 
+    public async Task<IReadOnlyList<UserNotificationContext>> GetUserNotificationContextAsync(
+        UserId userId,
+        CancellationToken ct = default)
+    {
+        const string sql = """
+            SELECT 
+                gm.user_id AS UserId,
+                gm.guild_id AS GuildId,
+                NULL AS ConversationId
+            FROM guild_members gm
+            WHERE gm.user_id = @UserId
+
+            UNION ALL
+
+            SELECT 
+                cp.user_id AS UserId,
+                NULL AS GuildId,
+                cp.conversation_id AS ConversationId
+            FROM conversation_participants cp
+            WHERE cp.user_id = @UserId
+            """;
+
+        var conn = await _dbSession.GetOpenConnectionAsync(ct);
+        var cmd = new CommandDefinition(
+            sql,
+            new { UserId = userId.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: ct);
+
+        var rows = await conn.QueryAsync<UserNotificationContextRow>(cmd);
+
+        var guildIds = rows.Select(r => r.GuildId).Where(id => id is not null).Select(id => id!.Value).ToArray();
+        var conversationIds = rows.Select(r => r.ConversationId).Where(id => id is not null).Select(id => id!.Value).ToArray();
+
+        return new[] { new UserNotificationContext(guildIds, conversationIds) };
+    }
+
     private static User MapToUser(UserRow userRow)
     {
         var emailResult = Email.Create(userRow.Email);

--- a/src/Harmonie.Infrastructure/Persistence/Users/UserRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Users/UserRepository.cs
@@ -362,40 +362,30 @@ public sealed class UserRepository : IUserRepository
         await conn.ExecuteAsync(cmd);
     }
 
-  public async Task<UserNotificationContext> GetUserNotificationContextAsync(
+    public async Task<UserNotificationContext> GetUserNotificationContextAsync(
         UserId userId,
         CancellationToken ct = default)
     {
         const string sql = """
-            SELECT 
-                gm.user_id AS UserId,
-                gm.guild_id AS GuildId,
-                NULL AS ConversationId
+            SELECT gm.guild_id
             FROM guild_members gm
-            WHERE gm.user_id = @UserId
+            WHERE gm.user_id = @UserId;
 
-            UNION ALL
-
-            SELECT 
-                cp.user_id AS UserId,
-                NULL AS GuildId,
-                cp.conversation_id AS ConversationId
+            SELECT cp.conversation_id
             FROM conversation_participants cp
-            WHERE cp.user_id = @UserId
+            WHERE cp.user_id = @UserId;
             """;
 
         var conn = await _dbSession.GetOpenConnectionAsync(ct);
         var cmd = new CommandDefinition(
             sql,
-
             new { UserId = userId.Value },
             transaction: _dbSession.Transaction,
             cancellationToken: ct);
 
-        var rows = await conn.QueryAsync<UserNotificationContextRow>(cmd);
-
-        var guildIds = rows.Select(r => r.GuildId).Where(id => id is not null).Select(id => id!.Value).ToArray();
-        var conversationIds = rows.Select(r => r.ConversationId).Where(id => id is not null).Select(id => id!.Value).ToArray();
+        using var multi = await conn.QueryMultipleAsync(cmd);
+        var guildIds = (await multi.ReadAsync<Guid>()).ToArray();
+        var conversationIds = (await multi.ReadAsync<Guid>()).ToArray();
 
         return new UserNotificationContext(guildIds, conversationIds);
     }

--- a/src/Harmonie.Infrastructure/Persistence/Users/UserSubscriptionRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Users/UserSubscriptionRepository.cs
@@ -22,29 +22,19 @@ public sealed class UserSubscriptionRepository : IUserSubscriptionRepository
         CancellationToken cancellationToken = default)
     {
         const string sql = """
-                           SELECT 'guild'   AS "Kind",
-                                  g.id      AS "Id1",
-                                  NULL::uuid AS "Id2"
+                           SELECT g.id
                            FROM guild_members gm
                            JOIN guilds g ON g.id = gm.guild_id
-                           WHERE gm.user_id = @UserId
+                           WHERE gm.user_id = @UserId;
 
-                           UNION ALL
-
-                           SELECT 'channel' AS "Kind",
-                                  gc.id     AS "Id1",
-                                  NULL::uuid AS "Id2"
+                           SELECT gc.id
                            FROM guild_members gm
                            JOIN guild_channels gc ON gc.guild_id = gm.guild_id AND gc.type = 1
-                           WHERE gm.user_id = @UserId
+                           WHERE gm.user_id = @UserId;
 
-                           UNION ALL
-
-                           SELECT 'conversation' AS "Kind",
-                                  cp.conversation_id AS "Id1",
-                                  NULL::uuid         AS "Id2"
+                           SELECT cp.conversation_id
                            FROM conversation_participants cp
-                           WHERE cp.user_id = @UserId
+                           WHERE cp.user_id = @UserId;
                            """;
 
         var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
@@ -54,34 +44,11 @@ public sealed class UserSubscriptionRepository : IUserSubscriptionRepository
             transaction: _dbSession.Transaction,
             cancellationToken: cancellationToken);
 
-        var rows = await connection.QueryAsync<SubscriptionRow>(command);
-
-        var guildIds = new List<GuildId>();
-        var channelIds = new List<GuildChannelId>();
-        var conversationIds = new List<ConversationId>();
-
-        foreach (var row in rows)
-        {
-            switch (row.Kind)
-            {
-                case "guild":
-                    guildIds.Add(GuildId.From(row.Id1));
-                    break;
-                case "channel":
-                    channelIds.Add(GuildChannelId.From(row.Id1));
-                    break;
-                case "conversation":
-                    conversationIds.Add(ConversationId.From(row.Id1));
-                    break;
-            }
-        }
+        using var multi = await connection.QueryMultipleAsync(command);
+        var guildIds = (await multi.ReadAsync<Guid>()).Select(GuildId.From).ToArray();
+        var channelIds = (await multi.ReadAsync<Guid>()).Select(GuildChannelId.From).ToArray();
+        var conversationIds = (await multi.ReadAsync<Guid>()).Select(ConversationId.From).ToArray();
 
         return new UserSubscriptions(guildIds, channelIds, conversationIds);
-    }
-
-    private sealed class SubscriptionRow
-    {
-        public string Kind { get; init; } = string.Empty;
-        public Guid Id1 { get; init; }
     }
 }

--- a/src/Harmonie.Infrastructure/Rows/Users/UserNotificationContextRow.cs
+++ b/src/Harmonie.Infrastructure/Rows/Users/UserNotificationContextRow.cs
@@ -1,0 +1,6 @@
+namespace Harmonie.Infrastructure.Rows.Users;
+
+sealed record UserNotificationContextRow(
+    Guid UserId,
+    Guid? GuildId,
+    Guid? ConversationId);

--- a/src/Harmonie.Infrastructure/Rows/Users/UserNotificationContextRow.cs
+++ b/src/Harmonie.Infrastructure/Rows/Users/UserNotificationContextRow.cs
@@ -1,6 +1,0 @@
-namespace Harmonie.Infrastructure.Rows.Users;
-
-sealed record UserNotificationContextRow(
-    Guid UserId,
-    Guid? GuildId,
-    Guid? ConversationId);

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRUserProfileHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRUserProfileHubTests.cs
@@ -58,7 +58,7 @@ public sealed class SignalRUserProfileHubTests : IClassFixture<HarmonieWebApplic
 
         var updateResponse = await _client.SendAuthorizedPatchAsync(
             "/api/users/me",
-            new { displayName = $"Updated-{prefix}", displayNameIsSet = true },
+            new { displayName = $"Updated-{prefix}" },
             updatingUser.AccessToken);
         updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
@@ -107,7 +107,7 @@ public sealed class SignalRUserProfileHubTests : IClassFixture<HarmonieWebApplic
 
         var updateResponse = await _client.SendAuthorizedPatchAsync(
             "/api/users/me",
-            new { theme = "dark", themeIsSet = true },
+            new { theme = "dark" },
             updatingUser.AccessToken);
         updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRUserProfileHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRUserProfileHubTests.cs
@@ -1,0 +1,138 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Harmonie.API.IntegrationTests.Common;
+using Harmonie.Application.Features.Guilds.CreateGuild;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+
+namespace Harmonie.API.IntegrationTests;
+
+public sealed class SignalRUserProfileHubTests : IClassFixture<HarmonieWebApplicationFactory>
+{
+    private readonly HarmonieWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public SignalRUserProfileHubTests(HarmonieWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task UserProfileUpdated_WhenMemberUpdatesDisplayName_GuildMemberShouldReceiveEvent()
+    {
+        var updatingUser = await AuthTestHelper.RegisterAsync(_client);
+        var observer = await AuthTestHelper.RegisterAsync(_client);
+
+        var prefix = Guid.NewGuid().ToString("N")[..8];
+
+        var createGuildResponse = await _client.SendAuthorizedPostAsync(
+            "/api/guilds",
+            new CreateGuildRequest($"Profile Update Guild {prefix}"),
+            updatingUser.AccessToken);
+        createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        createGuildPayload.Should().NotBeNull();
+
+        await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, updatingUser.AccessToken, observer.AccessToken);
+
+        await using var connection = CreateHubConnection(observer.AccessToken);
+        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var eventReceived = new TaskCompletionSource<SignalRUserProfileUpdatedEvent>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        connection.On("Ready", () => ready.TrySetResult());
+        connection.On<SignalRUserProfileUpdatedEvent>("UserProfileUpdated", payload =>
+        {
+            if (payload.UserId == updatingUser.UserId.ToString())
+                eventReceived.TrySetResult(payload);
+        });
+
+        await connection.StartAsync();
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var updateResponse = await _client.SendAuthorizedPatchAsync(
+            "/api/users/me",
+            new { displayName = $"Updated-{prefix}", displayNameIsSet = true },
+            updatingUser.AccessToken);
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var completedTask = await Task.WhenAny(eventReceived.Task, Task.Delay(Timeout.InfiniteTimeSpan, timeout.Token));
+        completedTask.Should().Be(eventReceived.Task);
+
+        var eventPayload = await eventReceived.Task;
+        eventPayload.UserId.Should().Be(updatingUser.UserId.ToString());
+        eventPayload.DisplayName.Should().Be($"Updated-{prefix}");
+    }
+
+    [Fact]
+    public async Task UserProfileUpdated_WhenThemeOnlyChanges_ShouldNotSendEvent()
+    {
+        var updatingUser = await AuthTestHelper.RegisterAsync(_client);
+        var observer = await AuthTestHelper.RegisterAsync(_client);
+
+        var prefix = Guid.NewGuid().ToString("N")[..8];
+
+        var createGuildResponse = await _client.SendAuthorizedPostAsync(
+            "/api/guilds",
+            new CreateGuildRequest($"Theme Only Guild {prefix}"),
+            updatingUser.AccessToken);
+        createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        createGuildPayload.Should().NotBeNull();
+
+        await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, updatingUser.AccessToken, observer.AccessToken);
+
+        await using var connection = CreateHubConnection(observer.AccessToken);
+        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var eventReceived = new TaskCompletionSource<SignalRUserProfileUpdatedEvent>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        connection.On("Ready", () => ready.TrySetResult());
+        connection.On<SignalRUserProfileUpdatedEvent>("UserProfileUpdated", payload =>
+        {
+            if (payload.UserId == updatingUser.UserId.ToString())
+                eventReceived.TrySetResult(payload);
+        });
+
+        await connection.StartAsync();
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var updateResponse = await _client.SendAuthorizedPatchAsync(
+            "/api/users/me",
+            new { theme = "dark", themeIsSet = true },
+            updatingUser.AccessToken);
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var completedTask = await Task.WhenAny(eventReceived.Task, Task.Delay(Timeout.InfiniteTimeSpan, timeout.Token));
+        completedTask.Should().NotBe(eventReceived.Task, "theme-only changes should not trigger UserProfileUpdated");
+    }
+
+    private HubConnection CreateHubConnection(string accessToken)
+    {
+        var baseAddress = _client.BaseAddress ?? new Uri("http://localhost");
+        var hubUri = new Uri(baseAddress, "/hubs/realtime");
+
+        return new HubConnectionBuilder()
+            .WithUrl(hubUri, options =>
+            {
+                options.Transports = HttpTransportType.LongPolling;
+                options.AccessTokenProvider = () => Task.FromResult<string?>(accessToken);
+                options.HttpMessageHandlerFactory = _ => _factory.Server.CreateHandler();
+            })
+            .Build();
+    }
+
+    private sealed record SignalRUserProfileUpdatedEvent(
+        string UserId,
+        string? DisplayName,
+        string? AvatarFileId);
+}

--- a/tests/Harmonie.Application.Tests/Uploads/DeleteMyAvatarHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Uploads/DeleteMyAvatarHandlerTests.cs
@@ -44,7 +44,7 @@ public sealed class DeleteMyAvatarHandlerTests
 
         _userRepositoryMock
             .Setup(x => x.GetUserNotificationContextAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { new UserNotificationContext(Array.Empty<Guid>(), Array.Empty<Guid>()) });
+            .ReturnsAsync(new UserNotificationContext(Array.Empty<Guid>(), Array.Empty<Guid>()));
 
         _handler = new DeleteMyAvatarHandler(
             _userRepositoryMock.Object,

--- a/tests/Harmonie.Application.Tests/Uploads/DeleteMyAvatarHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Uploads/DeleteMyAvatarHandlerTests.cs
@@ -3,8 +3,6 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Features.Users.DeleteMyAvatar;
 using Harmonie.Application.Interfaces.Common;
-using Harmonie.Application.Interfaces.Conversations;
-using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
@@ -44,15 +42,9 @@ public sealed class DeleteMyAvatarHandlerTests
             .Setup(x => x.DisposeAsync())
             .Returns(ValueTask.CompletedTask);
 
-        var guildMemberRepositoryMock = new Mock<IGuildMemberRepository>();
-        guildMemberRepositoryMock
-            .Setup(x => x.GetUserGuildMembershipsAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<UserGuildMembership>());
-
-        var conversationRepositoryMock = new Mock<IConversationRepository>();
-        conversationRepositoryMock
-            .Setup(x => x.GetUserConversationsAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<UserConversationSummary>());
+        _userRepositoryMock
+            .Setup(x => x.GetUserNotificationContextAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new UserNotificationContext(Array.Empty<Guid>(), Array.Empty<Guid>()) });
 
         _handler = new DeleteMyAvatarHandler(
             _userRepositoryMock.Object,
@@ -61,8 +53,6 @@ public sealed class DeleteMyAvatarHandlerTests
                 _objectStorageServiceMock.Object,
                 NullLogger<UploadedFileCleanupService>.Instance),
             _unitOfWorkMock.Object,
-            guildMemberRepositoryMock.Object,
-            conversationRepositoryMock.Object,
             Mock.Of<IUserProfileNotifier>(),
             NullLogger<DeleteMyAvatarHandler>.Instance);
     }

--- a/tests/Harmonie.Application.Tests/Uploads/DeleteMyAvatarHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Uploads/DeleteMyAvatarHandlerTests.cs
@@ -3,6 +3,8 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Features.Users.DeleteMyAvatar;
 using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
@@ -42,13 +44,27 @@ public sealed class DeleteMyAvatarHandlerTests
             .Setup(x => x.DisposeAsync())
             .Returns(ValueTask.CompletedTask);
 
+        var guildMemberRepositoryMock = new Mock<IGuildMemberRepository>();
+        guildMemberRepositoryMock
+            .Setup(x => x.GetUserGuildMembershipsAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<UserGuildMembership>());
+
+        var conversationRepositoryMock = new Mock<IConversationRepository>();
+        conversationRepositoryMock
+            .Setup(x => x.GetUserConversationsAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<UserConversationSummary>());
+
         _handler = new DeleteMyAvatarHandler(
             _userRepositoryMock.Object,
             new UploadedFileCleanupService(
                 _uploadedFileRepositoryMock.Object,
                 _objectStorageServiceMock.Object,
                 NullLogger<UploadedFileCleanupService>.Instance),
-            _unitOfWorkMock.Object);
+            _unitOfWorkMock.Object,
+            guildMemberRepositoryMock.Object,
+            conversationRepositoryMock.Object,
+            Mock.Of<IUserProfileNotifier>(),
+            NullLogger<DeleteMyAvatarHandler>.Instance);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Uploads/DeleteMyAvatarHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Uploads/DeleteMyAvatarHandlerTests.cs
@@ -9,6 +9,8 @@ using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Uploads;
 using Harmonie.Domain.Entities.Users;
 using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -44,7 +46,7 @@ public sealed class DeleteMyAvatarHandlerTests
 
         _userRepositoryMock
             .Setup(x => x.GetUserNotificationContextAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new UserNotificationContext(Array.Empty<Guid>(), Array.Empty<Guid>()));
+            .ReturnsAsync(new UserNotificationContext(Array.Empty<GuildId>(), Array.Empty<ConversationId>()));
 
         _handler = new DeleteMyAvatarHandler(
             _userRepositoryMock.Object,

--- a/tests/Harmonie.Application.Tests/Uploads/UploadMyAvatarHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Uploads/UploadMyAvatarHandlerTests.cs
@@ -37,7 +37,7 @@ public sealed class UploadMyAvatarHandlerTests
 
         _userRepositoryMock
             .Setup(x => x.GetUserNotificationContextAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { new UserNotificationContext(Array.Empty<Guid>(), Array.Empty<Guid>()) });
+            .ReturnsAsync(new UserNotificationContext(Array.Empty<Guid>(), Array.Empty<Guid>()));
 
         _handler = new UploadMyAvatarHandler(
             _userRepositoryMock.Object,

--- a/tests/Harmonie.Application.Tests/Uploads/UploadMyAvatarHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Uploads/UploadMyAvatarHandlerTests.cs
@@ -3,6 +3,8 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Features.Users.UploadMyAvatar;
 using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
@@ -35,6 +37,16 @@ public sealed class UploadMyAvatarHandlerTests
 
         _transactionMock = _unitOfWorkMock.SetupTransactionMock();
 
+        var guildMemberRepositoryMock = new Mock<IGuildMemberRepository>();
+        guildMemberRepositoryMock
+            .Setup(x => x.GetUserGuildMembershipsAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<UserGuildMembership>());
+
+        var conversationRepositoryMock = new Mock<IConversationRepository>();
+        conversationRepositoryMock
+            .Setup(x => x.GetUserConversationsAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<UserConversationSummary>());
+
         _handler = new UploadMyAvatarHandler(
             _userRepositoryMock.Object,
             _uploadedFileRepositoryMock.Object,
@@ -44,6 +56,9 @@ public sealed class UploadMyAvatarHandlerTests
                 _objectStorageServiceMock.Object,
                 NullLogger<UploadedFileCleanupService>.Instance),
             _unitOfWorkMock.Object,
+            guildMemberRepositoryMock.Object,
+            conversationRepositoryMock.Object,
+            Mock.Of<IUserProfileNotifier>(),
             NullLogger<UploadMyAvatarHandler>.Instance);
     }
 

--- a/tests/Harmonie.Application.Tests/Uploads/UploadMyAvatarHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Uploads/UploadMyAvatarHandlerTests.cs
@@ -7,6 +7,8 @@ using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Users;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Users;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -37,7 +39,7 @@ public sealed class UploadMyAvatarHandlerTests
 
         _userRepositoryMock
             .Setup(x => x.GetUserNotificationContextAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new UserNotificationContext(Array.Empty<Guid>(), Array.Empty<Guid>()));
+            .ReturnsAsync(new UserNotificationContext(Array.Empty<GuildId>(), Array.Empty<ConversationId>()));
 
         _handler = new UploadMyAvatarHandler(
             _userRepositoryMock.Object,

--- a/tests/Harmonie.Application.Tests/Uploads/UploadMyAvatarHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Uploads/UploadMyAvatarHandlerTests.cs
@@ -3,8 +3,6 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Features.Users.UploadMyAvatar;
 using Harmonie.Application.Interfaces.Common;
-using Harmonie.Application.Interfaces.Conversations;
-using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
@@ -37,15 +35,9 @@ public sealed class UploadMyAvatarHandlerTests
 
         _transactionMock = _unitOfWorkMock.SetupTransactionMock();
 
-        var guildMemberRepositoryMock = new Mock<IGuildMemberRepository>();
-        guildMemberRepositoryMock
-            .Setup(x => x.GetUserGuildMembershipsAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<UserGuildMembership>());
-
-        var conversationRepositoryMock = new Mock<IConversationRepository>();
-        conversationRepositoryMock
-            .Setup(x => x.GetUserConversationsAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<UserConversationSummary>());
+        _userRepositoryMock
+            .Setup(x => x.GetUserNotificationContextAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new UserNotificationContext(Array.Empty<Guid>(), Array.Empty<Guid>()) });
 
         _handler = new UploadMyAvatarHandler(
             _userRepositoryMock.Object,
@@ -56,8 +48,6 @@ public sealed class UploadMyAvatarHandlerTests
                 _objectStorageServiceMock.Object,
                 NullLogger<UploadedFileCleanupService>.Instance),
             _unitOfWorkMock.Object,
-            guildMemberRepositoryMock.Object,
-            conversationRepositoryMock.Object,
             Mock.Of<IUserProfileNotifier>(),
             NullLogger<UploadMyAvatarHandler>.Instance);
     }

--- a/tests/Harmonie.Application.Tests/Users/UpdateMyProfileHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Users/UpdateMyProfileHandlerTests.cs
@@ -29,7 +29,7 @@ public sealed class UpdateMyProfileHandlerTests
 
         _userRepositoryMock
             .Setup(x => x.GetUserNotificationContextAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { new UserNotificationContext(Array.Empty<Guid>(), Array.Empty<Guid>()) });
+            .ReturnsAsync(new UserNotificationContext(Array.Empty<Guid>(), Array.Empty<Guid>()));
 
         _handler = new UpdateMyProfileHandler(
             _userRepositoryMock.Object,

--- a/tests/Harmonie.Application.Tests/Users/UpdateMyProfileHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Users/UpdateMyProfileHandlerTests.cs
@@ -5,6 +5,8 @@ using Harmonie.Application.Features.Users.UpdateMyProfile;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.Entities.Users;
 using Harmonie.Domain.ValueObjects.Users;
@@ -29,7 +31,7 @@ public sealed class UpdateMyProfileHandlerTests
 
         _userRepositoryMock
             .Setup(x => x.GetUserNotificationContextAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new UserNotificationContext(Array.Empty<Guid>(), Array.Empty<Guid>()));
+            .ReturnsAsync(new UserNotificationContext(Array.Empty<GuildId>(), Array.Empty<ConversationId>()));
 
         _handler = new UpdateMyProfileHandler(
             _userRepositoryMock.Object,

--- a/tests/Harmonie.Application.Tests/Users/UpdateMyProfileHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Users/UpdateMyProfileHandlerTests.cs
@@ -2,6 +2,8 @@ using FluentAssertions;
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Features.Users.UpdateMyProfile;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
@@ -26,12 +28,27 @@ public sealed class UpdateMyProfileHandlerTests
         _userRepositoryMock = new Mock<IUserRepository>();
         _uploadedFileRepositoryMock = new Mock<IUploadedFileRepository>();
         _objectStorageServiceMock = new Mock<IObjectStorageService>();
+
+        var guildMemberRepositoryMock = new Mock<IGuildMemberRepository>();
+        guildMemberRepositoryMock
+            .Setup(x => x.GetUserGuildMembershipsAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Harmonie.Application.Interfaces.Guilds.UserGuildMembership>());
+
+        var conversationRepositoryMock = new Mock<IConversationRepository>();
+        conversationRepositoryMock
+            .Setup(x => x.GetUserConversationsAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Harmonie.Application.Interfaces.Conversations.UserConversationSummary>());
+
         _handler = new UpdateMyProfileHandler(
             _userRepositoryMock.Object,
             new UploadedFileCleanupService(
                 _uploadedFileRepositoryMock.Object,
                 _objectStorageServiceMock.Object,
-                NullLogger<UploadedFileCleanupService>.Instance));
+                NullLogger<UploadedFileCleanupService>.Instance),
+            guildMemberRepositoryMock.Object,
+            conversationRepositoryMock.Object,
+            Mock.Of<IUserProfileNotifier>(),
+            NullLogger<UpdateMyProfileHandler>.Instance);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Users/UpdateMyProfileHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Users/UpdateMyProfileHandlerTests.cs
@@ -2,8 +2,6 @@ using FluentAssertions;
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Features.Users.UpdateMyProfile;
-using Harmonie.Application.Interfaces.Conversations;
-using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
@@ -29,15 +27,9 @@ public sealed class UpdateMyProfileHandlerTests
         _uploadedFileRepositoryMock = new Mock<IUploadedFileRepository>();
         _objectStorageServiceMock = new Mock<IObjectStorageService>();
 
-        var guildMemberRepositoryMock = new Mock<IGuildMemberRepository>();
-        guildMemberRepositoryMock
-            .Setup(x => x.GetUserGuildMembershipsAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<Harmonie.Application.Interfaces.Guilds.UserGuildMembership>());
-
-        var conversationRepositoryMock = new Mock<IConversationRepository>();
-        conversationRepositoryMock
-            .Setup(x => x.GetUserConversationsAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<Harmonie.Application.Interfaces.Conversations.UserConversationSummary>());
+        _userRepositoryMock
+            .Setup(x => x.GetUserNotificationContextAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new UserNotificationContext(Array.Empty<Guid>(), Array.Empty<Guid>()) });
 
         _handler = new UpdateMyProfileHandler(
             _userRepositoryMock.Object,
@@ -45,8 +37,6 @@ public sealed class UpdateMyProfileHandlerTests
                 _uploadedFileRepositoryMock.Object,
                 _objectStorageServiceMock.Object,
                 NullLogger<UploadedFileCleanupService>.Instance),
-            guildMemberRepositoryMock.Object,
-            conversationRepositoryMock.Object,
             Mock.Of<IUserProfileNotifier>(),
             NullLogger<UpdateMyProfileHandler>.Instance);
     }


### PR DESCRIPTION
## Summary
- Add `IUserProfileNotifier` interface and `SignalRUserProfileNotifier` that broadcasts `UserProfileUpdated` to all `guild:{id}` and `conversation:{id}` groups the user belongs to
- Call `NotifyProfileUpdatedAsync` from `UpdateMyProfileHandler` (only when display name, bio, or avatar changes — not theme/language), `UploadMyAvatarHandler`, and `DeleteMyAvatarHandler`
- Register notifier in `RealTimeConfiguration` and document the event in `RealtimeHubDocumentation`

## Test plan
- [ ] Unit tests: existing handler tests updated to pass new constructor dependencies — all 345 pass
- [ ] Integration test `UserProfileUpdated_WhenMemberUpdatesDisplayName_GuildMemberShouldReceiveEvent`: observer in same guild receives event with correct payload
- [ ] Integration test `UserProfileUpdated_WhenThemeOnlyChanges_ShouldNotSendEvent`: theme-only update does not trigger event

Closes #290