### PR TITLE
feat(voice): add Username to VoiceParticipantJoined and VoiceParticipantLeft SignalR events

### DIFF
--- a/src/Harmonie.API/RealTime/Voice/SignalRVoicePresenceNotifier.cs
+++ b/src/Harmonie.API/RealTime/Voice/SignalRVoicePresenceNotifier.cs
@@ -23,6 +23,7 @@ public sealed class SignalRVoicePresenceNotifier : IVoicePresenceNotifier
             GuildId: notification.GuildId.Value,
             ChannelId: notification.ChannelId.Value,
             UserId: notification.UserId.Value,
+            Username: notification.Username,
             DisplayName: notification.DisplayName,
             AvatarFileId: notification.AvatarFileId?.Value,
             AvatarColor: notification.AvatarColor,
@@ -45,6 +46,7 @@ public sealed class SignalRVoicePresenceNotifier : IVoicePresenceNotifier
             GuildId: notification.GuildId.Value,
             ChannelId: notification.ChannelId.Value,
             UserId: notification.UserId.Value,
+            Username: notification.Username,
             LeftAtUtc: notification.LeftAtUtc);
 
         await _hubContext.Clients
@@ -57,6 +59,7 @@ public sealed record VoiceParticipantJoinedEvent(
     Guid GuildId,
     Guid ChannelId,
     Guid UserId,
+    string? Username,
     string? DisplayName,
     Guid? AvatarFileId,
     string? AvatarColor,
@@ -68,4 +71,5 @@ public sealed record VoiceParticipantLeftEvent(
     Guid GuildId,
     Guid ChannelId,
     Guid UserId,
+    string? Username,
     DateTime LeftAtUtc);

--- a/src/Harmonie.Application/Features/Voice/HandleLiveKitWebhook/HandleLiveKitWebhookHandler.cs
+++ b/src/Harmonie.Application/Features/Voice/HandleLiveKitWebhook/HandleLiveKitWebhookHandler.cs
@@ -83,6 +83,7 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
                     GuildId: result.Channel.GuildId,
                     ChannelId: result.Channel.Id,
                     UserId: participantUserId,
+                    Username: result.Participant?.Username.Value,
                     DisplayName: result.Participant?.DisplayName,
                     AvatarFileId: result.Participant?.AvatarFileId,
                     AvatarColor: result.Participant?.AvatarColor,
@@ -98,6 +99,7 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
                     result.Channel.GuildId,
                     result.Channel.Id,
                     participantUserId,
+                    result.Participant?.Username.Value,
                     webhookEvent.OccurredAtUtc),
                 cancellationToken);
         }

--- a/src/Harmonie.Application/Interfaces/Voice/IVoicePresenceNotifier.cs
+++ b/src/Harmonie.Application/Interfaces/Voice/IVoicePresenceNotifier.cs
@@ -20,6 +20,7 @@ public sealed record VoiceParticipantJoinedNotification(
     GuildId GuildId,
     GuildChannelId ChannelId,
     UserId UserId,
+    string? Username,
     string? DisplayName,
     UploadedFileId? AvatarFileId,
     string? AvatarColor,
@@ -31,4 +32,5 @@ public sealed record VoiceParticipantLeftNotification(
     GuildId GuildId,
     GuildChannelId ChannelId,
     UserId UserId,
+    string? Username,
     DateTime LeftAtUtc);

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRVoicePresenceHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRVoicePresenceHubTests.cs
@@ -67,6 +67,7 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
         eventPayload.GuildId.Should().Be(guildId.ToString());
         eventPayload.ChannelId.Should().Be(voiceChannelId.ToString());
         eventPayload.UserId.Should().Be(member.UserId.ToString());
+        eventPayload.Username.Should().Be(member.Username);
         eventPayload.JoinedAtUtc.Should().NotBe(default);
         // A freshly registered user has no avatar set, so all fields are null.
         eventPayload.DisplayName.Should().BeNull();
@@ -111,6 +112,7 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
         eventPayload.GuildId.Should().Be(guildId.ToString());
         eventPayload.ChannelId.Should().Be(voiceChannelId.ToString());
         eventPayload.UserId.Should().Be(member.UserId.ToString());
+        eventPayload.Username.Should().Be(member.Username);
         eventPayload.LeftAtUtc.Should().NotBe(default);
     }
 
@@ -201,6 +203,7 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
         string GuildId,
         string ChannelId,
         string UserId,
+        string? Username,
         string? DisplayName,
         Guid? AvatarFileId,
         string? AvatarColor,
@@ -212,5 +215,6 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
         string GuildId,
         string ChannelId,
         string UserId,
+        string? Username,
         DateTime LeftAtUtc);
 }

--- a/tests/Harmonie.Application.Tests/Voice/HandleLiveKitWebhookHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Voice/HandleLiveKitWebhookHandlerTests.cs
@@ -142,6 +142,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
                     notification.GuildId == channel.GuildId
                     && notification.ChannelId == channel.Id
                     && notification.UserId == participantUserId
+                    && notification.Username == profile.Username.Value
                     && notification.DisplayName == profile.DisplayName
                     && notification.AvatarFileId == profile.AvatarFileId
                     && notification.AvatarColor == profile.AvatarColor
@@ -183,6 +184,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
             x => x.NotifyParticipantJoinedAsync(
                 It.Is<VoiceParticipantJoinedNotification>(notification =>
                     notification.UserId == participantUserId
+                    && notification.Username == null
                     && notification.DisplayName == null
                     && notification.AvatarFileId == null
                     && notification.AvatarColor == null
@@ -226,6 +228,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
                     notification.GuildId == channel.GuildId
                     && notification.ChannelId == channel.Id
                     && notification.UserId == participantUserId
+                    && notification.Username == null
                     && notification.LeftAtUtc == occurredAtUtc),
                 It.IsAny<CancellationToken>()),
             Times.Once);


### PR DESCRIPTION
## Summary

- Adds `Username` field to `VoiceParticipantJoinedNotification`, `VoiceParticipantLeftNotification`, `VoiceParticipantJoinedEvent`, and `VoiceParticipantLeftEvent`
- Populates it from `result.Participant?.Username.Value` in `HandleLiveKitWebhookHandler`
- Updates unit and integration tests to assert on the new field

Closes #314

## Test plan

- [ ] `HandleAsync_WhenParticipantJoined_ShouldNotifyWithAvatarData` — verifies `Username == profile.Username.Value`
- [ ] `HandleAsync_WhenParticipantJoinedAndNotGuildMember_ShouldNotifyWithNullAvatarData` — verifies `Username == null` when no participant profile
- [ ] `HandleAsync_WhenParticipantLeft_ShouldNotifyGuildGroup` — verifies `Username == null` when participant is null
- [ ] `VoiceParticipantJoined_WhenMemberConnected_ShouldReceiveEvent` — verifies `Username == member.Username` in SignalR payload
- [ ] `VoiceParticipantLeft_WhenMemberConnected_ShouldReceiveEvent` — verifies `Username == member.Username` in SignalR payload