### PR TITLE
feat(voice): include avatar data in VoiceParticipantJoined SignalR event (#310)

### DIFF
--- a/src/Harmonie.API/RealTime/Voice/SignalRVoicePresenceNotifier.cs
+++ b/src/Harmonie.API/RealTime/Voice/SignalRVoicePresenceNotifier.cs
@@ -24,6 +24,11 @@ public sealed class SignalRVoicePresenceNotifier : IVoicePresenceNotifier
             ChannelId: notification.ChannelId.Value,
             UserId: notification.UserId.Value,
             ParticipantName: notification.ParticipantName,
+            DisplayName: notification.DisplayName,
+            AvatarFileId: notification.AvatarFileId?.Value,
+            AvatarColor: notification.AvatarColor,
+            AvatarIcon: notification.AvatarIcon,
+            AvatarBg: notification.AvatarBg,
             JoinedAtUtc: notification.JoinedAtUtc);
 
         await _hubContext.Clients
@@ -55,6 +60,11 @@ public sealed record VoiceParticipantJoinedEvent(
     Guid ChannelId,
     Guid UserId,
     string ParticipantName,
+    string? DisplayName,
+    Guid? AvatarFileId,
+    string? AvatarColor,
+    string? AvatarIcon,
+    string? AvatarBg,
     DateTime JoinedAtUtc);
 
 public sealed record VoiceParticipantLeftEvent(

--- a/src/Harmonie.API/RealTime/Voice/SignalRVoicePresenceNotifier.cs
+++ b/src/Harmonie.API/RealTime/Voice/SignalRVoicePresenceNotifier.cs
@@ -23,7 +23,6 @@ public sealed class SignalRVoicePresenceNotifier : IVoicePresenceNotifier
             GuildId: notification.GuildId.Value,
             ChannelId: notification.ChannelId.Value,
             UserId: notification.UserId.Value,
-            ParticipantName: notification.ParticipantName,
             DisplayName: notification.DisplayName,
             AvatarFileId: notification.AvatarFileId?.Value,
             AvatarColor: notification.AvatarColor,
@@ -46,7 +45,6 @@ public sealed class SignalRVoicePresenceNotifier : IVoicePresenceNotifier
             GuildId: notification.GuildId.Value,
             ChannelId: notification.ChannelId.Value,
             UserId: notification.UserId.Value,
-            ParticipantName: notification.ParticipantName,
             LeftAtUtc: notification.LeftAtUtc);
 
         await _hubContext.Clients
@@ -59,7 +57,6 @@ public sealed record VoiceParticipantJoinedEvent(
     Guid GuildId,
     Guid ChannelId,
     Guid UserId,
-    string ParticipantName,
     string? DisplayName,
     Guid? AvatarFileId,
     string? AvatarColor,
@@ -71,5 +68,4 @@ public sealed record VoiceParticipantLeftEvent(
     Guid GuildId,
     Guid ChannelId,
     Guid UserId,
-    string ParticipantName,
     DateTime LeftAtUtc);

--- a/src/Harmonie.Application/Features/Voice/HandleLiveKitWebhook/HandleLiveKitWebhookHandler.cs
+++ b/src/Harmonie.Application/Features/Voice/HandleLiveKitWebhook/HandleLiveKitWebhookHandler.cs
@@ -1,5 +1,6 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Interfaces.Voice;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
@@ -15,15 +16,18 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
 
     private readonly ILiveKitWebhookReceiver _webhookReceiver;
     private readonly IGuildChannelRepository _guildChannelRepository;
+    private readonly IUserRepository _userRepository;
     private readonly IVoicePresenceNotifier _voicePresenceNotifier;
 
     public HandleLiveKitWebhookHandler(
         ILiveKitWebhookReceiver webhookReceiver,
         IGuildChannelRepository guildChannelRepository,
+        IUserRepository userRepository,
         IVoicePresenceNotifier voicePresenceNotifier)
     {
         _webhookReceiver = webhookReceiver;
         _guildChannelRepository = guildChannelRepository;
+        _userRepository = userRepository;
         _voicePresenceNotifier = voicePresenceNotifier;
     }
 
@@ -82,13 +86,20 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
 
         if (eventType == ParticipantJoinedEvent)
         {
+            var user = await _userRepository.GetByIdAsync(participantUserId, cancellationToken);
+
             await _voicePresenceNotifier.NotifyParticipantJoinedAsync(
                 new VoiceParticipantJoinedNotification(
-                    channel.GuildId,
-                    channel.Id,
-                    participantUserId,
-                    participantName,
-                    webhookEvent.OccurredAtUtc),
+                    GuildId: channel.GuildId,
+                    ChannelId: channel.Id,
+                    UserId: participantUserId,
+                    ParticipantName: participantName,
+                    DisplayName: user?.DisplayName,
+                    AvatarFileId: user?.AvatarFileId,
+                    AvatarColor: user?.AvatarColor,
+                    AvatarIcon: user?.AvatarIcon,
+                    AvatarBg: user?.AvatarBg,
+                    JoinedAtUtc: webhookEvent.OccurredAtUtc),
                 cancellationToken);
         }
         else

