### PR TITLE
feat(voice): add current participants to guild voice channels response

### DIFF
--- a/src/Harmonie.API/Configuration/RealTimeConfiguration.cs
+++ b/src/Harmonie.API/Configuration/RealTimeConfiguration.cs
@@ -45,6 +45,7 @@ public static class RealTimeConfiguration
         services.AddScoped<ITextChannelNotifier, SignalRTextChannelNotifier>();
         services.AddScoped<IGuildNotifier, SignalRGuildNotifier>();
         services.AddScoped<IVoicePresenceNotifier, SignalRVoicePresenceNotifier>();
+        services.AddSingleton<IVoiceParticipantCache, InMemoryVoiceParticipantCache>();
         services.AddScoped<IConversationMessageNotifier, SignalRConversationMessageNotifier>();
         services.AddScoped<IConversationNotifier, SignalRConversationNotifier>();
         services.AddScoped<IUserPresenceNotifier, SignalRUserPresenceNotifier>();

--- a/src/Harmonie.API/RealTime/Voice/InMemoryVoiceParticipantCache.cs
+++ b/src/Harmonie.API/RealTime/Voice/InMemoryVoiceParticipantCache.cs
@@ -1,0 +1,44 @@
+using System.Collections.Concurrent;
+using Harmonie.Application.Interfaces.Voice;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.API.RealTime.Voice;
+
+public sealed class InMemoryVoiceParticipantCache : IVoiceParticipantCache
+{
+    private static readonly TimeSpan ParticipantTtl = TimeSpan.FromHours(1);
+
+    private readonly ConcurrentDictionary<Guid, ConcurrentDictionary<Guid, CachedEntry>> _channels = new();
+
+    public Task AddOrUpdateAsync(GuildChannelId channelId, CachedVoiceParticipant participant, CancellationToken cancellationToken = default)
+    {
+        var channel = _channels.GetOrAdd(channelId.Value, _ => new ConcurrentDictionary<Guid, CachedEntry>());
+        channel[participant.UserId.Value] = new CachedEntry(participant, DateTime.UtcNow + ParticipantTtl);
+        return Task.CompletedTask;
+    }
+
+    public Task RemoveAsync(GuildChannelId channelId, UserId userId, CancellationToken cancellationToken = default)
+    {
+        if (_channels.TryGetValue(channelId.Value, out var channel))
+            channel.TryRemove(userId.Value, out _);
+
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<CachedVoiceParticipant>> GetAsync(GuildChannelId channelId, CancellationToken cancellationToken = default)
+    {
+        if (!_channels.TryGetValue(channelId.Value, out var channel))
+            return Task.FromResult<IReadOnlyList<CachedVoiceParticipant>>(Array.Empty<CachedVoiceParticipant>());
+
+        var now = DateTime.UtcNow;
+        var result = channel.Values
+            .Where(e => e.ExpiresAt > now)
+            .Select(e => e.Participant)
+            .ToArray();
+
+        return Task.FromResult<IReadOnlyList<CachedVoiceParticipant>>(result);
+    }
+
+    private sealed record CachedEntry(CachedVoiceParticipant Participant, DateTime ExpiresAt);
+}

--- a/src/Harmonie.Application/Features/Guilds/GetGuildChannels/GetGuildChannelsHandler.cs
+++ b/src/Harmonie.Application/Features/Guilds/GetGuildChannels/GetGuildChannelsHandler.cs
@@ -46,14 +46,9 @@ public sealed class GetGuildChannelsHandler : IAuthenticatedHandler<GuildId, Get
 
         var channels = await _guildChannelRepository.GetByGuildIdAsync(guildId, cancellationToken);
 
-        var voiceChannels = channels.Where(c => c.Type == GuildChannelType.Voice).ToArray();
-        var participantTasks = voiceChannels
-            .Select(c => _voiceParticipantCache.GetAsync(c.Id, cancellationToken))
-            .ToArray();
-        var participantResults = await Task.WhenAll(participantTasks);
-        var participantsByChannelId = voiceChannels
-            .Select((c, i) => (ChannelId: c.Id.Value, Participants: participantResults[i]))
-            .ToDictionary(x => x.ChannelId, x => x.Participants);
+        var participantsByChannelId = new Dictionary<Guid, IReadOnlyList<CachedVoiceParticipant>>();
+        foreach (var c in channels.Where(c => c.Type == GuildChannelType.Voice))
+            participantsByChannelId[c.Id.Value] = await _voiceParticipantCache.GetAsync(c.Id, cancellationToken);
 
         var payload = new GetGuildChannelsResponse(
             GuildId: guildId.Value,

--- a/src/Harmonie.Application/Features/Guilds/GetGuildChannels/GetGuildChannelsHandler.cs
+++ b/src/Harmonie.Application/Features/Guilds/GetGuildChannels/GetGuildChannelsHandler.cs
@@ -1,6 +1,8 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Guilds;
+using Harmonie.Application.Interfaces.Voice;
+using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Users;
 
@@ -10,13 +12,16 @@ public sealed class GetGuildChannelsHandler : IAuthenticatedHandler<GuildId, Get
 {
     private readonly IGuildRepository _guildRepository;
     private readonly IGuildChannelRepository _guildChannelRepository;
+    private readonly IVoiceParticipantCache _voiceParticipantCache;
 
     public GetGuildChannelsHandler(
         IGuildRepository guildRepository,
-        IGuildChannelRepository guildChannelRepository)
+        IGuildChannelRepository guildChannelRepository,
+        IVoiceParticipantCache voiceParticipantCache)
     {
         _guildRepository = guildRepository;
         _guildChannelRepository = guildChannelRepository;
+        _voiceParticipantCache = voiceParticipantCache;
     }
 
     public async Task<ApplicationResponse<GetGuildChannelsResponse>> HandleAsync(
@@ -41,15 +46,42 @@ public sealed class GetGuildChannelsHandler : IAuthenticatedHandler<GuildId, Get
 
         var channels = await _guildChannelRepository.GetByGuildIdAsync(guildId, cancellationToken);
 
+        var voiceChannels = channels.Where(c => c.Type == GuildChannelType.Voice).ToArray();
+        var participantTasks = voiceChannels
+            .Select(c => _voiceParticipantCache.GetAsync(c.Id, cancellationToken))
+            .ToArray();
+        var participantResults = await Task.WhenAll(participantTasks);
+        var participantsByChannelId = voiceChannels
+            .Select((c, i) => (ChannelId: c.Id.Value, Participants: participantResults[i]))
+            .ToDictionary(x => x.ChannelId, x => x.Participants);
+
         var payload = new GetGuildChannelsResponse(
             GuildId: guildId.Value,
-            Channels: channels.Select(channel => new GetGuildChannelsItemResponse(
+            Channels: channels.Select(channel =>
+            {
+                IReadOnlyList<GetGuildChannelsVoiceParticipantResponse>? currentParticipants = null;
+                if (channel.Type == GuildChannelType.Voice && participantsByChannelId.TryGetValue(channel.Id.Value, out var cached))
+                {
+                    currentParticipants = cached
+                        .Select(p => new GetGuildChannelsVoiceParticipantResponse(
+                            UserId: p.UserId.Value,
+                            Username: p.Username,
+                            DisplayName: p.DisplayName,
+                            AvatarFileId: p.AvatarFileId?.Value,
+                            AvatarColor: p.AvatarColor,
+                            AvatarIcon: p.AvatarIcon,
+                            AvatarBg: p.AvatarBg))
+                        .ToArray();
+                }
+
+                return new GetGuildChannelsItemResponse(
                     ChannelId: channel.Id.Value,
                     Name: channel.Name,
                     Type: channel.Type.ToString(),
                     IsDefault: channel.IsDefault,
-                    Position: channel.Position))
-                .ToArray());
+                    Position: channel.Position,
+                    CurrentParticipants: currentParticipants);
+            }).ToArray());
 
         return ApplicationResponse<GetGuildChannelsResponse>.Ok(payload);
     }

--- a/src/Harmonie.Application/Features/Guilds/GetGuildChannels/GetGuildChannelsResponse.cs
+++ b/src/Harmonie.Application/Features/Guilds/GetGuildChannels/GetGuildChannelsResponse.cs
@@ -9,4 +9,14 @@ public sealed record GetGuildChannelsItemResponse(
     string Name,
     string Type,
     bool IsDefault,
-    int Position);
+    int Position,
+    IReadOnlyList<GetGuildChannelsVoiceParticipantResponse>? CurrentParticipants);
+
+public sealed record GetGuildChannelsVoiceParticipantResponse(
+    Guid UserId,
+    string? Username,
+    string? DisplayName,
+    Guid? AvatarFileId,
+    string? AvatarColor,
+    string? AvatarIcon,
+    string? AvatarBg);

