### PR TITLE
feat(voice): return current participants in POST join voice channel response

### DIFF
--- a/src/Harmonie.Application/Features/Channels/JoinVoiceChannel/JoinVoiceChannelHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/JoinVoiceChannel/JoinVoiceChannelHandler.cs
@@ -73,14 +73,19 @@ public sealed class JoinVoiceChannelHandler : IAuthenticatedHandler<GuildChannel
                 "User profile was not found");
         }
 
-        var roomToken = await _liveKitTokenService.GenerateRoomTokenAsync(
+        var roomTokenTask = _liveKitTokenService.GenerateRoomTokenAsync(
             request,
             currentUserId,
             user.Username.Value,
             cancellationToken);
+        var liveKitParticipantsTask = _liveKitRoomService.ListChannelParticipantsAsync(request, cancellationToken);
+        var cachedParticipantsTask = _voiceParticipantCache.GetAsync(request, cancellationToken);
 
-        var liveKitParticipants = await _liveKitRoomService.ListChannelParticipantsAsync(request, cancellationToken);
-        var cachedParticipants = await _voiceParticipantCache.GetAsync(request, cancellationToken);
+        await Task.WhenAll(roomTokenTask, liveKitParticipantsTask, cachedParticipantsTask);
+
+        var roomToken = roomTokenTask.Result;
+        var liveKitParticipants = liveKitParticipantsTask.Result;
+        var cachedParticipants = cachedParticipantsTask.Result;
 
         var cachedById = cachedParticipants.ToDictionary(p => p.UserId.Value);
         var liveKitIds = liveKitParticipants.Select(p => p.UserId.Value).ToHashSet();

--- a/src/Harmonie.Application/Features/Channels/JoinVoiceChannel/JoinVoiceChannelHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/JoinVoiceChannel/JoinVoiceChannelHandler.cs
@@ -15,17 +15,23 @@ public sealed class JoinVoiceChannelHandler : IAuthenticatedHandler<GuildChannel
     private readonly IGuildMemberRepository _guildMemberRepository;
     private readonly IUserRepository _userRepository;
     private readonly ILiveKitTokenService _liveKitTokenService;
+    private readonly ILiveKitRoomService _liveKitRoomService;
+    private readonly IVoiceParticipantCache _voiceParticipantCache;
 
     public JoinVoiceChannelHandler(
         IGuildChannelRepository guildChannelRepository,
         IGuildMemberRepository guildMemberRepository,
         IUserRepository userRepository,
-        ILiveKitTokenService liveKitTokenService)
+        ILiveKitTokenService liveKitTokenService,
+        ILiveKitRoomService liveKitRoomService,
+        IVoiceParticipantCache voiceParticipantCache)
     {
         _guildChannelRepository = guildChannelRepository;
         _guildMemberRepository = guildMemberRepository;
         _userRepository = userRepository;
         _liveKitTokenService = liveKitTokenService;
+        _liveKitRoomService = liveKitRoomService;
+        _voiceParticipantCache = voiceParticipantCache;
     }
 
     public async Task<ApplicationResponse<JoinVoiceChannelResponse>> HandleAsync(
@@ -73,10 +79,78 @@ public sealed class JoinVoiceChannelHandler : IAuthenticatedHandler<GuildChannel
             user.Username.Value,
             cancellationToken);
 