--- a/src/Harmonie.Application/Features/Voice/HandleLiveKitWebhook/HandleLiveKitWebhookHandler.cs
+++ b/src/Harmonie.Application/Features/Voice/HandleLiveKitWebhook/HandleLiveKitWebhookHandler.cs
@@ -76,11 +76,6 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
             return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(false, eventType));
         }
 
-        var participantName = result.Participant?.Username.Value
-            ?? (string.IsNullOrWhiteSpace(webhookEvent.ParticipantName)
-                ? participantUserId.ToString()
-                : webhookEvent.ParticipantName);
-
         if (eventType == ParticipantJoinedEvent)
         {
             await _voicePresenceNotifier.NotifyParticipantJoinedAsync(
@@ -88,7 +83,6 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
                     GuildId: result.Channel.GuildId,
                     ChannelId: result.Channel.Id,
                     UserId: participantUserId,
-                    ParticipantName: participantName,
                     DisplayName: result.Participant?.DisplayName,
                     AvatarFileId: result.Participant?.AvatarFileId,
                     AvatarColor: result.Participant?.AvatarColor,
@@ -104,7 +98,6 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
                     result.Channel.GuildId,
                     result.Channel.Id,
                     participantUserId,
-                    participantName,
                     webhookEvent.OccurredAtUtc),
                 cancellationToken);
         }

--- a/src/Harmonie.Application/Features/Voice/HandleLiveKitWebhook/HandleLiveKitWebhookHandler.cs
+++ b/src/Harmonie.Application/Features/Voice/HandleLiveKitWebhook/HandleLiveKitWebhookHandler.cs
@@ -1,6 +1,5 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Interfaces.Channels;
-using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Interfaces.Voice;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
@@ -16,18 +15,15 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
 
     private readonly ILiveKitWebhookReceiver _webhookReceiver;
     private readonly IGuildChannelRepository _guildChannelRepository;
-    private readonly IUserRepository _userRepository;
     private readonly IVoicePresenceNotifier _voicePresenceNotifier;
 
     public HandleLiveKitWebhookHandler(
         ILiveKitWebhookReceiver webhookReceiver,
         IGuildChannelRepository guildChannelRepository,
-        IUserRepository userRepository,
         IVoicePresenceNotifier voicePresenceNotifier)
     {
         _webhookReceiver = webhookReceiver;
         _guildChannelRepository = guildChannelRepository;
-        _userRepository = userRepository;
         _voicePresenceNotifier = voicePresenceNotifier;
     }
 
@@ -64,41 +60,40 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
             return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(false, eventType));
         }
 
-        var channel = await _guildChannelRepository.GetByIdAsync(channelId, cancellationToken);
-        if (channel is null)
-        {
-            return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(false, eventType));
-        }
-
-        if (channel.Type != GuildChannelType.Voice)
-        {
-            return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(false, eventType));
-        }
-
         if (!TryParseUserId(webhookEvent.ParticipantIdentity, out var participantUserId) || participantUserId is null)
         {
             return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(false, eventType));
         }
 
-        var participantName = string.IsNullOrWhiteSpace(webhookEvent.ParticipantName)
-            ? participantUserId.ToString()
-            : webhookEvent.ParticipantName;
+        var result = await _guildChannelRepository.GetWithParticipantAsync(channelId, participantUserId, cancellationToken);
+        if (result is null)
+        {
+            return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(false, eventType));
+        }
+
+        if (result.Channel.Type != GuildChannelType.Voice)
+        {
+            return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(false, eventType));
+        }
+
+        var participantName = result.Participant?.Username.Value
+            ?? (string.IsNullOrWhiteSpace(webhookEvent.ParticipantName)
+                ? participantUserId.ToString()
+                : webhookEvent.ParticipantName);
 
         if (eventType == ParticipantJoinedEvent)
         {
-            var user = await _userRepository.GetByIdAsync(participantUserId, cancellationToken);
-
             await _voicePresenceNotifier.NotifyParticipantJoinedAsync(
                 new VoiceParticipantJoinedNotification(
-                    GuildId: channel.GuildId,
-                    ChannelId: channel.Id,
+                    GuildId: result.Channel.GuildId,
+                    ChannelId: result.Channel.Id,
                     UserId: participantUserId,
                     ParticipantName: participantName,
-                    DisplayName: user?.DisplayName,
-                    AvatarFileId: user?.AvatarFileId,
-                    AvatarColor: user?.AvatarColor,
-                    AvatarIcon: user?.AvatarIcon,
-                    AvatarBg: user?.AvatarBg,
+                    DisplayName: result.Participant?.DisplayName,
+                    AvatarFileId: result.Participant?.AvatarFileId,
+                    AvatarColor: result.Participant?.AvatarColor,
+                    AvatarIcon: result.Participant?.AvatarIcon,
+                    AvatarBg: result.Participant?.AvatarBg,
                     JoinedAtUtc: webhookEvent.OccurredAtUtc),
                 cancellationToken);
         }