--- a/src/Harmonie.Application/Features/Voice/HandleLiveKitWebhook/HandleLiveKitWebhookHandler.cs
+++ b/src/Harmonie.Application/Features/Voice/HandleLiveKitWebhook/HandleLiveKitWebhookHandler.cs
@@ -16,15 +16,18 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
     private readonly ILiveKitWebhookReceiver _webhookReceiver;
     private readonly IGuildChannelRepository _guildChannelRepository;
     private readonly IVoicePresenceNotifier _voicePresenceNotifier;
+    private readonly IVoiceParticipantCache _voiceParticipantCache;
 
     public HandleLiveKitWebhookHandler(
         ILiveKitWebhookReceiver webhookReceiver,
         IGuildChannelRepository guildChannelRepository,
-        IVoicePresenceNotifier voicePresenceNotifier)
+        IVoicePresenceNotifier voicePresenceNotifier,
+        IVoiceParticipantCache voiceParticipantCache)
     {
         _webhookReceiver = webhookReceiver;
         _guildChannelRepository = guildChannelRepository;
         _voicePresenceNotifier = voicePresenceNotifier;
+        _voiceParticipantCache = voiceParticipantCache;
     }
 
     public async Task<ApplicationResponse<HandleLiveKitWebhookResponse>> HandleAsync(
@@ -78,6 +81,18 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
 
         if (eventType == ParticipantJoinedEvent)
         {
+            await _voiceParticipantCache.AddOrUpdateAsync(
+                result.Channel.Id,
+                new CachedVoiceParticipant(
+                    UserId: participantUserId,
+                    Username: result.Participant?.Username.Value,
+                    DisplayName: result.Participant?.DisplayName,
+                    AvatarFileId: result.Participant?.AvatarFileId,
+                    AvatarColor: result.Participant?.AvatarColor,
+                    AvatarIcon: result.Participant?.AvatarIcon,
+                    AvatarBg: result.Participant?.AvatarBg),
+                cancellationToken);
+
             await _voicePresenceNotifier.NotifyParticipantJoinedAsync(
                 new VoiceParticipantJoinedNotification(
                     GuildId: result.Channel.GuildId,
@@ -94,6 +109,8 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
         }
         else
         {
+            await _voiceParticipantCache.RemoveAsync(result.Channel.Id, participantUserId, cancellationToken);
+
             await _voicePresenceNotifier.NotifyParticipantLeftAsync(
                 new VoiceParticipantLeftNotification(
                     result.Channel.GuildId,

--- a/src/Harmonie.Application/Interfaces/Voice/IVoiceParticipantCache.cs
+++ b/src/Harmonie.Application/Interfaces/Voice/IVoiceParticipantCache.cs
@@ -1,0 +1,23 @@
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Uploads;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Interfaces.Voice;
+
+public interface IVoiceParticipantCache
+{
+    Task AddOrUpdateAsync(GuildChannelId channelId, CachedVoiceParticipant participant, CancellationToken cancellationToken = default);
+
+    Task RemoveAsync(GuildChannelId channelId, UserId userId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<CachedVoiceParticipant>> GetAsync(GuildChannelId channelId, CancellationToken cancellationToken = default);
+}
+
+public sealed record CachedVoiceParticipant(
+    UserId UserId,
+    string? Username,
+    string? DisplayName,
+    UploadedFileId? AvatarFileId,
+    string? AvatarColor,
+    string? AvatarIcon,
+    string? AvatarBg);

--- a/tests/Harmonie.Application.Tests/Channels/GetGuildChannelsHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Channels/GetGuildChannelsHandlerTests.cs
@@ -3,12 +3,14 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Features.Guilds.GetGuildChannels;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Guilds;
+using Harmonie.Application.Interfaces.Voice;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Guilds;
 using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Guilds;
+using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
-using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -18,16 +20,23 @@ public sealed class GetGuildChannelsHandlerTests
 {
     private readonly Mock<IGuildRepository> _guildRepositoryMock;
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
+    private readonly Mock<IVoiceParticipantCache> _voiceParticipantCacheMock;
     private readonly GetGuildChannelsHandler _handler;
 
     public GetGuildChannelsHandlerTests()
     {
         _guildRepositoryMock = new Mock<IGuildRepository>();
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
+        _voiceParticipantCacheMock = new Mock<IVoiceParticipantCache>();
+
+        _voiceParticipantCacheMock
+            .Setup(x => x.GetAsync(It.IsAny<GuildChannelId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<CachedVoiceParticipant>());
 
         _handler = new GetGuildChannelsHandler(
             _guildRepositoryMock.Object,
-            _guildChannelRepositoryMock.Object);
+            _guildChannelRepositoryMock.Object,
+            _voiceParticipantCacheMock.Object);
     }
 
     [Fact]
@@ -88,7 +97,58 @@ public sealed class GetGuildChannelsHandlerTests
         response.Data!.GuildId.Should().Be(guild.Id.Value);
         response.Data.Channels.Should().HaveCount(2);
         response.Data.Channels[0].Type.Should().Be("Text");
+        response.Data.Channels[0].CurrentParticipants.Should().BeNull();
         response.Data.Channels[1].Type.Should().Be("Voice");
+        response.Data.Channels[1].CurrentParticipants.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithVoiceChannelParticipants_ShouldIncludeParticipantsInResponse()
+    {
+        var guild = ApplicationTestBuilders.CreateGuild();
+        var userId = UserId.New();
+        var voiceChannel = CreateChannel(guild.Id, "General Voice", GuildChannelType.Voice, true, 0);
+        var participantUserId = UserId.New();
+        var avatarFileId = UploadedFileId.New();
+        var participant = new CachedVoiceParticipant(
+            UserId: participantUserId,
+            Username: "alice",
+            DisplayName: "Alice",
+            AvatarFileId: avatarFileId,
+            AvatarColor: "#ff0000",
+            AvatarIcon: "star",
+            AvatarBg: "#000000");
+
+        _guildRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(guild.Id, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetByGuildIdAsync(guild.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([voiceChannel]);
+
+        _voiceParticipantCacheMock
+            .Setup(x => x.GetAsync(voiceChannel.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([participant]);
+
+        var response = await _handler.HandleAsync(guild.Id, userId);
+
+        response.Success.Should().BeTrue();
+        response.Data.Should().NotBeNull();
+        response.Data!.Channels.Should().HaveCount(1);
+
+        var channelResponse = response.Data.Channels[0];
+        channelResponse.Type.Should().Be("Voice");
+        channelResponse.CurrentParticipants.Should().HaveCount(1);
+
+        var p = channelResponse.CurrentParticipants![0];
+        p.UserId.Should().Be(participantUserId.Value);
+        p.Username.Should().Be("alice");
+        p.DisplayName.Should().Be("Alice");
+        p.AvatarFileId.Should().Be(avatarFileId.Value);
+        p.AvatarColor.Should().Be("#ff0000");
+        p.AvatarIcon.Should().Be("star");
+        p.AvatarBg.Should().Be("#000000");
     }
 
     private static GuildChannel CreateChannel(

--- a/tests/Harmonie.Application.Tests/Voice/HandleLiveKitWebhookHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Voice/HandleLiveKitWebhookHandlerTests.cs
@@ -19,6 +19,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
     private readonly Mock<ILiveKitWebhookReceiver> _webhookReceiverMock;
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IVoicePresenceNotifier> _voicePresenceNotifierMock;
+    private readonly Mock<IVoiceParticipantCache> _voiceParticipantCacheMock;
     private readonly HandleLiveKitWebhookHandler _handler;
 
     public HandleLiveKitWebhookHandlerTests()
@@ -26,11 +27,13 @@ public sealed class HandleLiveKitWebhookHandlerTests
         _webhookReceiverMock = new Mock<ILiveKitWebhookReceiver>();
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
         _voicePresenceNotifierMock = new Mock<IVoicePresenceNotifier>();
+        _voiceParticipantCacheMock = new Mock<IVoiceParticipantCache>();
 
         _handler = new HandleLiveKitWebhookHandler(
             _webhookReceiverMock.Object,
             _guildChannelRepositoryMock.Object,
-            _voicePresenceNotifierMock.Object);
+            _voicePresenceNotifierMock.Object,
+            _voiceParticipantCacheMock.Object);
     }
 
     [Fact]
@@ -231,6 +234,80 @@ public sealed class HandleLiveKitWebhookHandlerTests
                     && notification.Username == null
                     && notification.LeftAtUtc == occurredAtUtc),
                 It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenParticipantJoined_ShouldAddToCache()
+    {
+        var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
+        var participantUserId = UserId.New();
+        var avatarFileId = UploadedFileId.New();
+        var profile = new ChannelParticipantProfile(
+            Username.Create("alice").Value!,
+            DisplayName: "Alice",
+            AvatarFileId: avatarFileId,
+            AvatarColor: "#ff0000",
+            AvatarIcon: "star",
+            AvatarBg: "#000000");
+        var request = new HandleLiveKitWebhookRequest("{}", "Bearer token");
+
+        _webhookReceiverMock
+            .Setup(x => x.Receive(request.RawBody, request.AuthorizationHeader!))
+            .Returns(LiveKitWebhookReceiveResult.Ok(
+                new LiveKitWebhookEvent(
+                    "participant_joined",
+                    $"channel:{channel.Id}",
+                    participantUserId.ToString(),
+                    "alice",
+                    DateTime.UtcNow)));
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithParticipantAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelWithParticipant(channel, profile));
+
+        await _handler.HandleAsync(request);
+
+        _voiceParticipantCacheMock.Verify(
+            x => x.AddOrUpdateAsync(
+                channel.Id,
+                It.Is<CachedVoiceParticipant>(p =>
+                    p.UserId == participantUserId
+                    && p.Username == profile.Username.Value
+                    && p.DisplayName == profile.DisplayName
+                    && p.AvatarFileId == profile.AvatarFileId
+                    && p.AvatarColor == profile.AvatarColor
+                    && p.AvatarIcon == profile.AvatarIcon
+                    && p.AvatarBg == profile.AvatarBg),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenParticipantLeft_ShouldRemoveFromCache()
+    {
+        var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
+        var participantUserId = UserId.New();
+        var request = new HandleLiveKitWebhookRequest("{}", "Bearer token");
+
+        _webhookReceiverMock
+            .Setup(x => x.Receive(request.RawBody, request.AuthorizationHeader!))
+            .Returns(LiveKitWebhookReceiveResult.Ok(
+                new LiveKitWebhookEvent(
+                    "participant_left",
+                    $"channel:{channel.Id}",
+                    participantUserId.ToString(),
+                    "alice",
+                    DateTime.UtcNow)));
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithParticipantAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelWithParticipant(channel, null));
+
+        await _handler.HandleAsync(request);
+
+        _voiceParticipantCacheMock.Verify(
+            x => x.RemoveAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 


### PR DESCRIPTION
## Summary

Closes #316

- Introduce `IVoiceParticipantCache` interface and `InMemoryVoiceParticipantCache` implementation (singleton, `ConcurrentDictionary` with per-participant TTL of 1h)
- `HandleLiveKitWebhookHandler` now updates the cache on `participant_joined` (add/update) and `participant_left` (remove) events
- `GET /api/guilds/{guildId}/channels` response includes `currentParticipants` for voice channels (null for text channels), read from cache — zero LiveKit API calls at request time
- TTL guards against stale entries when a `participant_left` webhook is missed

## Test plan

- [ ] `GetGuildChannelsHandler` tests updated: text channels return `null`, voice channels return empty list or populated list from cache
- [ ] `HandleLiveKitWebhookHandler` tests updated: `AddOrUpdateAsync` called on join, `RemoveAsync` called on left
- [ ] All 743 tests passing (357 unit + 386 integration)