+        var liveKitParticipants = await _liveKitRoomService.ListChannelParticipantsAsync(request, cancellationToken);
+        var cachedParticipants = await _voiceParticipantCache.GetAsync(request, cancellationToken);
+
+        var cachedById = cachedParticipants.ToDictionary(p => p.UserId.Value);
+        var liveKitIds = liveKitParticipants.Select(p => p.UserId.Value).ToHashSet();
+
+        var missingIds = liveKitParticipants
+            .Where(p => !cachedById.ContainsKey(p.UserId.Value))
+            .Select(p => p.UserId)
+            .ToArray();
+
+        var fetchedUsers = missingIds.Length > 0
+            ? await _userRepository.GetManyByIdsAsync(missingIds, cancellationToken)
+            : [];
+        var fetchedById = fetchedUsers.ToDictionary(u => u.Id.Value);
+
+        var reconciledParticipants = new List<CachedVoiceParticipant>(liveKitParticipants.Count);
+
+        foreach (var lkParticipant in liveKitParticipants)
+        {
+            CachedVoiceParticipant cached;
+
+            if (cachedById.TryGetValue(lkParticipant.UserId.Value, out var existing))
+            {
+                cached = existing;
+            }
+            else if (fetchedById.TryGetValue(lkParticipant.UserId.Value, out var dbUser))
+            {
+                cached = new CachedVoiceParticipant(
+                    UserId: dbUser.Id,
+                    Username: dbUser.Username.Value,
+                    DisplayName: dbUser.DisplayName,
+                    AvatarFileId: dbUser.AvatarFileId,
+                    AvatarColor: dbUser.AvatarColor,
+                    AvatarIcon: dbUser.AvatarIcon,
+                    AvatarBg: dbUser.AvatarBg);
+            }
+            else
+            {
+                cached = new CachedVoiceParticipant(
+                    UserId: lkParticipant.UserId,
+                    Username: lkParticipant.Username,
+                    DisplayName: null,
+                    AvatarFileId: null,
+                    AvatarColor: null,
+                    AvatarIcon: null,
+                    AvatarBg: null);
+            }
+
+            await _voiceParticipantCache.AddOrUpdateAsync(request, cached, cancellationToken);
+            reconciledParticipants.Add(cached);
+        }
+
+        foreach (var stale in cachedParticipants.Where(p => !liveKitIds.Contains(p.UserId.Value)))
+            await _voiceParticipantCache.RemoveAsync(request, stale.UserId, cancellationToken);
+
+        var currentParticipants = reconciledParticipants
+            .Select(p => new JoinVoiceChannelParticipantResponse(
+                UserId: p.UserId.Value,
+                Username: p.Username,
+                DisplayName: p.DisplayName,
+                AvatarFileId: p.AvatarFileId?.Value,
+                AvatarColor: p.AvatarColor,
+                AvatarIcon: p.AvatarIcon,
+                AvatarBg: p.AvatarBg))
+            .ToArray();
+
         var payload = new JoinVoiceChannelResponse(
             Token: roomToken.Token,
             Url: roomToken.Url,
-            RoomName: roomToken.RoomName);
+            RoomName: roomToken.RoomName,
+            CurrentParticipants: currentParticipants);
 
         return ApplicationResponse<JoinVoiceChannelResponse>.Ok(payload);
     }

--- a/src/Harmonie.Application/Features/Channels/JoinVoiceChannel/JoinVoiceChannelResponse.cs
+++ b/src/Harmonie.Application/Features/Channels/JoinVoiceChannel/JoinVoiceChannelResponse.cs
@@ -3,4 +3,14 @@ namespace Harmonie.Application.Features.Channels.JoinVoiceChannel;
 public sealed record JoinVoiceChannelResponse(
     string Token,
     string Url,
-    string RoomName);
+    string RoomName,
+    IReadOnlyList<JoinVoiceChannelParticipantResponse> CurrentParticipants);
+
+public sealed record JoinVoiceChannelParticipantResponse(
+    Guid UserId,
+    string? Username,
+    string? DisplayName,
+    Guid? AvatarFileId,
+    string? AvatarColor,
+    string? AvatarIcon,
+    string? AvatarBg);

--- a/src/Harmonie.Application/Interfaces/Voice/ILiveKitRoomService.cs
+++ b/src/Harmonie.Application/Interfaces/Voice/ILiveKitRoomService.cs
@@ -9,6 +9,10 @@ public interface ILiveKitRoomService
     Task<IReadOnlyList<GuildVoiceChannelParticipants>> GetGuildVoiceParticipantsAsync(
         GuildId guildId,
         CancellationToken ct);
+
+    Task<IReadOnlyList<VoiceChannelParticipant>> ListChannelParticipantsAsync(
+        GuildChannelId channelId,
+        CancellationToken ct);
 }
 
 public sealed record GuildVoiceChannelParticipants(

--- a/src/Harmonie.Infrastructure/DependencyInjection.cs
+++ b/src/Harmonie.Infrastructure/DependencyInjection.cs
@@ -56,7 +56,7 @@ public static class DependencyInjection
             _ = sp.GetRequiredService<IOptions<LiveKitSettings>>().Value;
             return new HttpClient();
         });
