### PR TITLE
feat(auth): allow optional avatar and theme on user registration

### DIFF
--- a/src/Harmonie.Application/Features/Auth/Register/RegisterHandler.cs
+++ b/src/Harmonie.Application/Features/Auth/Register/RegisterHandler.cs
@@ -1,4 +1,5 @@
 using Harmonie.Application.Common;
+using Harmonie.Application.Features.Users;
 using Harmonie.Application.Interfaces.Auth;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Users;
@@ -90,6 +91,54 @@ public sealed class RegisterHandler : IHandler<RegisterRequest, RegisterResponse
 
         var user = userResult.Value;
 
+        // Apply optional avatar fields
+        if (request.Avatar is not null)
+        {
+            var colorResult = user.UpdateAvatarColor(request.Avatar.Color);
+            if (colorResult.IsFailure)
+                return ApplicationResponse<RegisterResponse>.Fail(
+                    ApplicationErrorCodes.Common.ValidationFailed,
+                    "Request validation failed",
+                    EndpointExtensions.SingleValidationError(
+                        "Avatar.Color",
+                        ApplicationErrorCodes.Validation.Invalid,
+                        colorResult.Error ?? "Avatar color is invalid"));
+
+            var iconResult = user.UpdateAvatarIcon(request.Avatar.Icon);
+            if (iconResult.IsFailure)
+                return ApplicationResponse<RegisterResponse>.Fail(
+                    ApplicationErrorCodes.Common.ValidationFailed,
+                    "Request validation failed",
+                    EndpointExtensions.SingleValidationError(
+                        "Avatar.Icon",
+                        ApplicationErrorCodes.Validation.Invalid,
+                        iconResult.Error ?? "Avatar icon is invalid"));
+
+            var bgResult = user.UpdateAvatarBg(request.Avatar.Bg);
+            if (bgResult.IsFailure)
+                return ApplicationResponse<RegisterResponse>.Fail(
+                    ApplicationErrorCodes.Common.ValidationFailed,
+                    "Request validation failed",
+                    EndpointExtensions.SingleValidationError(
+                        "Avatar.Bg",
+                        ApplicationErrorCodes.Validation.Invalid,
+                        bgResult.Error ?? "Avatar background is invalid"));
+        }
+
+        // Apply optional theme
+        if (request.Theme is not null)
+        {
+            var themeResult = user.UpdateTheme(request.Theme);
+            if (themeResult.IsFailure)
+                return ApplicationResponse<RegisterResponse>.Fail(
+                    ApplicationErrorCodes.Common.ValidationFailed,
+                    "Request validation failed",
+                    EndpointExtensions.SingleValidationError(
+                        nameof(request.Theme),
+                        ApplicationErrorCodes.Validation.Invalid,
+                        themeResult.Error ?? "Theme is invalid"));
+        }
+
         // Generate tokens
         var accessToken = _jwtTokenService.GenerateAccessToken(
             user.Id,
@@ -110,13 +159,19 @@ public sealed class RegisterHandler : IHandler<RegisterRequest, RegisterResponse
             cancellationToken);
         await transaction.CommitAsync(cancellationToken);
 
+        var avatar = user.AvatarColor is not null || user.AvatarIcon is not null || user.AvatarBg is not null
+            ? new AvatarAppearanceDto(user.AvatarColor, user.AvatarIcon, user.AvatarBg)
+            : null;
+
         var payload = new RegisterResponse(
             UserId: user.Id.Value,
             Email: user.Email,
             Username: user.Username,
             AccessToken: accessToken,
             RefreshToken: refreshToken,
-            ExpiresAt: accessTokenExpiresAt
+            ExpiresAt: accessTokenExpiresAt,
+            Avatar: avatar,
+            Theme: user.Theme
         );
 
         return ApplicationResponse<RegisterResponse>.Ok(payload);

--- a/src/Harmonie.Application/Features/Auth/Register/RegisterRequest.cs
+++ b/src/Harmonie.Application/Features/Auth/Register/RegisterRequest.cs
@@ -1,3 +1,5 @@
+using Harmonie.Application.Features.Users;
+
 namespace Harmonie.Application.Features.Auth.Register;
 
 /// <summary>
@@ -6,4 +8,6 @@ namespace Harmonie.Application.Features.Auth.Register;
 public sealed record RegisterRequest(
     string Email,
     string Username,
-    string Password);
+    string Password,
+    AvatarAppearanceDto? Avatar = null,
+    string? Theme = null);

