### PR TITLE
feat: send SignalR notification when a group conversation is created

### DIFF
--- a/src/Harmonie.API/Configuration/RealTimeConfiguration.cs
+++ b/src/Harmonie.API/Configuration/RealTimeConfiguration.cs
@@ -46,6 +46,7 @@ public static class RealTimeConfiguration
         services.AddScoped<IGuildNotifier, SignalRGuildNotifier>();
         services.AddScoped<IVoicePresenceNotifier, SignalRVoicePresenceNotifier>();
         services.AddScoped<IConversationMessageNotifier, SignalRConversationMessageNotifier>();
+        services.AddScoped<IConversationNotifier, SignalRConversationNotifier>();
         services.AddScoped<IUserPresenceNotifier, SignalRUserPresenceNotifier>();
         services.AddScoped<IUserProfileNotifier, SignalRUserProfileNotifier>();
         services.AddScoped<IReactionNotifier, SignalRReactionNotifier>();

--- a/src/Harmonie.API/RealTime/Common/RealtimeHubDocumentation.cs
+++ b/src/Harmonie.API/RealTime/Common/RealtimeHubDocumentation.cs
@@ -45,6 +45,11 @@ public class RealtimeHubDocumentation
         Summary = "Received when a message is deleted in a text channel.")]
     public void OnMessageDeleted() { }
 
+    [Channel("hubs/realtime/ConversationCreated")]
+    [SubscribeOperation(typeof(ConversationCreatedEvent),
+        Summary = "Received by all participants when a new group conversation is created. Broadcast to the conversation group after all participants have been subscribed.")]
+    public void OnConversationCreated() { }
+
     [Channel("hubs/realtime/ConversationMessageCreated")]
     [SubscribeOperation(typeof(ConversationMessageCreatedEvent),
         Summary = "Received when a new message is posted in a direct conversation.")]

--- a/src/Harmonie.API/RealTime/Conversations/SignalRConversationNotifier.cs
+++ b/src/Harmonie.API/RealTime/Conversations/SignalRConversationNotifier.cs
@@ -1,0 +1,36 @@
+using Harmonie.API.RealTime.Common;
+using Harmonie.Application.Interfaces.Conversations;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Harmonie.API.RealTime.Conversations;
+
+public sealed class SignalRConversationNotifier : IConversationNotifier
+{
+    private readonly IHubContext<RealtimeHub> _hubContext;
+
+    public SignalRConversationNotifier(IHubContext<RealtimeHub> hubContext)
+    {
+        _hubContext = hubContext;
+    }
+
+    public async Task NotifyConversationCreatedAsync(
+        ConversationCreatedNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var payload = new ConversationCreatedEvent(
+            ConversationId: notification.ConversationId.Value,
+            Name: notification.Name,
+            ParticipantIds: notification.ParticipantIds.Select(id => id.Value).ToArray());
+
+        await _hubContext.Clients
+            .Group(RealtimeHub.GetConversationGroupName(notification.ConversationId))
+            .SendAsync("ConversationCreated", payload, cancellationToken);
+    }
+}
+
+public sealed record ConversationCreatedEvent(
+    Guid ConversationId,
+    string? Name,
+    IReadOnlyList<Guid> ParticipantIds);

--- a/src/Harmonie.Application/Features/Conversations/CreateGroupConversation/CreateGroupConversationHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/CreateGroupConversation/CreateGroupConversationHandler.cs
@@ -12,17 +12,20 @@ public sealed class CreateGroupConversationHandler : IAuthenticatedHandler<Creat
     private readonly IConversationRepository _conversationRepository;
     private readonly IUserRepository _userRepository;
     private readonly IRealtimeGroupManager _realtimeGroupManager;
+    private readonly IConversationNotifier _conversationNotifier;
     private readonly ILogger<CreateGroupConversationHandler> _logger;
 
     public CreateGroupConversationHandler(
         IConversationRepository conversationRepository,
         IUserRepository userRepository,
         IRealtimeGroupManager realtimeGroupManager,
+        IConversationNotifier conversationNotifier,
         ILogger<CreateGroupConversationHandler> logger)
     {
         _conversationRepository = conversationRepository;
         _userRepository = userRepository;
         _realtimeGroupManager = realtimeGroupManager;
+        _conversationNotifier = conversationNotifier;
         _logger = logger;
     }
 
@@ -62,10 +65,17 @@ public sealed class CreateGroupConversationHandler : IAuthenticatedHandler<Creat
                 await Task.WhenAll(
                     participantUserIds.Select(uid =>
                         _realtimeGroupManager.AddUserToConversationGroupAsync(uid, conversation.Id, ct)));
+
+                await _conversationNotifier.NotifyConversationCreatedAsync(
+                    new ConversationCreatedNotification(
+                        ConversationId: conversation.Id,
+                        Name: conversation.Name,
+                        ParticipantIds: participantUserIds),
+                    ct);
             },
             TimeSpan.FromSeconds(5),
             _logger,