@@ -106,8 +101,8 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
         {
             await _voicePresenceNotifier.NotifyParticipantLeftAsync(
                 new VoiceParticipantLeftNotification(
-                    channel.GuildId,
-                    channel.Id,
+                    result.Channel.GuildId,
+                    result.Channel.Id,
                     participantUserId,
                     participantName,
                     webhookEvent.OccurredAtUtc),

--- a/src/Harmonie.Application/Interfaces/Channels/IGuildChannelRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Channels/IGuildChannelRepository.cs
@@ -2,6 +2,7 @@ using Harmonie.Domain.Entities.Guilds;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
 
 namespace Harmonie.Application.Interfaces.Channels;
@@ -10,10 +11,27 @@ public sealed record ChannelAccessContext(
     GuildChannel Channel,
     GuildRole? CallerRole);
 
+public sealed record ChannelParticipantProfile(
+    Username Username,
+    string? DisplayName,
+    UploadedFileId? AvatarFileId,
+    string? AvatarColor,
+    string? AvatarIcon,
+    string? AvatarBg);
+
+public sealed record ChannelWithParticipant(
+    GuildChannel Channel,
+    ChannelParticipantProfile? Participant);
+
 public interface IGuildChannelRepository
 {
     Task<GuildChannel?> GetByIdAsync(
         GuildChannelId channelId,
+        CancellationToken cancellationToken = default);
+
+    Task<ChannelWithParticipant?> GetWithParticipantAsync(
+        GuildChannelId channelId,
+        UserId participantId,
         CancellationToken cancellationToken = default);
 
     Task AddAsync(

--- a/src/Harmonie.Application/Interfaces/Voice/IVoicePresenceNotifier.cs
+++ b/src/Harmonie.Application/Interfaces/Voice/IVoicePresenceNotifier.cs
@@ -20,7 +20,6 @@ public sealed record VoiceParticipantJoinedNotification(
     GuildId GuildId,
     GuildChannelId ChannelId,
     UserId UserId,
-    string ParticipantName,
     string? DisplayName,
     UploadedFileId? AvatarFileId,
     string? AvatarColor,
@@ -32,5 +31,4 @@ public sealed record VoiceParticipantLeftNotification(
     GuildId GuildId,
     GuildChannelId ChannelId,
     UserId UserId,
-    string ParticipantName,
     DateTime LeftAtUtc);

--- a/src/Harmonie.Application/Interfaces/Voice/IVoicePresenceNotifier.cs
+++ b/src/Harmonie.Application/Interfaces/Voice/IVoicePresenceNotifier.cs
@@ -1,5 +1,6 @@
 using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
 
 namespace Harmonie.Application.Interfaces.Voice;
@@ -20,6 +21,11 @@ public sealed record VoiceParticipantJoinedNotification(
     GuildChannelId ChannelId,
     UserId UserId,
     string ParticipantName,
+    string? DisplayName,
+    UploadedFileId? AvatarFileId,
+    string? AvatarColor,
+    string? AvatarIcon,
+    string? AvatarBg,
     DateTime JoinedAtUtc);
 
 public sealed record VoiceParticipantLeftNotification(

--- a/src/Harmonie.Infrastructure/Persistence/Channels/GuildChannelRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Channels/GuildChannelRepository.cs
@@ -4,6 +4,7 @@ using Harmonie.Domain.Entities.Guilds;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
 using Harmonie.Infrastructure.Persistence.Common;
 using Harmonie.Infrastructure.Rows.Channels;
@@ -189,6 +190,66 @@ public sealed class GuildChannelRepository : IGuildChannelRepository
         return count > 0;
     }
 
+    public async Task<ChannelWithParticipant?> GetWithParticipantAsync(
+        GuildChannelId channelId,
+        UserId participantId,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+                           SELECT gc.id             AS "Id",
+                                  gc.guild_id       AS "GuildId",
+                                  gc.name           AS "Name",
+                                  gc.type           AS "Type",
+                                  gc.is_default     AS "IsDefault",
+                                  gc.position       AS "Position",
+                                  gc.created_at_utc AS "CreatedAtUtc",
+                                  u.username        AS "Username",
+                                  u.display_name    AS "DisplayName",
+                                  u.avatar_file_id  AS "AvatarFileId",
+                                  u.avatar_color    AS "AvatarColor",
+                                  u.avatar_icon     AS "AvatarIcon",
+                                  u.avatar_bg       AS "AvatarBg"
+                           FROM guild_channels gc
+                           LEFT JOIN guild_members gm
+                                  ON gm.guild_id = gc.guild_id
+                                 AND gm.user_id = @ParticipantId
+                           LEFT JOIN users u
+                                  ON u.id = gm.user_id
+                                 AND u.deleted_at IS NULL
+                           WHERE gc.id = @ChannelId
+                           LIMIT 1
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new { ChannelId = channelId.Value, ParticipantId = participantId.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        var row = await connection.QueryFirstOrDefaultAsync<ChannelWithParticipantDto>(command);
+        if (row is null)
+            return null;
+
+        ChannelParticipantProfile? profile = null;
+        if (row.Username is not null)
+        {
+            var usernameResult = Username.Create(row.Username);
+            if (usernameResult.IsFailure || usernameResult.Value is null)
+                throw new InvalidOperationException("Stored username is invalid.");
+
+            profile = new ChannelParticipantProfile(
+                usernameResult.Value,
+                row.DisplayName,
+                row.AvatarFileId.HasValue ? UploadedFileId.From(row.AvatarFileId.Value) : null,
+                row.AvatarColor,
+                row.AvatarIcon,
+                row.AvatarBg);
+        }
+
+        return new ChannelWithParticipant(MapToGuildChannel(row), profile);
+    }
+
     public async Task<ChannelAccessContext?> GetWithCallerRoleAsync(
         GuildChannelId channelId,
         UserId callerId,
@@ -256,6 +317,21 @@ public sealed class GuildChannelRepository : IGuildChannelRepository
             row.CreatedAtUtc);
     }
 
+    private static GuildChannel MapToGuildChannel(ChannelWithParticipantDto row)
+    {
+        if (!Enum.IsDefined(typeof(GuildChannelType), row.Type))
+            throw new InvalidOperationException("Stored channel type is invalid.");
+
+        return GuildChannel.Rehydrate(
+            GuildChannelId.From(row.Id),
+            GuildId.From(row.GuildId),
+            row.Name,
+            (GuildChannelType)row.Type,
+            row.IsDefault,
+            row.Position,
+            row.CreatedAtUtc);
+    }
+
     private sealed class ChannelWithRoleDto
     {
         public Guid Id { get; init; }
@@ -266,5 +342,22 @@ public sealed class GuildChannelRepository : IGuildChannelRepository
         public int Position { get; init; }
         public DateTime CreatedAtUtc { get; init; }
         public short? Role { get; init; }
+    }
+
+    private sealed class ChannelWithParticipantDto
+    {
+        public Guid Id { get; init; }
+        public Guid GuildId { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public short Type { get; init; }
+        public bool IsDefault { get; init; }
+        public int Position { get; init; }
+        public DateTime CreatedAtUtc { get; init; }
+        public string? Username { get; init; }
+        public string? DisplayName { get; init; }
+        public Guid? AvatarFileId { get; init; }
+        public string? AvatarColor { get; init; }
+        public string? AvatarIcon { get; init; }
+        public string? AvatarBg { get; init; }
     }
 }

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRVoicePresenceHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRVoicePresenceHubTests.cs
@@ -67,9 +67,7 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
         eventPayload.GuildId.Should().Be(guildId.ToString());
         eventPayload.ChannelId.Should().Be(voiceChannelId.ToString());
         eventPayload.UserId.Should().Be(member.UserId.ToString());
-        eventPayload.ParticipantName.Should().Be(member.Username);
         eventPayload.JoinedAtUtc.Should().NotBe(default);
-        // Avatar fields originate from the user profile fetched during webhook processing.
         // A freshly registered user has no avatar set, so all fields are null.
         eventPayload.DisplayName.Should().BeNull();
         eventPayload.AvatarFileId.Should().BeNull();
@@ -113,7 +111,6 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
         eventPayload.GuildId.Should().Be(guildId.ToString());
         eventPayload.ChannelId.Should().Be(voiceChannelId.ToString());
         eventPayload.UserId.Should().Be(member.UserId.ToString());
-        eventPayload.ParticipantName.Should().Be(member.Username);
         eventPayload.LeftAtUtc.Should().NotBe(default);
     }
 
@@ -204,7 +201,6 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
         string GuildId,
         string ChannelId,
         string UserId,
-        string ParticipantName,
         string? DisplayName,
         Guid? AvatarFileId,
         string? AvatarColor,
@@ -216,6 +212,5 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
         string GuildId,
         string ChannelId,
         string UserId,
-        string ParticipantName,
         DateTime LeftAtUtc);
 }

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRVoicePresenceHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRVoicePresenceHubTests.cs
@@ -69,6 +69,13 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
         eventPayload.UserId.Should().Be(member.UserId.ToString());
         eventPayload.ParticipantName.Should().Be(member.Username);
         eventPayload.JoinedAtUtc.Should().NotBe(default);
+        // Avatar fields originate from the user profile fetched during webhook processing.
+        // A freshly registered user has no avatar set, so all fields are null.
+        eventPayload.DisplayName.Should().BeNull();
+        eventPayload.AvatarFileId.Should().BeNull();
+        eventPayload.AvatarColor.Should().BeNull();
+        eventPayload.AvatarIcon.Should().BeNull();
+        eventPayload.AvatarBg.Should().BeNull();
     }
 
     [Fact]
@@ -198,6 +205,11 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
         string ChannelId,
         string UserId,
         string ParticipantName,
+        string? DisplayName,
+        Guid? AvatarFileId,
+        string? AvatarColor,
+        string? AvatarIcon,
+        string? AvatarBg,
         DateTime JoinedAtUtc);
 
     private sealed record SignalRVoiceParticipantLeftEvent(

--- a/tests/Harmonie.Application.Tests/Voice/HandleLiveKitWebhookHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Voice/HandleLiveKitWebhookHandlerTests.cs
@@ -3,7 +3,6 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Features.Voice.HandleLiveKitWebhook;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Application.Interfaces.Channels;
-using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Interfaces.Voice;
 using Harmonie.Domain.Entities.Guilds;
 using Harmonie.Domain.Enums;
@@ -20,7 +19,6 @@ public sealed class HandleLiveKitWebhookHandlerTests
 {
     private readonly Mock<ILiveKitWebhookReceiver> _webhookReceiverMock;
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
-    private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IVoicePresenceNotifier> _voicePresenceNotifierMock;
     private readonly HandleLiveKitWebhookHandler _handler;
 
@@ -28,13 +26,11 @@ public sealed class HandleLiveKitWebhookHandlerTests
     {
         _webhookReceiverMock = new Mock<ILiveKitWebhookReceiver>();
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
-        _userRepositoryMock = new Mock<IUserRepository>();
         _voicePresenceNotifierMock = new Mock<IVoicePresenceNotifier>();
 
         _handler = new HandleLiveKitWebhookHandler(
             _webhookReceiverMock.Object,
             _guildChannelRepositoryMock.Object,
-            _userRepositoryMock.Object,
             _voicePresenceNotifierMock.Object);
     }
 
@@ -109,7 +105,17 @@ public sealed class HandleLiveKitWebhookHandlerTests
     public async Task HandleAsync_WhenParticipantJoined_ShouldNotifyWithAvatarData()
     {
         var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
-        var user = ApplicationTestBuilders.CreateUser();
+        var participantUserId = UserId.New();
+        var avatarFileId = UploadedFileId.New();
+        var usernameResult = Username.Create("alice");
+        var username = usernameResult.Value!;
+        var profile = new ChannelParticipantProfile(
+            username,
+            DisplayName: "Alice",
+            AvatarFileId: avatarFileId,
+            AvatarColor: "#ff0000",
+            AvatarIcon: "star",
+            AvatarBg: "#000000");
         var occurredAtUtc = DateTime.UtcNow;
         var request = new HandleLiveKitWebhookRequest("{}", "Bearer token");
 
@@ -119,17 +125,13 @@ public sealed class HandleLiveKitWebhookHandlerTests
                 new LiveKitWebhookEvent(
                     "participant_joined",
                     $"channel:{channel.Id}",
-                    user.Id.ToString(),
-                    user.Username.Value,
+                    participantUserId.ToString(),
+                    username.Value,
                     occurredAtUtc)));
 
         _guildChannelRepositoryMock
-            .Setup(x => x.GetByIdAsync(channel.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(channel);
-
-        _userRepositoryMock
-            .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(user);
+            .Setup(x => x.GetWithParticipantAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelWithParticipant(channel, profile));
 
         var response = await _handler.HandleAsync(request);
 
@@ -143,20 +145,20 @@ public sealed class HandleLiveKitWebhookHandlerTests
                 It.Is<VoiceParticipantJoinedNotification>(notification =>
                     notification.GuildId == channel.GuildId
                     && notification.ChannelId == channel.Id
-                    && notification.UserId == user.Id
-                    && notification.ParticipantName == user.Username.Value
-                    && notification.DisplayName == user.DisplayName
-                    && notification.AvatarFileId == user.AvatarFileId
-                    && notification.AvatarColor == user.AvatarColor
-                    && notification.AvatarIcon == user.AvatarIcon
-                    && notification.AvatarBg == user.AvatarBg
+                    && notification.UserId == participantUserId
+                    && notification.ParticipantName == username.Value
+                    && notification.DisplayName == profile.DisplayName
+                    && notification.AvatarFileId == profile.AvatarFileId
+                    && notification.AvatarColor == profile.AvatarColor
+                    && notification.AvatarIcon == profile.AvatarIcon
+                    && notification.AvatarBg == profile.AvatarBg
                     && notification.JoinedAtUtc == occurredAtUtc),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
     [Fact]
-    public async Task HandleAsync_WhenParticipantJoinedAndUserNotFound_ShouldNotifyWithNullAvatarData()
+    public async Task HandleAsync_WhenParticipantJoinedAndNotGuildMember_ShouldNotifyWithNullAvatarDataAndWebhookName()
     {
         var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
         var participantUserId = UserId.New();
@@ -174,12 +176,8 @@ public sealed class HandleLiveKitWebhookHandlerTests
                     occurredAtUtc)));
 
         _guildChannelRepositoryMock
-            .Setup(x => x.GetByIdAsync(channel.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(channel);
-
-        _userRepositoryMock
-            .Setup(x => x.GetByIdAsync(participantUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Harmonie.Domain.Entities.Users.User?)null);
+            .Setup(x => x.GetWithParticipantAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelWithParticipant(channel, null));
 
         var response = await _handler.HandleAsync(request);
 
@@ -190,6 +188,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
             x => x.NotifyParticipantJoinedAsync(
                 It.Is<VoiceParticipantJoinedNotification>(notification =>
                     notification.UserId == participantUserId
+                    && notification.ParticipantName == "ghost"
                     && notification.DisplayName == null
                     && notification.AvatarFileId == null
                     && notification.AvatarColor == null
@@ -204,6 +203,9 @@ public sealed class HandleLiveKitWebhookHandlerTests
     {
         var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
         var participantUserId = UserId.New();
+        var usernameResult = Username.Create("alice");
+        var username = usernameResult.Value!;
+        var profile = new ChannelParticipantProfile(username, null, null, null, null, null);
         var occurredAtUtc = DateTime.UtcNow;
         var request = new HandleLiveKitWebhookRequest("{}", "Bearer token");
 
@@ -214,12 +216,12 @@ public sealed class HandleLiveKitWebhookHandlerTests
                     "participant_left",
                     $"channel:{channel.Id}",
                     participantUserId.ToString(),
-                    "alice",
+                    username.Value,
                     occurredAtUtc)));
 
         _guildChannelRepositoryMock
-            .Setup(x => x.GetByIdAsync(channel.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(channel);
+            .Setup(x => x.GetWithParticipantAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelWithParticipant(channel, profile));
 
         var response = await _handler.HandleAsync(request);
 
@@ -234,7 +236,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
                     notification.GuildId == channel.GuildId
                     && notification.ChannelId == channel.Id
                     && notification.UserId == participantUserId
-                    && notification.ParticipantName == "alice"
+                    && notification.ParticipantName == username.Value
                     && notification.LeftAtUtc == occurredAtUtc),
                 It.IsAny<CancellationToken>()),
             Times.Once);

--- a/tests/Harmonie.Application.Tests/Voice/HandleLiveKitWebhookHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Voice/HandleLiveKitWebhookHandlerTests.cs
@@ -7,7 +7,6 @@ using Harmonie.Application.Interfaces.Voice;
 using Harmonie.Domain.Entities.Guilds;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
-using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
 using Moq;
@@ -107,10 +106,8 @@ public sealed class HandleLiveKitWebhookHandlerTests
         var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
         var participantUserId = UserId.New();
         var avatarFileId = UploadedFileId.New();
-        var usernameResult = Username.Create("alice");
-        var username = usernameResult.Value!;
         var profile = new ChannelParticipantProfile(
-            username,
+            Username.Create("alice").Value!,
             DisplayName: "Alice",
             AvatarFileId: avatarFileId,
             AvatarColor: "#ff0000",
@@ -126,7 +123,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
                     "participant_joined",
                     $"channel:{channel.Id}",
                     participantUserId.ToString(),
-                    username.Value,
+                    "alice",
                     occurredAtUtc)));
 
         _guildChannelRepositoryMock