--- a/src/Harmonie.Application/Features/Auth/Register/RegisterResponse.cs
+++ b/src/Harmonie.Application/Features/Auth/Register/RegisterResponse.cs
@@ -1,3 +1,5 @@
+using Harmonie.Application.Features.Users;
+
 namespace Harmonie.Application.Features.Auth.Register;
 
 /// <summary>
@@ -9,4 +11,6 @@ public sealed record RegisterResponse(
     string Username,
     string AccessToken,
     string RefreshToken,
-    DateTime ExpiresAt);
+    DateTime ExpiresAt,
+    AvatarAppearanceDto? Avatar,
+    string Theme);

--- a/tests/Harmonie.API.IntegrationTests/Auth/AuthEndpointsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Auth/AuthEndpointsTests.cs
@@ -7,6 +7,7 @@ using Harmonie.Application.Features.Auth.Login;
 using Harmonie.Application.Features.Auth.Logout;
 using Harmonie.Application.Features.Auth.RefreshToken;
 using Harmonie.Application.Features.Auth.Register;
+using Harmonie.Application.Features.Users;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 
@@ -406,5 +407,77 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
         var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
+    }
+
+    [Fact]
+    public async Task Register_WithoutAvatarAndTheme_ReturnsNullAvatarAndDefaultTheme()
+    {
+        // Arrange
+        var request = new RegisterRequest(
+            Email: $"test{Guid.NewGuid()}@harmonie.chat",
+            Username: $"testuser{Guid.NewGuid():N}"[..20],
+            Password: "Test123!@#");
+
+        // Act
+        var response = await _client.PostAsJsonAsync("/api/auth/register", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var result = await response.Content.ReadFromJsonAsync<RegisterResponse>();
+        result.Should().NotBeNull();
+        result!.Avatar.Should().BeNull();
+        result.Theme.Should().Be("default");
+    }
+
+    [Fact]
+    public async Task Register_WithFullAvatarAndTheme_ReturnsAvatarAndTheme()
+    {
+        // Arrange
+        var request = new RegisterRequest(
+            Email: $"test{Guid.NewGuid()}@harmonie.chat",
+            Username: $"testuser{Guid.NewGuid():N}"[..20],
+            Password: "Test123!@#",
+            Avatar: new AvatarAppearanceDto("#ff0000", "star", "#0000ff"),
+            Theme: "dark");
+
+        // Act
+        var response = await _client.PostAsJsonAsync("/api/auth/register", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var result = await response.Content.ReadFromJsonAsync<RegisterResponse>();
+        result.Should().NotBeNull();
+        result!.Avatar.Should().NotBeNull();
+        result.Avatar!.Color.Should().Be("#ff0000");
+        result.Avatar.Icon.Should().Be("star");
+        result.Avatar.Bg.Should().Be("#0000ff");
+        result.Theme.Should().Be("dark");
+    }
+
+    [Fact]
+    public async Task Register_WithPartialAvatar_ReturnsPartialAvatarAndDefaultTheme()
+    {
+        // Arrange
+        var request = new RegisterRequest(
+            Email: $"test{Guid.NewGuid()}@harmonie.chat",
+            Username: $"testuser{Guid.NewGuid():N}"[..20],
+            Password: "Test123!@#",
+            Avatar: new AvatarAppearanceDto("#ff0000", null, null));
+
+        // Act
+        var response = await _client.PostAsJsonAsync("/api/auth/register", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var result = await response.Content.ReadFromJsonAsync<RegisterResponse>();
+        result.Should().NotBeNull();
+        result!.Avatar.Should().NotBeNull();
+        result.Avatar!.Color.Should().Be("#ff0000");
+        result.Avatar.Icon.Should().BeNull();
+        result.Avatar.Bg.Should().BeNull();
+        result.Theme.Should().Be("default");
     }
 }

--- a/tests/Harmonie.Application.Tests/Auth/RegisterHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Auth/RegisterHandlerTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Harmonie.Application.Common;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Application.Features.Auth.Register;
+using Harmonie.Application.Features.Users;
 using Harmonie.Application.Interfaces.Auth;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Users;
@@ -239,5 +240,113 @@ public sealed class RegisterHandlerTests
         response.Data.Should().BeNull();
         response.Error.Should().NotBeNull();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Auth.DuplicateUsername);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithoutAvatarAndTheme_ShouldReturnNullAvatarAndDefaultTheme()
+    {
+        // Arrange
+        var request = new RegisterRequest(
+            "test@harmonie.chat",
+            "testuser",
+            "Test123!@#");
+
+        SetupSuccessfulTokenMocks();
+
+        _userRepositoryMock
+            .Setup(x => x.CheckDuplicatesAsync(It.IsAny<Email>(), It.IsAny<Username>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserDuplicateCheck(false, false));
+
+        // Act
+        var response = await _handler.HandleAsync(request);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.Data!.Avatar.Should().BeNull();
+        response.Data.Theme.Should().Be("default");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithFullAvatarAndTheme_ShouldReturnAvatarAndTheme()
+    {
+        // Arrange
+        var request = new RegisterRequest(
+            "test@harmonie.chat",
+            "testuser",
+            "Test123!@#",
+            Avatar: new AvatarAppearanceDto("#ff0000", "star", "#0000ff"),
+            Theme: "dark");
+
+        SetupSuccessfulTokenMocks();
+
+        _userRepositoryMock
+            .Setup(x => x.CheckDuplicatesAsync(It.IsAny<Email>(), It.IsAny<Username>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserDuplicateCheck(false, false));
+
+        // Act
+        var response = await _handler.HandleAsync(request);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.Data!.Avatar.Should().NotBeNull();
+        response.Data.Avatar!.Color.Should().Be("#ff0000");
+        response.Data.Avatar.Icon.Should().Be("star");
+        response.Data.Avatar.Bg.Should().Be("#0000ff");
+        response.Data.Theme.Should().Be("dark");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithPartialAvatar_ShouldReturnPartialAvatarAndDefaultTheme()
+    {
+        // Arrange
+        var request = new RegisterRequest(
+            "test@harmonie.chat",
+            "testuser",
+            "Test123!@#",
+            Avatar: new AvatarAppearanceDto("#ff0000", null, null));
+
+        SetupSuccessfulTokenMocks();
+
+        _userRepositoryMock
+            .Setup(x => x.CheckDuplicatesAsync(It.IsAny<Email>(), It.IsAny<Username>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserDuplicateCheck(false, false));
+
+        // Act
+        var response = await _handler.HandleAsync(request);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.Data!.Avatar.Should().NotBeNull();
+        response.Data.Avatar!.Color.Should().Be("#ff0000");
+        response.Data.Avatar.Icon.Should().BeNull();
+        response.Data.Avatar.Bg.Should().BeNull();
+        response.Data.Theme.Should().Be("default");
+    }
+
+    private void SetupSuccessfulTokenMocks()
+    {
+        _passwordHasherMock
+            .Setup(x => x.HashPassword(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns("hashed_password");
+
+        _jwtTokenServiceMock
+            .Setup(x => x.GenerateAccessToken(It.IsAny<UserId>(), It.IsAny<Email>(), It.IsAny<Username>()))
+            .Returns("access_token");
+
+        _jwtTokenServiceMock
+            .Setup(x => x.GenerateRefreshToken())
+            .Returns("refresh_token");
+
+        _jwtTokenServiceMock
+            .Setup(x => x.HashRefreshToken(It.IsAny<string>()))
+            .Returns("refresh_token_hash");
+
+        _jwtTokenServiceMock
+            .Setup(x => x.GetAccessTokenExpirationUtc())
+            .Returns(DateTime.UtcNow.AddMinutes(15));
+
+        _jwtTokenServiceMock
+            .Setup(x => x.GetRefreshTokenExpirationUtc())
+            .Returns(DateTime.UtcNow.AddDays(30));
     }
 }


### PR DESCRIPTION
## Summary

- Add optional `Avatar` (`AvatarAppearanceDto?`) and `Theme` (`string?`) fields to `POST /auth/register`
- Apply avatar sub-fields and theme to the newly created user entity before persisting
- Return `avatar` and `theme` in `RegisterResponse` (same shape as `GetMyProfile` / `UpdateMyProfile`)
- No migration needed — `avatar_color`, `avatar_icon`, `avatar_bg`, and `theme` columns already exist

## Test plan

- [x] Unit tests: no avatar/theme → null avatar + "default" theme; full avatar + theme → persisted and returned; partial avatar → sub-fields correctly null
- [x] Integration tests: same three scenarios verified end-to-end against the real database
- [x] All 360 application unit tests pass
- [x] All 386 integration tests pass

Closes #322