### PR TITLE
feat(conversations): Delete Conversation — DELETE /api/conversations/{conversationId} (#305)

### DIFF
--- a/src/Harmonie.API/Endpoints/ConversationEndpoints.cs
+++ b/src/Harmonie.API/Endpoints/ConversationEndpoints.cs
@@ -1,4 +1,5 @@
 using Harmonie.Application.Features.Conversations.CreateGroupConversation;
+using Harmonie.Application.Features.Conversations.DeleteConversation;
 using Harmonie.Application.Features.Conversations.ListConversations;
 using Harmonie.Application.Features.Conversations.OpenConversation;
 using Harmonie.Application.Features.Conversations.SearchConversationMessages;
@@ -19,6 +20,7 @@ public static class ConversationEndpoints
     {
         OpenConversationEndpoint.Map(app);
         CreateGroupConversationEndpoint.Map(app);
+        DeleteConversationEndpoint.Map(app);
         ListConversationsEndpoint.Map(app);
         SearchConversationMessagesEndpoint.Map(app);
 

--- a/src/Harmonie.API/RealTime/Common/SignalRRealtimeGroupManager.cs
+++ b/src/Harmonie.API/RealTime/Common/SignalRRealtimeGroupManager.cs
@@ -205,4 +205,26 @@ public sealed class SignalRRealtimeGroupManager : IRealtimeGroupManager
 
         await Task.WhenAll(tasks);
     }
+
+    public async Task RemoveUserFromConversationGroupAsync(
+        UserId userId,
+        ConversationId conversationId,
+        CancellationToken cancellationToken = default)
+    {
+        var connectionIds = _connectionTracker.GetConnectionIds(userId);
+        if (connectionIds.Count == 0)
+            return;
+
+        var tasks = new List<Task>(connectionIds.Count);
+
+        foreach (var connectionId in connectionIds)
+        {
+            tasks.Add(_hubContext.Groups.RemoveFromGroupAsync(
+                connectionId,
+                RealtimeHub.GetConversationGroupName(conversationId),
+                cancellationToken));
+        }
+
+        await Task.WhenAll(tasks);
+    }
 }

--- a/src/Harmonie.API/RealTime/Conversations/SignalRConversationNotifier.cs
+++ b/src/Harmonie.API/RealTime/Conversations/SignalRConversationNotifier.cs
@@ -28,9 +28,28 @@ public sealed class SignalRConversationNotifier : IConversationNotifier
             .Group(RealtimeHub.GetConversationGroupName(notification.ConversationId))
             .SendAsync("ConversationCreated", payload, cancellationToken);
     }
+
+    public async Task NotifyParticipantLeftAsync(
+        ConversationParticipantLeftNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var payload = new ConversationParticipantLeftEvent(
+            ConversationId: notification.ConversationId.Value,
+            UserId: notification.UserId.Value);
+
+        await _hubContext.Clients
+            .Group(RealtimeHub.GetConversationGroupName(notification.ConversationId))
+            .SendAsync("ConversationParticipantLeft", payload, cancellationToken);
+    }
 }
 
 public sealed record ConversationCreatedEvent(
     Guid ConversationId,
     string? Name,
     IReadOnlyList<Guid> ParticipantIds);
+
+public sealed record ConversationParticipantLeftEvent(
+    Guid ConversationId,
+    Guid UserId);

--- a/src/Harmonie.Application/Features/Conversations/DeleteConversation/DeleteConversationEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteConversation/DeleteConversationEndpoint.cs
@@ -1,0 +1,41 @@
+using Harmonie.Application.Common;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Harmonie.Application.Features.Conversations.DeleteConversation;
+
+public static class DeleteConversationEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        app.MapDelete("/api/conversations/{conversationId}", HandleAsync)
+            .WithName("DeleteConversation")
+            .WithTags("Conversations")
+            .RequireAuthorization()
+            .WithSummary("Delete a conversation")
+            .WithDescription("Removes the authenticated user from a conversation. If no participants remain, the conversation is permanently deleted.")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesErrors(
+                ApplicationErrorCodes.Auth.InvalidCredentials,
+                ApplicationErrorCodes.Conversation.NotFound,
+                ApplicationErrorCodes.Conversation.AccessDenied);
+    }
+
+    private static async Task<IResult> HandleAsync(
+        ConversationId conversationId,
+        [FromServices] IAuthenticatedHandler<DeleteConversationInput, bool> handler,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var callerId = httpContext.GetRequiredAuthenticatedUserId();
+
+        var response = await handler.HandleAsync(new DeleteConversationInput(conversationId), callerId, cancellationToken);
+        if (response.Success)
+            return Results.NoContent();
+
+        return response.ToHttpResult();
+    }
+}