@@ -136,7 +133,6 @@ public sealed class HandleLiveKitWebhookHandlerTests
         var response = await _handler.HandleAsync(request);
 
         response.Success.Should().BeTrue();
-        response.Data.Should().NotBeNull();
         response.Data!.Processed.Should().BeTrue();
         response.Data.EventType.Should().Be("participant_joined");
 
@@ -146,7 +142,6 @@ public sealed class HandleLiveKitWebhookHandlerTests
                     notification.GuildId == channel.GuildId
                     && notification.ChannelId == channel.Id
                     && notification.UserId == participantUserId
-                    && notification.ParticipantName == username.Value
                     && notification.DisplayName == profile.DisplayName
                     && notification.AvatarFileId == profile.AvatarFileId
                     && notification.AvatarColor == profile.AvatarColor
@@ -158,7 +153,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_WhenParticipantJoinedAndNotGuildMember_ShouldNotifyWithNullAvatarDataAndWebhookName()
+    public async Task HandleAsync_WhenParticipantJoinedAndNotGuildMember_ShouldNotifyWithNullAvatarData()
     {
         var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
         var participantUserId = UserId.New();
@@ -188,7 +183,6 @@ public sealed class HandleLiveKitWebhookHandlerTests
             x => x.NotifyParticipantJoinedAsync(
                 It.Is<VoiceParticipantJoinedNotification>(notification =>
                     notification.UserId == participantUserId
-                    && notification.ParticipantName == "ghost"
                     && notification.DisplayName == null
                     && notification.AvatarFileId == null
                     && notification.AvatarColor == null
@@ -203,9 +197,6 @@ public sealed class HandleLiveKitWebhookHandlerTests
     {
         var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
         var participantUserId = UserId.New();
-        var usernameResult = Username.Create("alice");
-        var username = usernameResult.Value!;
-        var profile = new ChannelParticipantProfile(username, null, null, null, null, null);
         var occurredAtUtc = DateTime.UtcNow;
         var request = new HandleLiveKitWebhookRequest("{}", "Bearer token");
 
@@ -216,17 +207,16 @@ public sealed class HandleLiveKitWebhookHandlerTests
                     "participant_left",
                     $"channel:{channel.Id}",
                     participantUserId.ToString(),
-                    username.Value,
+                    "alice",
                     occurredAtUtc)));
 
         _guildChannelRepositoryMock
             .Setup(x => x.GetWithParticipantAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ChannelWithParticipant(channel, profile));
+            .ReturnsAsync(new ChannelWithParticipant(channel, null));
 
         var response = await _handler.HandleAsync(request);
 
         response.Success.Should().BeTrue();
-        response.Data.Should().NotBeNull();
         response.Data!.Processed.Should().BeTrue();
         response.Data.EventType.Should().Be("participant_left");
 
@@ -236,7 +226,6 @@ public sealed class HandleLiveKitWebhookHandlerTests
                     notification.GuildId == channel.GuildId
                     && notification.ChannelId == channel.Id
                     && notification.UserId == participantUserId
-                    && notification.ParticipantName == username.Value
                     && notification.LeftAtUtc == occurredAtUtc),
                 It.IsAny<CancellationToken>()),
             Times.Once);

