### PR TITLE
feat: include avatar appearance (color/icon/bg) in user search results (#307)

### DIFF
--- a/src/Harmonie.Application/Features/Users/SearchUsers/SearchUsersHandler.cs
+++ b/src/Harmonie.Application/Features/Users/SearchUsers/SearchUsersHandler.cs
@@ -63,13 +63,21 @@ public sealed class SearchUsersHandler
             cancellationToken);
 
         var payload = new SearchUsersResponse(
-            users.Select(user => new SearchUsersItemResponse(
-                UserId: user.UserId.Value,
-                Username: user.Username.Value,
-                DisplayName: user.DisplayName,
-                AvatarFileId: user.AvatarFileId?.Value,
-                Bio: user.Bio,
-                Status: user.IsActive ? "Active" : "Blocked"))
+            users.Select(user =>
+            {
+                var avatar = user.AvatarColor is not null || user.AvatarIcon is not null || user.AvatarBg is not null
+                    ? new AvatarAppearanceDto(user.AvatarColor, user.AvatarIcon, user.AvatarBg)
+                    : null;
+
+                return new SearchUsersItemResponse(
+                    UserId: user.UserId.Value,
+                    Username: user.Username.Value,
+                    DisplayName: user.DisplayName,
+                    AvatarFileId: user.AvatarFileId?.Value,
+                    Avatar: avatar,
+                    Bio: user.Bio,
+                    Status: user.IsActive ? "Active" : "Blocked");
+            })
             .ToArray());
 
         return ApplicationResponse<SearchUsersResponse>.Ok(payload);

--- a/src/Harmonie.Application/Features/Users/SearchUsers/SearchUsersResponse.cs
+++ b/src/Harmonie.Application/Features/Users/SearchUsers/SearchUsersResponse.cs
@@ -1,3 +1,5 @@
+using Harmonie.Application.Features.Users;
+
 namespace Harmonie.Application.Features.Users.SearchUsers;
 
 public sealed record SearchUsersResponse(
@@ -8,5 +10,6 @@ public sealed record SearchUsersItemResponse(
     string Username,
     string? DisplayName,
     Guid? AvatarFileId,
+    AvatarAppearanceDto? Avatar,
     string? Bio,
     string Status);

--- a/src/Harmonie.Application/Interfaces/Users/IUserRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Users/IUserRepository.cs
@@ -18,6 +18,9 @@ public sealed record SearchUserResult(
     Username Username,
     string? DisplayName,
     UploadedFileId? AvatarFileId,
+    string? AvatarColor,
+    string? AvatarIcon,
+    string? AvatarBg,
     string? Bio,
     bool IsActive);
 

--- a/src/Harmonie.Infrastructure/Persistence/Users/UserRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Users/UserRepository.cs
@@ -146,6 +146,9 @@ public sealed class UserRepository : IUserRepository
                    u.username AS "Username",
                    u.display_name AS "DisplayName",
                    u.avatar_file_id AS "AvatarFileId",
+                   u.avatar_color AS "AvatarColor",
+                   u.avatar_icon AS "AvatarIcon",
+                   u.avatar_bg AS "AvatarBg",
                    u.bio AS "Bio",
                    u.is_active AS "IsActive"
             FROM users u
@@ -434,6 +437,9 @@ public sealed class UserRepository : IUserRepository
             Username: usernameResult.Value,
             DisplayName: row.DisplayName,
             AvatarFileId: row.AvatarFileId.HasValue ? UploadedFileId.From(row.AvatarFileId.Value) : null,
+            AvatarColor: row.AvatarColor,
+            AvatarIcon: row.AvatarIcon,
+            AvatarBg: row.AvatarBg,
             Bio: row.Bio,
             IsActive: row.IsActive);
     }

--- a/src/Harmonie.Infrastructure/Rows/Users/SearchUserRow.cs
+++ b/src/Harmonie.Infrastructure/Rows/Users/SearchUserRow.cs
@@ -10,6 +10,12 @@ public sealed class SearchUserRow
 
     public Guid? AvatarFileId { get; init; }
 
+    public string? AvatarColor { get; init; }
+
+    public string? AvatarIcon { get; init; }
+
+    public string? AvatarBg { get; init; }
+
     public string? Bio { get; init; }
 
     public bool IsActive { get; init; }

--- a/tests/Harmonie.API.IntegrationTests/Users/SearchUsersEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Users/SearchUsersEndpointTests.cs
@@ -117,6 +117,33 @@ public sealed class SearchUsersEndpointTests : IClassFixture<HarmonieWebApplicat
     }
 
     [Fact]
