### PR TITLE
feat(conversations): include avatar data and participant details across conversation responses and SignalR events

### DIFF
--- a/src/Harmonie.API/RealTime/Conversations/SignalRConversationNotifier.cs
+++ b/src/Harmonie.API/RealTime/Conversations/SignalRConversationNotifier.cs
@@ -1,4 +1,6 @@
 using Harmonie.API.RealTime.Common;
+using Harmonie.Application.Features.Conversations;
+using Harmonie.Application.Features.Users;
 using Harmonie.Application.Interfaces.Conversations;
 using Microsoft.AspNetCore.SignalR;
 
@@ -22,7 +24,16 @@ public sealed class SignalRConversationNotifier : IConversationNotifier
         var payload = new ConversationCreatedEvent(
             ConversationId: notification.ConversationId.Value,
             Name: notification.Name,
-            ParticipantIds: notification.ParticipantIds.Select(id => id.Value).ToArray());
+            Participants: notification.Participants
+                .Select(p => new ConversationParticipantEventDto(
+                    UserId: p.UserId,
+                    Username: p.Username,
+                    DisplayName: p.DisplayName,
+                    AvatarFileId: p.AvatarFileId,
+                    Avatar: p.Avatar is not null
+                        ? new AvatarAppearanceDto(p.Avatar.Color, p.Avatar.Icon, p.Avatar.Bg)
+                        : null))
+                .ToArray());
 
         await _hubContext.Clients
             .Group(RealtimeHub.GetConversationGroupName(notification.ConversationId))
@@ -48,7 +59,14 @@ public sealed class SignalRConversationNotifier : IConversationNotifier
 public sealed record ConversationCreatedEvent(
     Guid ConversationId,
     string? Name,
-    IReadOnlyList<Guid> ParticipantIds);
+    IReadOnlyList<ConversationParticipantEventDto> Participants);
+
+public sealed record ConversationParticipantEventDto(
+    Guid UserId,
+    string Username,
+    string? DisplayName,
+    Guid? AvatarFileId,
+    AvatarAppearanceDto? Avatar);
 
 public sealed record ConversationParticipantLeftEvent(
     Guid ConversationId,

--- a/src/Harmonie.Application/Features/Conversations/ConversationParticipantDto.cs
+++ b/src/Harmonie.Application/Features/Conversations/ConversationParticipantDto.cs
@@ -1,0 +1,10 @@
+using Harmonie.Application.Features.Users;
+
+namespace Harmonie.Application.Features.Conversations;
+
+public sealed record ConversationParticipantDto(
+    Guid UserId,
+    string Username,
+    string? DisplayName,
+    Guid? AvatarFileId,
+    AvatarAppearanceDto? Avatar);

--- a/src/Harmonie.Application/Features/Conversations/CreateGroupConversation/CreateGroupConversationHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/CreateGroupConversation/CreateGroupConversationHandler.cs
@@ -1,7 +1,9 @@
 using Harmonie.Application.Common;
+using Harmonie.Application.Features.Users;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Users;
+using Harmonie.Domain.Entities.Users;
 using Harmonie.Domain.ValueObjects.Users;
 using Microsoft.Extensions.Logging;
 
@@ -43,6 +45,7 @@ public sealed class CreateGroupConversationHandler : IAuthenticatedHandler<Creat
                 "You must be included in the participant list");
         }
 
+        var participantUsers = new List<User>(participantUserIds.Length);
         foreach (var participantId in participantUserIds)
         {
             var user = await _userRepository.GetByIdAsync(participantId, cancellationToken);
@@ -52,12 +55,15 @@ public sealed class CreateGroupConversationHandler : IAuthenticatedHandler<Creat
                     ApplicationErrorCodes.User.NotFound,
                     $"User {participantId} was not found");
             }
+            participantUsers.Add(user);
         }
 
         var conversation = await _conversationRepository.CreateGroupAsync(
             request.Name,
             participantUserIds,
             cancellationToken);
+
+        var participantDtos = participantUsers.Select(ToParticipantDto).ToArray();
 
         await BestEffortNotificationHelper.TryNotifyAsync(
             async ct =>
@@ -70,7 +76,7 @@ public sealed class CreateGroupConversationHandler : IAuthenticatedHandler<Creat
                     new ConversationCreatedNotification(
                         ConversationId: conversation.Id,
                         Name: conversation.Name,
-                        ParticipantIds: participantUserIds),
+                        Participants: participantDtos),
                     ct);
             },
             TimeSpan.FromSeconds(5),