-        services.AddScoped<ILiveKitRoomApiClient, LiveKitSdkRoomApiClient>();
+        services.AddSingleton<ILiveKitRoomApiClient, LiveKitSdkRoomApiClient>();
         services.AddScoped<ILiveKitRoomService, LiveKitRoomService>();
         services.AddScoped<IObjectStorageService, LocalFileSystemObjectStorageService>();
 

--- a/src/Harmonie.Infrastructure/LiveKit/LiveKitRoomService.cs
+++ b/src/Harmonie.Infrastructure/LiveKit/LiveKitRoomService.cs
@@ -107,6 +107,19 @@ public sealed class LiveKitRoomService : ILiveKitRoomService
         return new VoiceChannelParticipant(userId, username);
     }
 
+    public async Task<IReadOnlyList<VoiceChannelParticipant>> ListChannelParticipantsAsync(
+        GuildChannelId channelId,
+        CancellationToken ct)
+    {
+        var roomName = BuildRoomName(channelId);
+        var participants = await _roomApiClient.ListParticipantsAsync(roomName, ct);
+
+        return participants
+            .Select(p => TryMapParticipant(p.Identity, p.Name))
+            .OfType<VoiceChannelParticipant>()
+            .ToArray();
+    }
+
     private static string BuildRoomName(GuildChannelId channelId)
         => $"{ChannelRoomPrefix}{channelId}";
 }

--- a/tests/Harmonie.API.IntegrationTests/Channels/JoinVoiceChannelTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Channels/JoinVoiceChannelTests.cs
@@ -36,6 +36,7 @@ public sealed class JoinVoiceChannelTests : IClassFixture<HarmonieWebApplication
         payload!.Token.Should().NotBeNullOrWhiteSpace();
         payload.Url.Should().Be("ws://localhost:7880");
         payload.RoomName.Should().Be($"channel:{voiceChannelId}");
+        payload.CurrentParticipants.Should().NotBeNull();
     }
 
     [Fact]

--- a/tests/Harmonie.API.IntegrationTests/Guilds/GuildVoiceParticipantsEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/GuildVoiceParticipantsEndpointTests.cs
@@ -131,5 +131,10 @@ public sealed class GuildVoiceParticipantsEndpointTests : IClassFixture<Harmonie
                 ResultsByGuildId.TryGetValue(guildId.ToString(), out var results)
                     ? results
                     : (IReadOnlyList<GuildVoiceChannelParticipants>)[]);
+
+        public Task<IReadOnlyList<VoiceChannelParticipant>> ListChannelParticipantsAsync(
+            GuildChannelId channelId,
+            CancellationToken ct)
+            => Task.FromResult<IReadOnlyList<VoiceChannelParticipant>>([]);
     }
 }

--- a/tests/Harmonie.Application.Tests/Voice/JoinVoiceChannelHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Voice/JoinVoiceChannelHandlerTests.cs
@@ -23,6 +23,8 @@ public sealed class JoinVoiceChannelHandlerTests
     private readonly Mock<IGuildMemberRepository> _guildMemberRepositoryMock;
     private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<ILiveKitTokenService> _liveKitTokenServiceMock;
+    private readonly Mock<ILiveKitRoomService> _liveKitRoomServiceMock;
+    private readonly Mock<IVoiceParticipantCache> _voiceParticipantCacheMock;
     private readonly JoinVoiceChannelHandler _handler;
 
     public JoinVoiceChannelHandlerTests()
@@ -31,12 +33,28 @@ public sealed class JoinVoiceChannelHandlerTests
         _guildMemberRepositoryMock = new Mock<IGuildMemberRepository>();
         _userRepositoryMock = new Mock<IUserRepository>();
         _liveKitTokenServiceMock = new Mock<ILiveKitTokenService>();