+    public async Task SearchUsers_WhenUserHasAvatarAppearance_ShouldReturnAvatarDto()
+    {
+        var caller = await RegisterAsync();
+        var token = Guid.NewGuid().ToString("N")[..8];
+        var target = await RegisterAsync(usernamePrefix: $"{token}av");
+
+        await _client.SendAuthorizedPatchAsync(
+            "/api/users/me",
+            new { avatar = new { color = "#FFF4D6", icon = "star", bg = "#1F2937" } },
+            target.AccessToken);
+
+        var response = await _client.SendAuthorizedGetAsync(
+            $"/api/users/search?q={token}av",
+            caller.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<SearchUsersResponse>();
+        payload.Should().NotBeNull();
+        var user = payload!.Users.Should().ContainSingle(u => u.UserId == target.UserId).Subject;
+        user.Avatar.Should().NotBeNull();
+        user.Avatar!.Color.Should().Be("#FFF4D6");
+        user.Avatar.Icon.Should().Be("star");
+        user.Avatar.Bg.Should().Be("#1F2937");
+    }
+
+    [Fact]
     public async Task SearchUsers_WithoutAuthentication_ShouldReturnUnauthorized()
     {
         var response = await _client.GetAsync("/api/users/search?q=al");

--- a/tests/Harmonie.Application.Tests/Users/SearchUsersHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Users/SearchUsersHandlerTests.cs
@@ -115,7 +115,43 @@ public sealed class SearchUsersHandlerTests
         response.Data.Users[0].Status.Should().Be("Active");
     }
 
-    private static SearchUserResult CreateSearchUser(string username, string? displayName, bool isActive)
+    [Fact]
+    public async Task HandleAsync_WithAvatarAppearance_ShouldMapAvatarDto()
+    {
+        var currentUserId = UserId.New();
+        var userWithAvatar = CreateSearchUser("bob", null, isActive: true, avatarColor: "#ff0000", avatarIcon: "cat", avatarBg: "#ffffff");
+        var userWithoutAvatar = CreateSearchUser("alice", null, isActive: true);
+
+        _userRepositoryMock
+            .Setup(x => x.SearchUsersAsync(
+                It.IsAny<SearchUsersQuery>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([userWithAvatar, userWithoutAvatar]);
+
+        var response = await _handler.HandleAsync(
+            new SearchUsersRequest { Q = "b" },
+            currentUserId);
+
+        response.Success.Should().BeTrue();
+        var users = response.Data!.Users;
+
+        var mappedWithAvatar = users.First(u => u.Username == "bob");
+        mappedWithAvatar.Avatar.Should().NotBeNull();
+        mappedWithAvatar.Avatar!.Color.Should().Be("#ff0000");
+        mappedWithAvatar.Avatar.Icon.Should().Be("cat");
+        mappedWithAvatar.Avatar.Bg.Should().Be("#ffffff");
+
+        var mappedWithoutAvatar = users.First(u => u.Username == "alice");
+        mappedWithoutAvatar.Avatar.Should().BeNull();
+    }
+
+    private static SearchUserResult CreateSearchUser(
+        string username,
+        string? displayName,
+        bool isActive,
+        string? avatarColor = null,
+        string? avatarIcon = null,
+        string? avatarBg = null)
     {
         var usernameResult = Username.Create(username);
         if (usernameResult.IsFailure || usernameResult.Value is null)
@@ -126,6 +162,9 @@ public sealed class SearchUsersHandlerTests
             Username: usernameResult.Value,
             DisplayName: displayName,
             AvatarFileId: UploadedFileId.From(Guid.Parse("9b46d971-3590-4f09-bce6-2a218fc8a8ec")),
+            AvatarColor: avatarColor,
+            AvatarIcon: avatarIcon,
+            AvatarBg: avatarBg,
             Bio: null,
             IsActive: isActive);
     }


### PR DESCRIPTION
## Summary

- Add `avatar_color`, `avatar_icon`, `avatar_bg` to `SearchUserRow` and the SQL query in `SearchUsersAsync`
- Add `AvatarColor/Icon/Bg` to `SearchUserResult` (interface + infrastructure mapping)
- Add `AvatarAppearanceDto? Avatar` to `SearchUsersItemResponse`, matching the pattern used by all other endpoints that return user avatar data
- Update handler to map the new fields
- Add unit test for the avatar DTO mapping (null vs populated)
- Add integration test verifying the avatar appearance is returned after a profile update

Closes #307