--- a/src/Harmonie.Application/Features/Conversations/DeleteConversation/DeleteConversationHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteConversation/DeleteConversationHandler.cs
@@ -1,0 +1,82 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging;
+
+namespace Harmonie.Application.Features.Conversations.DeleteConversation;
+
+public sealed record DeleteConversationInput(ConversationId ConversationId);
+
+public sealed class DeleteConversationHandler : IAuthenticatedHandler<DeleteConversationInput, bool>
+{
+    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly IConversationRepository _conversationRepository;
+    private readonly IRealtimeGroupManager _realtimeGroupManager;
+    private readonly IConversationNotifier _conversationNotifier;
+    private readonly ILogger<DeleteConversationHandler> _logger;
+
+    public DeleteConversationHandler(
+        IConversationRepository conversationRepository,
+        IRealtimeGroupManager realtimeGroupManager,
+        IConversationNotifier conversationNotifier,
+        ILogger<DeleteConversationHandler> logger)
+    {
+        _conversationRepository = conversationRepository;
+        _realtimeGroupManager = realtimeGroupManager;
+        _conversationNotifier = conversationNotifier;
+        _logger = logger;
+    }
+
+    public async Task<ApplicationResponse<bool>> HandleAsync(
+        DeleteConversationInput request,
+        UserId currentUserId,
+        CancellationToken cancellationToken = default)
+    {
+        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(
+            request.ConversationId, currentUserId, cancellationToken);
+
+        if (access is null)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Conversation.NotFound,
+                "Conversation was not found");
+        }
+
+        if (!access.IsParticipant)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Conversation.AccessDenied,
+                "You are not a participant of this conversation");
+        }
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            ct => _conversationNotifier.NotifyParticipantLeftAsync(
+                new ConversationParticipantLeftNotification(request.ConversationId, currentUserId), ct),
+            NotificationTimeout,
+            _logger,
+            "Failed to notify participants of conversation {ConversationId} that user {UserId} left",
+            request.ConversationId,
+            currentUserId);
+
+        var remaining = await _conversationRepository.RemoveParticipantAsync(
+            request.ConversationId, currentUserId, cancellationToken);
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            ct => _realtimeGroupManager.RemoveUserFromConversationGroupAsync(currentUserId, request.ConversationId, ct),
+            NotificationTimeout,
+            _logger,
+            "Failed to remove user {UserId} from conversation {ConversationId} SignalR group",
+            currentUserId,
+            request.ConversationId);
+
+        if (remaining == 0)
+        {
+            await _conversationRepository.DeleteAsync(request.ConversationId, cancellationToken);
+        }
+
+        return ApplicationResponse<bool>.Ok(true);
+    }
+}

--- a/src/Harmonie.Application/Interfaces/Common/IRealtimeGroupManager.cs
+++ b/src/Harmonie.Application/Interfaces/Common/IRealtimeGroupManager.cs
@@ -36,4 +36,9 @@ public interface IRealtimeGroupManager
         UserId userId,
         ConversationId conversationId,
         CancellationToken cancellationToken = default);
+
+    Task RemoveUserFromConversationGroupAsync(
+        UserId userId,
+        ConversationId conversationId,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Harmonie.Application/Interfaces/Conversations/IConversationNotifier.cs
+++ b/src/Harmonie.Application/Interfaces/Conversations/IConversationNotifier.cs
@@ -8,9 +8,17 @@ public interface IConversationNotifier
     Task NotifyConversationCreatedAsync(
         ConversationCreatedNotification notification,
         CancellationToken cancellationToken = default);
+
+    Task NotifyParticipantLeftAsync(
+        ConversationParticipantLeftNotification notification,
+        CancellationToken cancellationToken = default);
 }
 
 public sealed record ConversationCreatedNotification(
     ConversationId ConversationId,
     string? Name,
     IReadOnlyList<UserId> ParticipantIds);