+        _liveKitRoomServiceMock = new Mock<ILiveKitRoomService>();
+        _voiceParticipantCacheMock = new Mock<IVoiceParticipantCache>();
+
+        _voiceParticipantCacheMock
+            .Setup(x => x.GetAsync(It.IsAny<GuildChannelId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        _voiceParticipantCacheMock
+            .Setup(x => x.AddOrUpdateAsync(It.IsAny<GuildChannelId>(), It.IsAny<CachedVoiceParticipant>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _liveKitRoomServiceMock
+            .Setup(x => x.ListChannelParticipantsAsync(It.IsAny<GuildChannelId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
 
         _handler = new JoinVoiceChannelHandler(
             _guildChannelRepositoryMock.Object,
             _guildMemberRepositoryMock.Object,
             _userRepositoryMock.Object,
-            _liveKitTokenServiceMock.Object);
+            _liveKitTokenServiceMock.Object,
+            _liveKitRoomServiceMock.Object,
+            _voiceParticipantCacheMock.Object);
     }
 
     [Fact]
@@ -120,7 +138,7 @@ public sealed class JoinVoiceChannelHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_WhenRequestIsValid_ShouldReturnLiveKitConnectionInfo()
+    public async Task HandleAsync_WhenRoomIsEmpty_ShouldReturnEmptyCurrentParticipants()
     {
         var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
         var user = ApplicationTestBuilders.CreateUser();
@@ -142,21 +160,177 @@ public sealed class JoinVoiceChannelHandlerTests
             .ReturnsAsync(user);
 
         _liveKitTokenServiceMock
-            .Setup(x => x.GenerateRoomTokenAsync(
-                channel.Id,
-                user.Id,
-                user.Username.Value,
-                It.IsAny<CancellationToken>()))
+            .Setup(x => x.GenerateRoomTokenAsync(channel.Id, user.Id, user.Username.Value, It.IsAny<CancellationToken>()))
             .ReturnsAsync(roomToken);
 
         var response = await _handler.HandleAsync(channel.Id, user.Id);
 
         response.Success.Should().BeTrue();
-        response.Error.Should().BeNull();
         response.Data.Should().NotBeNull();
         response.Data!.Token.Should().Be(roomToken.Token);
         response.Data.Url.Should().Be(roomToken.Url);
         response.Data.RoomName.Should().Be(roomToken.RoomName);
+        response.Data.CurrentParticipants.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task HandleAsync_WhenParticipantsAreAlreadyCached_ShouldReturnCachedParticipants()
+    {
+        var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
+        var user = ApplicationTestBuilders.CreateUser();
+        var roomToken = new LiveKitRoomToken("eyJ.token", "ws://localhost:7880", $"channel:{channel.Id}");
+
+        var participantUserId = UserId.New();
+        var lkParticipant = new VoiceChannelParticipant(participantUserId, "lk-username");
+        var cachedParticipant = new CachedVoiceParticipant(
+            UserId: participantUserId,
+            Username: "cached-username",
+            DisplayName: "Cached Display",
+            AvatarFileId: null,
+            AvatarColor: "#abc",
+            AvatarIcon: "star",
+            AvatarBg: "#fff");
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetByIdAsync(channel.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(channel);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.IsMemberAsync(channel.GuildId, user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _liveKitTokenServiceMock
+            .Setup(x => x.GenerateRoomTokenAsync(channel.Id, user.Id, user.Username.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(roomToken);
+
+        _liveKitRoomServiceMock
+            .Setup(x => x.ListChannelParticipantsAsync(channel.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([lkParticipant]);
+
+        _voiceParticipantCacheMock
+            .Setup(x => x.GetAsync(channel.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([cachedParticipant]);
+
+        var response = await _handler.HandleAsync(channel.Id, user.Id);
+
+        response.Success.Should().BeTrue();
+        response.Data!.CurrentParticipants.Should().HaveCount(1);
+
+        var p = response.Data.CurrentParticipants[0];
+        p.UserId.Should().Be(participantUserId.Value);
+        p.Username.Should().Be("cached-username");
+        p.DisplayName.Should().Be("Cached Display");
+        p.AvatarColor.Should().Be("#abc");
+        p.AvatarIcon.Should().Be("star");
+        p.AvatarBg.Should().Be("#fff");
+
+        _userRepositoryMock.Verify(
+            x => x.GetManyByIdsAsync(It.IsAny<IReadOnlyList<UserId>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenParticipantNotInCache_ShouldFetchFromDbAndUpdateCache()
+    {
+        var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
+        var user = ApplicationTestBuilders.CreateUser();
+        var roomToken = new LiveKitRoomToken("eyJ.token", "ws://localhost:7880", $"channel:{channel.Id}");
+
+        var participantUserId = UserId.New();
+        var dbUser = ApplicationTestBuilders.CreateUser();
+        var lkParticipant = new VoiceChannelParticipant(dbUser.Id, dbUser.Username.Value);
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetByIdAsync(channel.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(channel);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.IsMemberAsync(channel.GuildId, user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _liveKitTokenServiceMock
+            .Setup(x => x.GenerateRoomTokenAsync(channel.Id, user.Id, user.Username.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(roomToken);
+
+        _liveKitRoomServiceMock
+            .Setup(x => x.ListChannelParticipantsAsync(channel.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([lkParticipant]);
+
+        _userRepositoryMock
+            .Setup(x => x.GetManyByIdsAsync(
+                It.Is<IReadOnlyList<UserId>>(ids => ids.Contains(dbUser.Id)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([dbUser]);
+
+        var response = await _handler.HandleAsync(channel.Id, user.Id);
+
+        response.Success.Should().BeTrue();
+        response.Data!.CurrentParticipants.Should().HaveCount(1);
+
+        var p = response.Data.CurrentParticipants[0];
+        p.UserId.Should().Be(dbUser.Id.Value);
+        p.Username.Should().Be(dbUser.Username.Value);
+
+        _voiceParticipantCacheMock.Verify(
+            x => x.AddOrUpdateAsync(
+                channel.Id,
+                It.Is<CachedVoiceParticipant>(cp => cp.UserId == dbUser.Id),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCachedParticipantNotInLiveKit_ShouldRemoveFromCache()
+    {
+        var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
+        var user = ApplicationTestBuilders.CreateUser();
+        var roomToken = new LiveKitRoomToken("eyJ.token", "ws://localhost:7880", $"channel:{channel.Id}");
+
+        var staleUserId = UserId.New();
+        var staleParticipant = new CachedVoiceParticipant(
+            UserId: staleUserId,
+            Username: "stale",
+            DisplayName: null,
+            AvatarFileId: null,
+            AvatarColor: null,
+            AvatarIcon: null,
+            AvatarBg: null);
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetByIdAsync(channel.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(channel);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.IsMemberAsync(channel.GuildId, user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _liveKitTokenServiceMock
+            .Setup(x => x.GenerateRoomTokenAsync(channel.Id, user.Id, user.Username.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(roomToken);
+
+        _voiceParticipantCacheMock
+            .Setup(x => x.GetAsync(channel.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([staleParticipant]);
+
+        var response = await _handler.HandleAsync(channel.Id, user.Id);
+
+        response.Success.Should().BeTrue();
+        response.Data!.CurrentParticipants.Should().BeEmpty();
+
+        _voiceParticipantCacheMock.Verify(
+            x => x.RemoveAsync(channel.Id, staleUserId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `currentParticipants` to the `POST /guilds/{guildId}/channels/{channelId}/voice/join` response (user ID, username, display name, avatar file ID, avatar appearance)
- Adds `ListChannelParticipantsAsync(GuildChannelId)` to `ILiveKitRoomService` and implements it in `LiveKitRoomService`
- On each join, the handler queries LiveKit directly and reconciles the in-memory participant cache: missing participants are fetched from DB and added, stale participants are removed

## Test plan

- [x] Unit tests: 4 new cases covering empty room, cache hit, DB fallback for uncached participants, and stale cache cleanup
- [ ] Integration test: existing `JoinVoiceChannel_WhenGuildMemberJoinsVoiceChannel_ShouldReturn200` extended to assert `currentParticipants` is non-null
- [ ] `FakeLiveKitRoomService` in `GuildVoiceParticipantsEndpointTests` updated to implement the new interface method

Closes #317