@@ -82,9 +88,23 @@ public sealed class CreateGroupConversationHandler : IAuthenticatedHandler<Creat
             ConversationId: conversation.Id.Value,
             Type: "group",
             Name: conversation.Name,
-            ParticipantIds: participantUserIds.Select(id => id.Value).ToArray(),
+            Participants: participantDtos,
             CreatedAtUtc: conversation.CreatedAtUtc);
 
         return ApplicationResponse<CreateGroupConversationResponse>.Ok(payload);
+    }
+
+    private static ConversationParticipantDto ToParticipantDto(User user)
+    {
+        var avatar = user.AvatarColor is not null || user.AvatarIcon is not null || user.AvatarBg is not null
+            ? new AvatarAppearanceDto(user.AvatarColor, user.AvatarIcon, user.AvatarBg)
+            : null;
+
+        return new ConversationParticipantDto(
+            UserId: user.Id.Value,
+            Username: user.Username.Value,
+            DisplayName: user.DisplayName,
+            AvatarFileId: user.AvatarFileId?.Value,
+            Avatar: avatar);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/CreateGroupConversation/CreateGroupConversationHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/CreateGroupConversation/CreateGroupConversationHandler.cs
@@ -45,17 +45,13 @@ public sealed class CreateGroupConversationHandler : IAuthenticatedHandler<Creat
                 "You must be included in the participant list");
         }
 
-        var participantUsers = new List<User>(participantUserIds.Length);
-        foreach (var participantId in participantUserIds)
+        var participantUsers = await _userRepository.GetManyByIdsAsync(participantUserIds, cancellationToken);
+        var missingId = participantUserIds.FirstOrDefault(id => participantUsers.All(u => u.Id != id));
+        if (missingId != default)
         {
-            var user = await _userRepository.GetByIdAsync(participantId, cancellationToken);
-            if (user is null)
-            {
-                return ApplicationResponse<CreateGroupConversationResponse>.Fail(
-                    ApplicationErrorCodes.User.NotFound,
-                    $"User {participantId} was not found");
-            }
-            participantUsers.Add(user);
+            return ApplicationResponse<CreateGroupConversationResponse>.Fail(
+                ApplicationErrorCodes.User.NotFound,
+                $"User {missingId} was not found");
         }
 
         var conversation = await _conversationRepository.CreateGroupAsync(

--- a/src/Harmonie.Application/Features/Conversations/CreateGroupConversation/CreateGroupConversationResponse.cs
+++ b/src/Harmonie.Application/Features/Conversations/CreateGroupConversation/CreateGroupConversationResponse.cs
@@ -4,5 +4,5 @@ public sealed record CreateGroupConversationResponse(
     Guid ConversationId,
     string Type,
     string? Name,
-    IReadOnlyList<Guid> ParticipantIds,
+    IReadOnlyList<ConversationParticipantDto> Participants,
     DateTime CreatedAtUtc);

--- a/src/Harmonie.Application/Features/Conversations/ListConversations/ListConversationsHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/ListConversations/ListConversationsHandler.cs
@@ -1,4 +1,5 @@
 using Harmonie.Application.Common;
+using Harmonie.Application.Features.Users;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Domain.ValueObjects.Users;
 
@@ -29,7 +30,19 @@ public sealed class ListConversationsHandler : IAuthenticatedHandler<Unit, ListC
                     Type: conversation.Type.ToString().ToLowerInvariant(),
                     Name: conversation.Name,
                     Participants: conversation.Participants
-                        .Select(p => new ListConversationsParticipantDto(p.UserId.Value, p.Username.Value))
+                        .Select(p =>
+                        {
+                            var avatar = p.AvatarColor is not null || p.AvatarIcon is not null || p.AvatarBg is not null
+                                ? new AvatarAppearanceDto(p.AvatarColor, p.AvatarIcon, p.AvatarBg)
+                                : null;
+
+                            return new ListConversationsParticipantDto(
+                                UserId: p.UserId.Value,
+                                Username: p.Username.Value,
+                                DisplayName: p.DisplayName,
+                                AvatarFileId: p.AvatarFileId,
+                                Avatar: avatar);
+                        })
                         .ToArray(),
                     CreatedAtUtc: conversation.CreatedAtUtc))
                 .ToArray());