+
+public sealed record ConversationParticipantLeftNotification(
+    ConversationId ConversationId,
+    UserId UserId);

--- a/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
@@ -41,4 +41,13 @@ public interface IConversationRepository
         ConversationId conversationId,
         UserId userId,
         CancellationToken cancellationToken = default);
+
+    Task<int> RemoveParticipantAsync(
+        ConversationId conversationId,
+        UserId userId,
+        CancellationToken cancellationToken = default);
+
+    Task DeleteAsync(
+        ConversationId conversationId,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Harmonie.Application/Registration/ConversationRegistration.cs
+++ b/src/Harmonie.Application/Registration/ConversationRegistration.cs
@@ -2,6 +2,7 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Features.Conversations.AcknowledgeRead;
 using Harmonie.Application.Features.Conversations.AddReaction;
 using Harmonie.Application.Features.Conversations.CreateGroupConversation;
+using Harmonie.Application.Features.Conversations.DeleteConversation;
 using Harmonie.Application.Features.Conversations.DeleteMessage;
 using Harmonie.Application.Features.Conversations.DeleteMessageAttachment;
 using Harmonie.Application.Features.Conversations.EditMessage;
@@ -21,6 +22,7 @@ public static class ConversationRegistration
     {
         services.AddAuthenticatedHandler<OpenConversationRequest, OpenConversationResponse, OpenConversationHandler>();
         services.AddAuthenticatedHandler<CreateGroupConversationRequest, CreateGroupConversationResponse, CreateGroupConversationHandler>();
+        services.AddAuthenticatedHandler<DeleteConversationInput, bool, DeleteConversationHandler>();
         services.AddAuthenticatedHandler<Unit, ListConversationsResponse, ListConversationsHandler>();
         services.AddAuthenticatedHandler<SearchConversationMessagesInput, SearchConversationMessagesResponse, SearchConversationMessagesHandler>();
 

--- a/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
@@ -241,6 +241,63 @@ public sealed class ConversationRepository : IConversationRepository
         return row is null ? null : new ConversationAccess(MapToConversation(row), row.IsParticipant);
     }
 
+    public async Task<int> RemoveParticipantAsync(
+        ConversationId conversationId,
+        UserId userId,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+
+        const string deleteSql = """
+                                  DELETE FROM conversation_participants
+                                  WHERE conversation_id = @ConversationId AND user_id = @UserId
+                                  """;
+        await connection.ExecuteAsync(new CommandDefinition(
+            deleteSql,
+            new { ConversationId = conversationId.Value, UserId = userId.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken));
+
+        const string countSql = """
+                                 SELECT COUNT(*) FROM conversation_participants
+                                 WHERE conversation_id = @ConversationId
+                                 """;
+        var remaining = await connection.ExecuteScalarAsync<int>(new CommandDefinition(
+            countSql,
+            new { ConversationId = conversationId.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken));
+
+        return remaining;
+    }
+
+    public async Task DeleteAsync(
+        ConversationId conversationId,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+
+        // direct_conversation_lookup does not have ON DELETE CASCADE on conversation_id, so delete it first
+        const string deleteLookupSql = """
+                                        DELETE FROM direct_conversation_lookup
+                                        WHERE conversation_id = @ConversationId
+                                        """;
+        await connection.ExecuteAsync(new CommandDefinition(
+            deleteLookupSql,
+            new { ConversationId = conversationId.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken));
+
+        const string deleteConversationSql = """
+                                              DELETE FROM conversations WHERE id = @ConversationId
+                                              """;
+        await connection.ExecuteAsync(new CommandDefinition(
+            deleteConversationSql,
+            new { ConversationId = conversationId.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken));
+    }
+
     private static Conversation MapToConversation(ConversationRow row)
         => Conversation.Rehydrate(
             ConversationId.From(row.Id),

--- a/tests/Harmonie.API.IntegrationTests/Conversations/DeleteConversationTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/DeleteConversationTests.cs
@@ -1,0 +1,149 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Harmonie.API.IntegrationTests.Common;
+using Harmonie.Application.Common;
+using Xunit;
+
+namespace Harmonie.API.IntegrationTests.Conversations;
+
+public sealed class DeleteConversationTests : IClassFixture<HarmonieWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public DeleteConversationTests(HarmonieWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task DeleteConversation_WhenParticipantDeletes_ShouldReturn204()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var other = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, other.UserId);
+
+        var response = await _client.SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}",
+            caller.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task DeleteConversation_WhenConversationDoesNotExist_ShouldReturnNotFound()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+
+        var response = await _client.SendAuthorizedDeleteAsync(
+            $"/api/conversations/{Guid.NewGuid()}",
+            caller.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteConversation_WhenCallerIsNotParticipant_ShouldReturnForbidden()
+    {
+        var participantOne = await AuthTestHelper.RegisterAsync(_client);
+        var participantTwo = await AuthTestHelper.RegisterAsync(_client);
+        var outsider = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, participantOne.AccessToken, participantTwo.UserId);
+
+        var response = await _client.SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}",
+            outsider.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
+    }
+
+    [Fact]
+    public async Task DeleteConversation_WithoutAuthentication_ShouldReturnUnauthorized()
+    {
+        var response = await _client.DeleteAsync($"/api/conversations/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task DeleteConversation_WhenLastParticipantDeletes_ConversationShouldBeGone()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var other = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, other.UserId);
+
+        // Both participants delete the conversation
+        var firstDelete = await _client.SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}",
+            caller.AccessToken);
+        firstDelete.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var secondDelete = await _client.SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}",
+            other.AccessToken);
+        secondDelete.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Conversation should now be gone for both
+        var getResponse = await _client.SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}",
+            caller.AccessToken);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteConversation_WhenOneParticipantLeaves_OtherShouldStillHaveAccess()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var other = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, other.UserId);
+
+        // Caller deletes their side
+        var deleteResponse = await _client.SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}",
+            caller.AccessToken);
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Other participant should still be able to fetch messages
+        var messagesResponse = await _client.SendAuthorizedGetAsync(
+            $"/api/conversations/{conversationId}/messages",
+            other.AccessToken);
+        messagesResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task DeleteConversation_AfterLeavingGroupConversation_OtherParticipantsShouldStillHaveAccess()
+    {
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var callerReg = await AuthTestHelper.RegisterAsync(_client, $"leaver_{tag}");
+        var other1Reg = await AuthTestHelper.RegisterAsync(_client, $"remain1_{tag}");
+        var other2Reg = await AuthTestHelper.RegisterAsync(_client, $"remain2_{tag}");
+
+        var groupConversation = await ConversationTestHelper.CreateGroupConversationAsync(
+            _client,
+            callerReg.AccessToken,
+            "Test group",
+            [callerReg.UserId, other1Reg.UserId, other2Reg.UserId]);
+
+        var conversationId = groupConversation.ConversationId;
+
+        // Caller leaves the group
+        var deleteResponse = await _client.SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}",
+            callerReg.AccessToken);
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Remaining participants can still access the conversation
+        var messagesResponse = await _client.SendAuthorizedGetAsync(
+            $"/api/conversations/{conversationId}/messages",
+            other1Reg.AccessToken);
+        messagesResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/tests/Harmonie.Application.Tests/Conversations/DeleteConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/DeleteConversationHandlerTests.cs
@@ -1,0 +1,210 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Conversations.DeleteConversation;
+using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Conversations;
+
+public sealed class DeleteConversationHandlerTests
+{
+    private readonly Mock<IConversationRepository> _conversationRepositoryMock;
+    private readonly Mock<IRealtimeGroupManager> _realtimeGroupManagerMock;
+    private readonly Mock<IConversationNotifier> _conversationNotifierMock;
+    private readonly DeleteConversationHandler _handler;
+
+    public DeleteConversationHandlerTests()
+    {
+        _conversationRepositoryMock = new Mock<IConversationRepository>();
+        _realtimeGroupManagerMock = new Mock<IRealtimeGroupManager>();
+        _conversationNotifierMock = new Mock<IConversationNotifier>();
+
+        _conversationNotifierMock
+            .Setup(x => x.NotifyParticipantLeftAsync(
+                It.IsAny<ConversationParticipantLeftNotification>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _realtimeGroupManagerMock
+            .Setup(x => x.RemoveUserFromConversationGroupAsync(
+                It.IsAny<UserId>(),
+                It.IsAny<ConversationId>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _handler = new DeleteConversationHandler(
+            _conversationRepositoryMock.Object,
+            _realtimeGroupManagerMock.Object,
+            _conversationNotifierMock.Object,
+            NullLogger<DeleteConversationHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenConversationDoesNotExist_ShouldReturnNotFound()
+    {
+        var conversationId = ConversationId.New();
+        var callerId = UserId.New();
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversationId, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConversationAccess?)null);
+
+        var response = await _handler.HandleAsync(new DeleteConversationInput(conversationId), callerId);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
+        _conversationRepositoryMock.Verify(
+            x => x.RemoveParticipantAsync(It.IsAny<ConversationId>(), It.IsAny<UserId>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCallerIsNotParticipant_ShouldReturnAccessDenied()
+    {
+        var participantOne = UserId.New();
+        var participantTwo = UserId.New();
+        var outsider = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(participantOne, participantTwo);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: false));
+
+        var response = await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), outsider);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
+        _conversationRepositoryMock.Verify(
+            x => x.RemoveParticipantAsync(It.IsAny<ConversationId>(), It.IsAny<UserId>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenParticipantLeaves_ShouldReturnSuccess()
+    {
+        var callerId = UserId.New();
+        var otherId = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+
+        _conversationRepositoryMock
+            .Setup(x => x.RemoveParticipantAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var response = await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId);
+
+        response.Success.Should().BeTrue();
+        response.Error.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenParticipantLeaves_ShouldNotifyAndRemoveFromSignalRGroup()
+    {
+        var callerId = UserId.New();
+        var otherId = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+
+        _conversationRepositoryMock
+            .Setup(x => x.RemoveParticipantAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId);
+
+        _conversationNotifierMock.Verify(
+            x => x.NotifyParticipantLeftAsync(
+                It.Is<ConversationParticipantLeftNotification>(n =>
+                    n.ConversationId == conversation.Id && n.UserId == callerId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _realtimeGroupManagerMock.Verify(
+            x => x.RemoveUserFromConversationGroupAsync(callerId, conversation.Id, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenLastParticipantLeaves_ShouldDeleteConversation()
+    {
+        var callerId = UserId.New();
+        var otherId = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+
+        _conversationRepositoryMock
+            .Setup(x => x.RemoveParticipantAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+
+        await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId);
+
+        _conversationRepositoryMock.Verify(
+            x => x.DeleteAsync(conversation.Id, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenParticipantsRemain_ShouldNotDeleteConversation()
+    {
+        var callerId = UserId.New();
+        var otherId = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+
+        _conversationRepositoryMock
+            .Setup(x => x.RemoveParticipantAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId);
+
+        _conversationRepositoryMock.Verify(
+            x => x.DeleteAsync(It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenNotifierThrows_ShouldStillSucceedAndRemoveParticipant()
+    {
+        var callerId = UserId.New();
+        var otherId = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+
+        _conversationRepositoryMock
+            .Setup(x => x.RemoveParticipantAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _conversationNotifierMock
+            .Setup(x => x.NotifyParticipantLeftAsync(
+                It.IsAny<ConversationParticipantLeftNotification>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("SignalR unavailable"));
+
+        var response = await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId);
+
+        response.Success.Should().BeTrue();
+        _conversationRepositoryMock.Verify(
+            x => x.RemoveParticipantAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `DELETE /api/conversations/{conversationId}` endpoint
- Removes the authenticated user from the conversation's participant list
- If no participants remain, hard-deletes the conversation (cascades to messages, reactions, read states, and the direct DM lookup entry)
- Sends a `ConversationParticipantLeft` SignalR event to the group before removal
- Adds `RemoveUserFromConversationGroupAsync` to `IRealtimeGroupManager` / `SignalRRealtimeGroupManager`

## Test plan

- [x] 204 — participant successfully leaves
- [x] 404 — conversation does not exist
- [x] 403 — caller is not a participant
- [x] 401 — unauthenticated
- [x] Last participant leaving hard-deletes the conversation
- [x] One participant leaving still allows the other to access the conversation
- [x] Leaving a group conversation leaves it intact for remaining participants

Closes #305