--- a/tests/Harmonie.Application.Tests/Voice/HandleLiveKitWebhookHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Voice/HandleLiveKitWebhookHandlerTests.cs
@@ -3,11 +3,13 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Features.Voice.HandleLiveKitWebhook;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Interfaces.Voice;
 using Harmonie.Domain.Entities.Guilds;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Guilds;
+using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
 using Moq;
 using Xunit;
@@ -18,6 +20,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
 {
     private readonly Mock<ILiveKitWebhookReceiver> _webhookReceiverMock;
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
+    private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IVoicePresenceNotifier> _voicePresenceNotifierMock;
     private readonly HandleLiveKitWebhookHandler _handler;
 
@@ -25,11 +28,13 @@ public sealed class HandleLiveKitWebhookHandlerTests
     {
         _webhookReceiverMock = new Mock<ILiveKitWebhookReceiver>();
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
+        _userRepositoryMock = new Mock<IUserRepository>();
         _voicePresenceNotifierMock = new Mock<IVoicePresenceNotifier>();
 
         _handler = new HandleLiveKitWebhookHandler(
             _webhookReceiverMock.Object,
             _guildChannelRepositoryMock.Object,
+            _userRepositoryMock.Object,
             _voicePresenceNotifierMock.Object);
     }
 
@@ -101,10 +106,10 @@ public sealed class HandleLiveKitWebhookHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_WhenParticipantJoined_ShouldNotifyGuildGroup()
+    public async Task HandleAsync_WhenParticipantJoined_ShouldNotifyWithAvatarData()
     {
         var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
-        var participantUserId = UserId.New();
+        var user = ApplicationTestBuilders.CreateUser();
         var occurredAtUtc = DateTime.UtcNow;
         var request = new HandleLiveKitWebhookRequest("{}", "Bearer token");
 
@@ -114,13 +119,17 @@ public sealed class HandleLiveKitWebhookHandlerTests
                 new LiveKitWebhookEvent(
                     "participant_joined",
                     $"channel:{channel.Id}",
-                    participantUserId.ToString(),
-                    "alice",
+                    user.Id.ToString(),
+                    user.Username.Value,
                     occurredAtUtc)));
 
         _guildChannelRepositoryMock
             .Setup(x => x.GetByIdAsync(channel.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(channel);
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
 
         var response = await _handler.HandleAsync(request);
 
@@ -134,9 +143,58 @@ public sealed class HandleLiveKitWebhookHandlerTests
                 It.Is<VoiceParticipantJoinedNotification>(notification =>
                     notification.GuildId == channel.GuildId
                     && notification.ChannelId == channel.Id
-                    && notification.UserId == participantUserId
-                    && notification.ParticipantName == "alice"
+                    && notification.UserId == user.Id
+                    && notification.ParticipantName == user.Username.Value
+                    && notification.DisplayName == user.DisplayName
+                    && notification.AvatarFileId == user.AvatarFileId
+                    && notification.AvatarColor == user.AvatarColor
+                    && notification.AvatarIcon == user.AvatarIcon
+                    && notification.AvatarBg == user.AvatarBg
                     && notification.JoinedAtUtc == occurredAtUtc),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenParticipantJoinedAndUserNotFound_ShouldNotifyWithNullAvatarData()
+    {
+        var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
+        var participantUserId = UserId.New();
+        var occurredAtUtc = DateTime.UtcNow;
+        var request = new HandleLiveKitWebhookRequest("{}", "Bearer token");
+
+        _webhookReceiverMock
+            .Setup(x => x.Receive(request.RawBody, request.AuthorizationHeader!))
+            .Returns(LiveKitWebhookReceiveResult.Ok(
+                new LiveKitWebhookEvent(
+                    "participant_joined",
+                    $"channel:{channel.Id}",
+                    participantUserId.ToString(),
+                    "ghost",
+                    occurredAtUtc)));
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetByIdAsync(channel.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(channel);
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Harmonie.Domain.Entities.Users.User?)null);
+
+        var response = await _handler.HandleAsync(request);
+
+        response.Success.Should().BeTrue();
+        response.Data!.Processed.Should().BeTrue();
+
+        _voicePresenceNotifierMock.Verify(
+            x => x.NotifyParticipantJoinedAsync(
+                It.Is<VoiceParticipantJoinedNotification>(notification =>
+                    notification.UserId == participantUserId
+                    && notification.DisplayName == null
+                    && notification.AvatarFileId == null
+                    && notification.AvatarColor == null
+                    && notification.AvatarIcon == null
+                    && notification.AvatarBg == null),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }


### PR DESCRIPTION
Closes #310

## Summary

- `HandleLiveKitWebhookHandler` now injects `IUserRepository` and fetches the user profile on `participant_joined` webhook events
- `VoiceParticipantJoinedNotification` and `VoiceParticipantJoinedEvent` carry `DisplayName`, `AvatarFileId`, `AvatarColor`, `AvatarIcon`, `AvatarBg`
- Null-safe: if the user is not found in the DB the avatar fields are `null` and the notification still goes through

## Test plan

- [x] Unit test: `HandleAsync_WhenParticipantJoined_ShouldNotifyWithAvatarData` — verifies avatar fields are populated from the user profile
- [x] Unit test: `HandleAsync_WhenParticipantJoinedAndUserNotFound_ShouldNotifyWithNullAvatarData` — verifies graceful null handling
- [x] Integration test: `VoiceParticipantJoined_WhenMemberConnected_ShouldReceiveEvent` — asserts new avatar fields present in the SignalR event (null for freshly registered user)
- [x] All 894 tests pass, 0 build warnings