--- a/src/Harmonie.Application/Features/Conversations/ListConversations/ListConversationsResponse.cs
+++ b/src/Harmonie.Application/Features/Conversations/ListConversations/ListConversationsResponse.cs
@@ -1,3 +1,5 @@
+using Harmonie.Application.Features.Users;
+
 namespace Harmonie.Application.Features.Conversations.ListConversations;
 
 public sealed record ListConversationsResponse(
@@ -10,4 +12,9 @@ public sealed record ListConversationsItemResponse(
     IReadOnlyList<ListConversationsParticipantDto> Participants,
     DateTime CreatedAtUtc);
 
-public sealed record ListConversationsParticipantDto(Guid UserId, string Username);
+public sealed record ListConversationsParticipantDto(
+    Guid UserId,
+    string Username,
+    string? DisplayName,
+    Guid? AvatarFileId,
+    AvatarAppearanceDto? Avatar);

--- a/src/Harmonie.Application/Features/Conversations/OpenConversation/OpenConversationHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/OpenConversation/OpenConversationHandler.cs
@@ -1,7 +1,9 @@
 using Harmonie.Application.Common;
+using Harmonie.Application.Features.Users;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Users;
+using Harmonie.Domain.Entities.Users;
 using Harmonie.Domain.ValueObjects.Users;
 using Microsoft.Extensions.Logging;
 
@@ -40,12 +42,24 @@ public sealed class OpenConversationHandler : IAuthenticatedHandler<OpenConversa
                 "You cannot open a conversation with yourself");
         }
 
-        var targetUser = await _userRepository.GetByIdAsync(targetUserId, cancellationToken);
+        var targetUserTask = _userRepository.GetByIdAsync(targetUserId, cancellationToken);
+        var currentUserTask = _userRepository.GetByIdAsync(currentUserId, cancellationToken);
+        await Task.WhenAll(targetUserTask, currentUserTask);
+        var targetUser = await targetUserTask;
+        var currentUser = await currentUserTask;
+
         if (targetUser is null)
         {
             return ApplicationResponse<OpenConversationResponse>.Fail(
                 ApplicationErrorCodes.User.NotFound,
                 "Target user was not found");
+        }
+
+        if (currentUser is null)
+        {
+            return ApplicationResponse<OpenConversationResponse>.Fail(
+                ApplicationErrorCodes.User.NotFound,
+                "Current user was not found");
         }
 
         var result = await _conversationRepository.GetOrCreateDirectAsync(
@@ -72,10 +86,24 @@ public sealed class OpenConversationHandler : IAuthenticatedHandler<OpenConversa
         var payload = new OpenConversationResponse(
             ConversationId: result.Conversation.Id.Value,
             Type: "direct",
-            ParticipantIds: [currentUserId.Value, targetUserId.Value],
+            Participants: [ToParticipantDto(currentUser), ToParticipantDto(targetUser)],
             CreatedAtUtc: result.Conversation.CreatedAtUtc,
             Created: result.WasCreated);
 
         return ApplicationResponse<OpenConversationResponse>.Ok(payload);
+    }
+
+    private static ConversationParticipantDto ToParticipantDto(User user)
+    {
+        var avatar = user.AvatarColor is not null || user.AvatarIcon is not null || user.AvatarBg is not null
+            ? new AvatarAppearanceDto(user.AvatarColor, user.AvatarIcon, user.AvatarBg)
+            : null;
+
+        return new ConversationParticipantDto(
+            UserId: user.Id.Value,
+            Username: user.Username.Value,
+            DisplayName: user.DisplayName,
+            AvatarFileId: user.AvatarFileId?.Value,
+            Avatar: avatar);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/OpenConversation/OpenConversationHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/OpenConversation/OpenConversationHandler.cs
@@ -42,11 +42,9 @@ public sealed class OpenConversationHandler : IAuthenticatedHandler<OpenConversa
                 "You cannot open a conversation with yourself");
         }
 