-            "Failed to subscribe users to group conversation {ConversationId} SignalR group",
+            "Failed to notify participants of group conversation {ConversationId} creation",
             conversation.Id);
 
         var payload = new CreateGroupConversationResponse(

--- a/src/Harmonie.Application/Interfaces/Conversations/IConversationNotifier.cs
+++ b/src/Harmonie.Application/Interfaces/Conversations/IConversationNotifier.cs
@@ -1,0 +1,16 @@
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Interfaces.Conversations;
+
+public interface IConversationNotifier
+{
+    Task NotifyConversationCreatedAsync(
+        ConversationCreatedNotification notification,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record ConversationCreatedNotification(
+    ConversationId ConversationId,
+    string? Name,
+    IReadOnlyList<UserId> ParticipantIds);

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRConversationCreatedHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRConversationCreatedHubTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using Harmonie.API.IntegrationTests.Common;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+
+namespace Harmonie.API.IntegrationTests;
+
+public sealed class SignalRConversationCreatedHubTests : IClassFixture<HarmonieWebApplicationFactory>
+{
+    private readonly HarmonieWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public SignalRConversationCreatedHubTests(HarmonieWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task ConversationCreated_WhenParticipantConnected_ShouldReceiveEvent()
+    {
+        var creator = await AuthTestHelper.RegisterAsync(_client);
+        var participant = await AuthTestHelper.RegisterAsync(_client);
+
+        await using var connection = CreateHubConnection(participant.AccessToken);
+        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var eventReceived = new TaskCompletionSource<SignalRConversationCreatedEvent>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        connection.On("Ready", () => ready.TrySetResult());
+        connection.On<SignalRConversationCreatedEvent>("ConversationCreated", payload =>
+        {
+            eventReceived.TrySetResult(payload);
+        });
+
+        await connection.StartAsync();
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        var group = await ConversationTestHelper.CreateGroupConversationAsync(
+            _client, creator.AccessToken, "Integration Test Group",
+            [creator.UserId, participant.UserId]);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var completedTask = await Task.WhenAny(eventReceived.Task, Task.Delay(Timeout.InfiniteTimeSpan, timeout.Token));
+        completedTask.Should().Be(eventReceived.Task);
+
+        var eventPayload = await eventReceived.Task;
+        eventPayload.ConversationId.Should().Be(group.ConversationId.ToString());
+        eventPayload.Name.Should().Be("Integration Test Group");
+        eventPayload.ParticipantIds.Should().Contain(creator.UserId.ToString());
+        eventPayload.ParticipantIds.Should().Contain(participant.UserId.ToString());
+    }
+
+    private HubConnection CreateHubConnection(string accessToken)
+    {
+        var baseAddress = _client.BaseAddress ?? new Uri("http://localhost");
+        var hubUri = new Uri(baseAddress, "/hubs/realtime");
+
+        return new HubConnectionBuilder()
+            .WithUrl(hubUri, options =>
+            {
+                options.Transports = HttpTransportType.LongPolling;
+                options.AccessTokenProvider = () => Task.FromResult<string?>(accessToken);
+                options.HttpMessageHandlerFactory = _ => _factory.Server.CreateHandler();
+            })
+            .Build();
+    }
+
+    private sealed record SignalRConversationCreatedEvent(
+        string ConversationId,
+        string? Name,
+        IReadOnlyList<string> ParticipantIds);
+}

--- a/tests/Harmonie.Application.Tests/Conversations/CreateGroupConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/CreateGroupConversationHandlerTests.cs
@@ -19,6 +19,7 @@ public sealed class CreateGroupConversationHandlerTests
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IRealtimeGroupManager> _realtimeGroupManagerMock;
+    private readonly Mock<IConversationNotifier> _conversationNotifierMock;
     private readonly CreateGroupConversationHandler _handler;
 
     public CreateGroupConversationHandlerTests()
@@ -26,15 +27,21 @@ public sealed class CreateGroupConversationHandlerTests
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _userRepositoryMock = new Mock<IUserRepository>();
         _realtimeGroupManagerMock = new Mock<IRealtimeGroupManager>();
+        _conversationNotifierMock = new Mock<IConversationNotifier>();
 
         _realtimeGroupManagerMock
             .Setup(x => x.AddUserToConversationGroupAsync(It.IsAny<UserId>(), It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _conversationNotifierMock
+            .Setup(x => x.NotifyConversationCreatedAsync(It.IsAny<ConversationCreatedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         _handler = new CreateGroupConversationHandler(
             _conversationRepositoryMock.Object,
             _userRepositoryMock.Object,
             _realtimeGroupManagerMock.Object,
+            _conversationNotifierMock.Object,
             NullLogger<CreateGroupConversationHandler>.Instance);
     }
 
@@ -114,6 +121,15 @@ public sealed class CreateGroupConversationHandlerTests
         response.Data.Name.Should().Be("Team Chat");
         response.Data.ConversationId.Should().Be(conversation.Id.Value);
         response.Data.ParticipantIds.Should().HaveCount(2);
+
+        _conversationNotifierMock.Verify(
+            x => x.NotifyConversationCreatedAsync(
+                It.Is<ConversationCreatedNotification>(n =>
+                    n.ConversationId == conversation.Id
+                    && n.Name == "Team Chat"
+                    && n.ParticipantIds.Count == 2),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Adds `IConversationNotifier` interface with `NotifyConversationCreatedAsync`
- Implements `SignalRConversationNotifier` that broadcasts `ConversationCreated` to the `conversation:{id}` group
- `CreateGroupConversationHandler` now notifies all participants after they are subscribed to the SignalR group
- Documents the new event in `RealtimeHubDocumentation`

## Test plan
- [ ] Unit test: `HandleAsync_WithValidRequest_ShouldReturnGroupConversationResponse` verifies `NotifyConversationCreatedAsync` is called with correct payload
- [ ] Integration test: `ConversationCreated_WhenParticipantConnected_ShouldReceiveEvent` verifies a connected participant receives the SignalR event with correct `ConversationId`, `Name`, and `ParticipantIds`

Closes #291