-        var targetUserTask = _userRepository.GetByIdAsync(targetUserId, cancellationToken);
-        var currentUserTask = _userRepository.GetByIdAsync(currentUserId, cancellationToken);
-        await Task.WhenAll(targetUserTask, currentUserTask);
-        var targetUser = await targetUserTask;
-        var currentUser = await currentUserTask;
+        var users = await _userRepository.GetManyByIdsAsync([currentUserId, targetUserId], cancellationToken);
+        var currentUser = users.FirstOrDefault(u => u.Id == currentUserId);
+        var targetUser = users.FirstOrDefault(u => u.Id == targetUserId);
 
         if (targetUser is null)
         {

--- a/src/Harmonie.Application/Features/Conversations/OpenConversation/OpenConversationResponse.cs
+++ b/src/Harmonie.Application/Features/Conversations/OpenConversation/OpenConversationResponse.cs
@@ -3,6 +3,6 @@ namespace Harmonie.Application.Features.Conversations.OpenConversation;
 public sealed record OpenConversationResponse(
     Guid ConversationId,
     string Type,
-    IReadOnlyList<Guid> ParticipantIds,
+    IReadOnlyList<ConversationParticipantDto> Participants,
     DateTime CreatedAtUtc,
     bool Created);

--- a/src/Harmonie.Application/Interfaces/Conversations/IConversationNotifier.cs
+++ b/src/Harmonie.Application/Interfaces/Conversations/IConversationNotifier.cs
@@ -1,3 +1,4 @@
+using Harmonie.Application.Features.Conversations;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Users;
 
@@ -17,7 +18,7 @@ public interface IConversationNotifier
 public sealed record ConversationCreatedNotification(
     ConversationId ConversationId,
     string? Name,
-    IReadOnlyList<UserId> ParticipantIds);
+    IReadOnlyList<ConversationParticipantDto> Participants);
 
 public sealed record ConversationParticipantLeftNotification(
     ConversationId ConversationId,

--- a/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
@@ -4,7 +4,14 @@ using Harmonie.Domain.ValueObjects.Users;
 
 namespace Harmonie.Application.Interfaces.Conversations;
 
-public sealed record ConversationParticipantSummary(UserId UserId, Username Username);
+public sealed record ConversationParticipantSummary(
+    UserId UserId,
+    Username Username,
+    string? DisplayName,
+    Guid? AvatarFileId,
+    string? AvatarColor,
+    string? AvatarIcon,
+    string? AvatarBg);
 
 public sealed record ConversationGetOrCreateResult(Conversation Conversation, bool WasCreated);
 

--- a/src/Harmonie.Application/Interfaces/Users/IUserRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Users/IUserRepository.cs
@@ -48,6 +48,11 @@ public interface IUserRepository
     Task<User?> GetByIdAsync(UserId userId, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Get multiple users by their IDs in a single query. Users not found are omitted from the result.
+    /// </summary>
+    Task<IReadOnlyList<User>> GetManyByIdsAsync(IReadOnlyList<UserId> userIds, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Get a user by their email address
     /// </summary>
     Task<User?> GetByEmailAsync(Email email, CancellationToken cancellationToken = default);

--- a/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
@@ -164,12 +164,17 @@ public sealed class ConversationRepository : IConversationRepository
         CancellationToken cancellationToken = default)
     {
         const string sql = """
-                           SELECT c.id             AS "ConversationId",
-                                  c.type           AS "Type",
-                                  c.name           AS "Name",
-                                  c.created_at_utc AS "CreatedAtUtc",
-                                  cp2.user_id      AS "ParticipantUserId",
-                                  u.username       AS "ParticipantUsername"
+                           SELECT c.id              AS "ConversationId",
+                                  c.type            AS "Type",
+                                  c.name            AS "Name",
+                                  c.created_at_utc  AS "CreatedAtUtc",
+                                  cp2.user_id       AS "ParticipantUserId",
+                                  u.username        AS "ParticipantUsername",
+                                  u.display_name    AS "ParticipantDisplayName",
+                                  u.avatar_file_id  AS "ParticipantAvatarFileId",
+                                  u.avatar_color    AS "ParticipantAvatarColor",
+                                  u.avatar_icon     AS "ParticipantAvatarIcon",
+                                  u.avatar_bg       AS "ParticipantAvatarBg"
                            FROM conversation_participants cp1
                            INNER JOIN conversations c ON c.id = cp1.conversation_id
                            INNER JOIN conversation_participants cp2 ON cp2.conversation_id = c.id
@@ -199,7 +204,14 @@ public sealed class ConversationRepository : IConversationRepository
                     var usernameResult = Username.Create(r.ParticipantUsername);
                     if (usernameResult.IsFailure || usernameResult.Value is null)
                         throw new InvalidOperationException("Stored conversation participant username is invalid.");
-                    return new ConversationParticipantSummary(UserId.From(r.ParticipantUserId), usernameResult.Value);
+                    return new ConversationParticipantSummary(
+                        UserId.From(r.ParticipantUserId),
+                        usernameResult.Value,
+                        r.ParticipantDisplayName,
+                        r.ParticipantAvatarFileId,
+                        r.ParticipantAvatarColor,
+                        r.ParticipantAvatarIcon,
+                        r.ParticipantAvatarBg);
                 }).ToArray();
 
                 return new UserConversationSummary(

--- a/src/Harmonie.Infrastructure/Persistence/Users/UserRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Users/UserRepository.cs
@@ -58,6 +58,23 @@ public sealed class UserRepository : IUserRepository
         return userRow is null ? null : MapToUser(userRow);
     }
 
+    public async Task<IReadOnlyList<User>> GetManyByIdsAsync(IReadOnlyList<UserId> userIds, CancellationToken ct = default)
+    {
+        if (userIds.Count == 0)
+            return [];
+
+        var sql = $"{SelectUserSql} WHERE id = ANY(@Ids) AND deleted_at IS NULL";
+        var conn = await _dbSession.GetOpenConnectionAsync(ct);
+        var cmd = new CommandDefinition(
+            sql,
+            new { Ids = userIds.Select(id => id.Value).ToArray() },
+            transaction: _dbSession.Transaction,
+            cancellationToken: ct);
+        var rows = await conn.QueryAsync<UserRow>(cmd);
+
+        return rows.Select(MapToUser).ToArray();
+    }
+
     public async Task<User?> GetByEmailAsync(Email email, CancellationToken ct = default)
     {
         var sql = $"{SelectUserSql} WHERE email = @Email AND deleted_at IS NULL";

--- a/src/Harmonie.Infrastructure/Rows/Conversations/UserConversationSummaryRow.cs
+++ b/src/Harmonie.Infrastructure/Rows/Conversations/UserConversationSummaryRow.cs
@@ -13,4 +13,14 @@ public sealed class UserConversationSummaryRow
     public Guid ParticipantUserId { get; init; }
 
     public string ParticipantUsername { get; init; } = string.Empty;
+
+    public string? ParticipantDisplayName { get; init; }
+
+    public Guid? ParticipantAvatarFileId { get; init; }
+
+    public string? ParticipantAvatarColor { get; init; }
+
+    public string? ParticipantAvatarIcon { get; init; }
+
+    public string? ParticipantAvatarBg { get; init; }
 }

--- a/tests/Harmonie.API.IntegrationTests/Conversations/ConversationEndpointsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/ConversationEndpointsTests.cs
@@ -37,7 +37,9 @@ public sealed class ConversationEndpointsTests : IClassFixture<HarmonieWebApplic
         payload!.Created.Should().BeTrue();
         payload.ConversationId.Should().NotBeEmpty();
         payload.Type.Should().Be("direct");
-        payload.ParticipantIds.Should().HaveCount(2).And.Contain(caller.UserId).And.Contain(target.UserId);
+        payload.Participants.Should().HaveCount(2);
+        payload.Participants.Should().Contain(p => p.UserId == caller.UserId);
+        payload.Participants.Should().Contain(p => p.UserId == target.UserId);
     }
 
     [Fact]

--- a/tests/Harmonie.API.IntegrationTests/Conversations/GroupConversationEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/GroupConversationEndpointTests.cs
@@ -42,10 +42,10 @@ public sealed class GroupConversationEndpointTests : IClassFixture<HarmonieWebAp
         payload!.Type.Should().Be("group");
         payload.Name.Should().Be("Dev Team");
         payload.ConversationId.Should().NotBeEmpty();
-        payload.ParticipantIds.Should().HaveCount(3)
-            .And.Contain(caller.UserId)
-            .And.Contain(memberB.UserId)
-            .And.Contain(memberC.UserId);
+        payload.Participants.Should().HaveCount(3);
+        payload.Participants.Should().Contain(p => p.UserId == caller.UserId);
+        payload.Participants.Should().Contain(p => p.UserId == memberB.UserId);
+        payload.Participants.Should().Contain(p => p.UserId == memberC.UserId);
     }
 
     [Fact]

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRConversationCreatedHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRConversationCreatedHubTests.cs
@@ -49,8 +49,8 @@ public sealed class SignalRConversationCreatedHubTests : IClassFixture<HarmonieW
         var eventPayload = await eventReceived.Task;
         eventPayload.ConversationId.Should().Be(group.ConversationId.ToString());
         eventPayload.Name.Should().Be("Integration Test Group");
-        eventPayload.ParticipantIds.Should().Contain(creator.UserId.ToString());
-        eventPayload.ParticipantIds.Should().Contain(participant.UserId.ToString());
+        eventPayload.Participants.Should().Contain(p => p.UserId == creator.UserId);
+        eventPayload.Participants.Should().Contain(p => p.UserId == participant.UserId);
     }
 
     private HubConnection CreateHubConnection(string accessToken)
@@ -71,5 +71,7 @@ public sealed class SignalRConversationCreatedHubTests : IClassFixture<HarmonieW
     private sealed record SignalRConversationCreatedEvent(
         string ConversationId,
         string? Name,
-        IReadOnlyList<string> ParticipantIds);
+        IReadOnlyList<SignalRConversationParticipantDto> Participants);
+
+    private sealed record SignalRConversationParticipantDto(Guid UserId, string Username);
 }

--- a/tests/Harmonie.Application.Tests/Common/ApplicationTestBuilders.cs
+++ b/tests/Harmonie.Application.Tests/Common/ApplicationTestBuilders.cs
@@ -15,7 +15,7 @@ namespace Harmonie.Application.Tests.Common;
 
 internal static class ApplicationTestBuilders
 {
-    public static User CreateUser()
+    public static User CreateUser(UserId? userId = null)
     {
         var emailResult = Email.Create($"test-{Guid.NewGuid():N}@harmonie.chat");
         if (emailResult.IsFailure || emailResult.Value is null)
@@ -25,11 +25,34 @@ internal static class ApplicationTestBuilders
         if (usernameResult.IsFailure || usernameResult.Value is null)
             throw new InvalidOperationException("Failed to create username for tests.");
 
-        var userResult = User.Create(emailResult.Value, usernameResult.Value, "hashed_password");
-        if (userResult.IsFailure || userResult.Value is null)
-            throw new InvalidOperationException("Failed to create user for tests.");
+        if (userId is null)
+        {
+            var userResult = User.Create(emailResult.Value, usernameResult.Value, "hashed_password");
+            if (userResult.IsFailure || userResult.Value is null)
+                throw new InvalidOperationException("Failed to create user for tests.");
+            return userResult.Value;
+        }
 
-        return userResult.Value;
+        return User.Rehydrate(
+            userId,
+            emailResult.Value,
+            usernameResult.Value,
+            passwordHash: "hashed_password",
+            avatarFileId: null,
+            isEmailVerified: true,
+            isActive: true,
+            lastLoginAtUtc: null,
+            displayName: null,
+            bio: null,
+            avatarColor: null,
+            avatarIcon: null,
+            avatarBg: null,
+            theme: "default",
+            language: null,
+            status: "online",
+            statusUpdatedAtUtc: null,
+            createdAtUtc: DateTime.UtcNow,
+            updatedAtUtc: DateTime.UtcNow);
     }
 
     public static Guild CreateGuild(UserId? ownerId = null, GuildId? guildId = null, UploadedFileId? iconFileId = null)

--- a/tests/Harmonie.Application.Tests/Conversations/CreateGroupConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/CreateGroupConversationHandlerTests.cs
@@ -120,14 +120,14 @@ public sealed class CreateGroupConversationHandlerTests
         response.Data!.Type.Should().Be("group");
         response.Data.Name.Should().Be("Team Chat");
         response.Data.ConversationId.Should().Be(conversation.Id.Value);
-        response.Data.ParticipantIds.Should().HaveCount(2);
+        response.Data.Participants.Should().HaveCount(2);
 
         _conversationNotifierMock.Verify(
             x => x.NotifyConversationCreatedAsync(
                 It.Is<ConversationCreatedNotification>(n =>
                     n.ConversationId == conversation.Id
                     && n.Name == "Team Chat"
-                    && n.ParticipantIds.Count == 2),
+                    && n.Participants.Count == 2),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }

--- a/tests/Harmonie.Application.Tests/Conversations/CreateGroupConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/CreateGroupConversationHandlerTests.cs
@@ -68,14 +68,11 @@ public sealed class CreateGroupConversationHandlerTests
     {
         var caller = UserId.New();
         var participantB = UserId.New();
+        var callerUser = ApplicationTestBuilders.CreateUser(caller);
 
         _userRepositoryMock
-            .Setup(x => x.GetByIdAsync(caller, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(ApplicationTestBuilders.CreateUser());
-
-        _userRepositoryMock
-            .Setup(x => x.GetByIdAsync(participantB, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Domain.Entities.Users.User?)null);
+            .Setup(x => x.GetManyByIdsAsync(It.IsAny<IReadOnlyList<UserId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([callerUser]); // participantB is missing
 
         var response = await _handler.HandleAsync(
             new CreateGroupConversationRequest("Team Chat", [caller.Value, participantB.Value]),
@@ -96,12 +93,8 @@ public sealed class CreateGroupConversationHandlerTests
         var conversation = Conversation.Rehydrate(ConversationId.New(), ConversationType.Group, "Team Chat", DateTime.UtcNow);
 
         _userRepositoryMock
-            .Setup(x => x.GetByIdAsync(caller, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(ApplicationTestBuilders.CreateUser());
-
-        _userRepositoryMock
-            .Setup(x => x.GetByIdAsync(participantB, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(ApplicationTestBuilders.CreateUser());
+            .Setup(x => x.GetManyByIdsAsync(It.IsAny<IReadOnlyList<UserId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([ApplicationTestBuilders.CreateUser(caller), ApplicationTestBuilders.CreateUser(participantB)]);
 
         _conversationRepositoryMock
             .Setup(x => x.CreateGroupAsync(
@@ -140,12 +133,8 @@ public sealed class CreateGroupConversationHandlerTests
         var conversation = Conversation.Rehydrate(ConversationId.New(), ConversationType.Group, null, DateTime.UtcNow);
 
         _userRepositoryMock
-            .Setup(x => x.GetByIdAsync(caller, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(ApplicationTestBuilders.CreateUser());
-
-        _userRepositoryMock
-            .Setup(x => x.GetByIdAsync(participantB, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(ApplicationTestBuilders.CreateUser());
+            .Setup(x => x.GetManyByIdsAsync(It.IsAny<IReadOnlyList<UserId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([ApplicationTestBuilders.CreateUser(caller), ApplicationTestBuilders.CreateUser(participantB)]);
 
         _conversationRepositoryMock
             .Setup(x => x.CreateGroupAsync(

--- a/tests/Harmonie.Application.Tests/Conversations/ListConversationsHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/ListConversationsHandlerTests.cs
@@ -62,13 +62,13 @@ public sealed class ListConversationsHandlerTests
                     ConversationId.New(),
                     ConversationType.Direct,
                     null,
-                    [new ConversationParticipantSummary(bobId, usernameBob.Value!)],
+                    [new ConversationParticipantSummary(bobId, usernameBob.Value!, null, null, null, null, null)],
                     secondCreatedAt),
                 new UserConversationSummary(
                     ConversationId.New(),
                     ConversationType.Direct,
                     null,
-                    [new ConversationParticipantSummary(aliceId, usernameAlice.Value!)],
+                    [new ConversationParticipantSummary(aliceId, usernameAlice.Value!, null, null, null, null, null)],
                     firstCreatedAt)
             ]);
 

--- a/tests/Harmonie.Application.Tests/Conversations/OpenConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/OpenConversationHandlerTests.cs
@@ -70,8 +70,13 @@ public sealed class OpenConversationHandlerTests
     {
         var callerUserId = UserId.New();
         var targetUserId = UserId.New();
+        var callerUser = CreateUser(callerUserId, "caller");
         var targetUser = CreateUser(targetUserId, "target");
         var conversation = ApplicationTestBuilders.CreateConversation(callerUserId, targetUserId);
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(callerUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(callerUser);
 
         _userRepositoryMock
             .Setup(x => x.GetByIdAsync(targetUserId, It.IsAny<CancellationToken>()))
@@ -90,7 +95,7 @@ public sealed class OpenConversationHandlerTests
         response.Data!.ConversationId.Should().Be(conversation.Id.Value);
         response.Data.Created.Should().BeTrue();
         response.Data.Type.Should().Be("direct");
-        response.Data.ParticipantIds.Should().HaveCount(2);
+        response.Data.Participants.Should().HaveCount(2);
     }
 
     [Fact]
@@ -98,8 +103,13 @@ public sealed class OpenConversationHandlerTests
     {
         var callerUserId = UserId.New();
         var targetUserId = UserId.New();
+        var callerUser = CreateUser(callerUserId, "caller");
         var targetUser = CreateUser(targetUserId, "target");
         var conversation = ApplicationTestBuilders.CreateConversation(callerUserId, targetUserId);
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(callerUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(callerUser);
 
         _userRepositoryMock
             .Setup(x => x.GetByIdAsync(targetUserId, It.IsAny<CancellationToken>()))

--- a/tests/Harmonie.Application.Tests/Conversations/OpenConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/OpenConversationHandlerTests.cs
@@ -51,10 +51,13 @@ public sealed class OpenConversationHandlerTests
     {
         var callerUserId = UserId.New();
         var targetUserId = UserId.New();
+        var callerUser = CreateUser(callerUserId, "caller");
 
         _userRepositoryMock
-            .Setup(x => x.GetByIdAsync(targetUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((User?)null);
+            .Setup(x => x.GetManyByIdsAsync(
+                It.Is<IReadOnlyList<UserId>>(ids => ids.Contains(callerUserId) && ids.Contains(targetUserId)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([callerUser]);
 
         var response = await _handler.HandleAsync(
             new OpenConversationRequest(targetUserId),
@@ -75,12 +78,10 @@ public sealed class OpenConversationHandlerTests
         var conversation = ApplicationTestBuilders.CreateConversation(callerUserId, targetUserId);
 
         _userRepositoryMock
-            .Setup(x => x.GetByIdAsync(callerUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(callerUser);
-
-        _userRepositoryMock
-            .Setup(x => x.GetByIdAsync(targetUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(targetUser);
+            .Setup(x => x.GetManyByIdsAsync(
+                It.Is<IReadOnlyList<UserId>>(ids => ids.Contains(callerUserId) && ids.Contains(targetUserId)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([callerUser, targetUser]);
 
         _conversationRepositoryMock
             .Setup(x => x.GetOrCreateDirectAsync(callerUserId, targetUserId, It.IsAny<CancellationToken>()))
@@ -108,12 +109,10 @@ public sealed class OpenConversationHandlerTests
         var conversation = ApplicationTestBuilders.CreateConversation(callerUserId, targetUserId);
 
         _userRepositoryMock
-            .Setup(x => x.GetByIdAsync(callerUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(callerUser);
-
-        _userRepositoryMock
-            .Setup(x => x.GetByIdAsync(targetUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(targetUser);
+            .Setup(x => x.GetManyByIdsAsync(
+                It.Is<IReadOnlyList<UserId>>(ids => ids.Contains(callerUserId) && ids.Contains(targetUserId)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([callerUser, targetUser]);
 
         _conversationRepositoryMock
             .Setup(x => x.GetOrCreateDirectAsync(callerUserId, targetUserId, It.IsAny<CancellationToken>()))


### PR DESCRIPTION
Closes #311

## Summary

- Add shared `ConversationParticipantDto` (`UserId`, `Username`, `DisplayName`, `AvatarFileId`, `Avatar`) consistent with `GetGuildVoiceParticipantsResponse`
- Replace bare `ParticipantIds` (`IReadOnlyList<Guid>`) in `OpenConversationResponse`, `CreateGroupConversationResponse`, and `ConversationCreatedEvent` with `IReadOnlyList<ConversationParticipantDto>`
- Enrich `ListConversationsParticipantDto` with `DisplayName`, `AvatarFileId`, and `Avatar` fields
- Extend `ConversationParticipantSummary` and update `GetUserConversationsAsync` SQL to JOIN avatar columns from `users`
- Update `ConversationCreatedNotification` to carry enriched participant data so `SignalRConversationNotifier` forwards it in `ConversationCreatedEvent`
- Update all affected handlers and tests

## Test plan

- [ ] Unit tests pass (`dotnet test tests/Harmonie.Application.Tests/`)
- [ ] `GET /api/conversations` returns `DisplayName`, `AvatarFileId`, `Avatar` per participant
- [ ] `POST /api/conversations` returns `Participants` list with full profile data instead of bare GUIDs
- [ ] `POST /api/conversations/group` returns `Participants` list with full profile data
- [ ] `ConversationCreated` SignalR event carries enriched participant objects