### PR TITLE
feat(signalrdoc): AsyncAPI 3.1 generator for SignalR hubs (#321)

### DIFF
--- a/Harmonie.sln
+++ b/Harmonie.sln
@@ -44,6 +44,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{B5EEC096-4
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmonie.Infrastructure.Tests", "tests\Harmonie.Infrastructure.Tests\Harmonie.Infrastructure.Tests.csproj", "{41BF7DBE-349D-41F0-8779-CD2A42AAB553}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmonie.API.Tests", "tests\Harmonie.API.Tests\Harmonie.API.Tests.csproj", "{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -162,6 +164,18 @@ Global
 		{41BF7DBE-349D-41F0-8779-CD2A42AAB553}.Release|x64.Build.0 = Release|Any CPU
 		{41BF7DBE-349D-41F0-8779-CD2A42AAB553}.Release|x86.ActiveCfg = Release|Any CPU
 		{41BF7DBE-349D-41F0-8779-CD2A42AAB553}.Release|x86.Build.0 = Release|Any CPU
+		{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F}.Debug|x64.Build.0 = Debug|Any CPU
+		{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F}.Debug|x86.Build.0 = Debug|Any CPU
+		{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F}.Release|x64.ActiveCfg = Release|Any CPU
+		{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F}.Release|x64.Build.0 = Release|Any CPU
+		{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F}.Release|x86.ActiveCfg = Release|Any CPU
+		{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -176,6 +190,7 @@ Global
 		{C1E7A1F1-8C2E-4D3A-9F5B-1234567890B3} = {E1E7A1F1-8C2E-4D3A-9F5B-1234567890D2}
 		{D1E7A1F1-8C2E-4D3A-9F5B-1234567890C1} = {E1E7A1F1-8C2E-4D3A-9F5B-1234567890D3}
 		{41BF7DBE-349D-41F0-8779-CD2A42AAB553} = {E1E7A1F1-8C2E-4D3A-9F5B-1234567890D2}
+		{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F} = {E1E7A1F1-8C2E-4D3A-9F5B-1234567890D2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F1E7A1F1-8C2E-4D3A-9F5B-1234567890E1}

--- a/src/Harmonie.API/Configuration/RealTimeConfiguration.cs
+++ b/src/Harmonie.API/Configuration/RealTimeConfiguration.cs
@@ -41,6 +41,14 @@ public static class RealTimeConfiguration
             options.Description = "Real-time events for the Harmonie chat platform.";
             options.HubRoutes[typeof(RealtimeHub)] = "/hubs/realtime";
             options.Assemblies.Add(typeof(RealtimeHub).Assembly);
+
+            options.MethodTags["Guilds"] = ["Guild", "Member", "YouWere", "Channel"];
+            options.MethodTags["Conversations"] = ["Conversation", "StartTypingConversation"];
+            options.MethodTags["Voice"] = ["Voice"];
+            options.MethodTags["Messages"] = ["Message", "Reaction"];
+            options.MethodTags["Users"] = ["User", "Presence", "Profile"];
+            options.MethodTags["Typing"] = ["StartTypingChannel", "UserTyping"];
+            options.MethodTags["Lifecycle"] = ["Ready"];
         });
 
         return services;

--- a/src/Harmonie.API/Configuration/RealTimeConfiguration.cs
+++ b/src/Harmonie.API/Configuration/RealTimeConfiguration.cs
@@ -5,6 +5,7 @@ using Harmonie.API.RealTime.Guilds;
 using Harmonie.API.RealTime.Messages;
 using Harmonie.API.RealTime.Users;
 using Harmonie.API.RealTime.Voice;
+using Harmonie.API.SignalRDoc.Extensions;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
@@ -12,6 +13,7 @@ using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Interfaces.Voice;
+
 namespace Harmonie.API.Configuration;
 
 public static class RealTimeConfiguration
@@ -31,6 +33,15 @@ public static class RealTimeConfiguration
         services.AddScoped<IReactionNotifier, SignalRReactionNotifier>();
         services.AddSingleton<IConnectionTracker, ConnectionTracker>();
         services.AddScoped<IRealtimeGroupManager, SignalRRealtimeGroupManager>();
+
+        services.AddSignalRAsyncApiDoc(options =>
+        {
+            options.Title = "Harmonie SignalR API";
+            options.Version = "1.0.0";
+            options.Description = "Real-time events for the Harmonie chat platform.";
+            options.HubRoutes[typeof(RealtimeHub)] = "/hubs/realtime";
+            options.Assemblies.Add(typeof(RealtimeHub).Assembly);
+        });
 
         return services;
     }

--- a/src/Harmonie.API/Harmonie.API.csproj
+++ b/src/Harmonie.API/Harmonie.API.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Harmonie.API.IntegrationTests" />
+    <InternalsVisibleTo Include="Harmonie.API.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="SignalRDoc/Assets/asyncapi-ui.html" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Harmonie.Application\Harmonie.Application.csproj" />

--- a/src/Harmonie.API/Program.cs
+++ b/src/Harmonie.API/Program.cs
@@ -3,6 +3,7 @@ using Harmonie.API.Configuration;
 using Harmonie.API.Endpoints;
 using Harmonie.API.Middleware;
 using Harmonie.API.RealTime.Common;
+using Harmonie.API.SignalRDoc.Extensions;
 using Harmonie.Application;
 using Harmonie.Application.Features.Uploads.UploadFile;
 using Harmonie.Infrastructure;
@@ -44,6 +45,7 @@ if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
     app.MapScalarApiReference();
+    app.MapSignalRAsyncApiDoc();
 }
 
 app.UseMiddleware<GlobalExceptionHandler>();

--- a/src/Harmonie.API/SignalRDoc/Assets/asyncapi-ui.html
+++ b/src/Harmonie.API/SignalRDoc/Assets/asyncapi-ui.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SignalR AsyncAPI</title>
+  <style>
+    :root {
+      --bg: #0f1117;
+      --surface: #1a1d27;
+      --surface2: #232635;
+      --border: #2e3347;
+      --text: #e2e8f0;
+      --muted: #8892a4;
+      --accent: #6c8ef7;
+      --send: #34d399;
+      --receive: #f59e0b;
+      --tag-bg: #2e3347;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { background: var(--bg); color: var(--text); font-family: system-ui, -apple-system, sans-serif; font-size: 14px; line-height: 1.6; }
+    a { color: var(--accent); text-decoration: none; }
+    #app { max-width: 1100px; margin: 0 auto; padding: 32px 24px; }
+    #loading { text-align: center; color: var(--muted); padding: 80px 0; font-size: 16px; }
+    #error { background: #3b1c1c; border: 1px solid #7f1d1d; border-radius: 8px; padding: 16px; color: #fca5a5; }
+
+    /* Header */
+    .header { border-bottom: 1px solid var(--border); padding-bottom: 24px; margin-bottom: 32px; }
+    .header h1 { font-size: 28px; font-weight: 700; color: var(--text); }
+    .header .meta { margin-top: 8px; display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+    .badge { background: var(--tag-bg); border: 1px solid var(--border); border-radius: 4px; padding: 2px 8px; font-size: 12px; color: var(--muted); }
+    .badge.version { color: var(--accent); border-color: var(--accent); }
+    .description { margin-top: 12px; color: var(--muted); }
+
+    /* Sections */
+    .section { margin-bottom: 40px; }
+    .section-title { font-size: 18px; font-weight: 600; color: var(--text); margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid var(--border); }
+
+    /* Cards */
+    .card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; margin-bottom: 12px; overflow: hidden; }
+    .card-header { padding: 14px 18px; cursor: pointer; display: flex; align-items: center; gap: 12px; user-select: none; }
+    .card-header:hover { background: var(--surface2); }
+    .card-body { padding: 16px 18px; border-top: 1px solid var(--border); display: none; }
+    .card-body.open { display: block; }
+    .chevron { margin-left: auto; color: var(--muted); transition: transform 0.2s; }
+    .chevron.open { transform: rotate(90deg); }
+
+    /* Operation tags */
+    .tag { display: inline-flex; align-items: center; padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; }
+    .tag.send { background: #064e3b; color: var(--send); }
+    .tag.receive { background: #451a03; color: var(--receive); }
+
+    /* Channel pill */
+    .channel-pill { font-size: 12px; color: var(--muted); background: var(--tag-bg); border-radius: 4px; padding: 2px 6px; font-family: monospace; }
+
+    /* Op name */
+    .op-name { font-family: monospace; font-size: 14px; font-weight: 600; }
+
+    /* Schema table */
+    .schema-block { margin-top: 12px; }
+    .schema-label { font-size: 11px; font-weight: 600; text-transform: uppercase; color: var(--muted); margin-bottom: 6px; letter-spacing: 0.05em; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { text-align: left; padding: 6px 12px; border-bottom: 1px solid var(--border); font-size: 13px; }
+    th { color: var(--muted); font-weight: 600; font-size: 11px; text-transform: uppercase; background: var(--surface2); }
+    td code { font-family: monospace; font-size: 12px; color: var(--accent); background: var(--tag-bg); padding: 1px 5px; border-radius: 3px; }
+
+    /* Server */
+    .server-row { display: flex; gap: 8px; align-items: center; padding: 8px 0; }
+    .server-host { font-family: monospace; color: var(--send); }
+
+    /* No payload */
+    .no-payload { color: var(--muted); font-style: italic; font-size: 13px; }
+  </style>
+</head>
+<body>
+  <div id="app"><div id="loading">Loading AsyncAPI document…</div></div>
+  <script>
+    (async () => {
+      const app = document.getElementById('app');
+
+      let doc;
+      try {
+        const res = await fetch('/asyncapi/v1.json');
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        doc = await res.json();
+      } catch (e) {
+        app.innerHTML = `<div id="error">Failed to load /asyncapi/v1.json: ${e.message}</div>`;
+        return;
+      }
+
+      const info = doc.info || {};
+      const servers = doc.servers || {};
+      const channels = doc.channels || {};
+      const operations = doc.operations || {};
+      const components = doc.components || {};
+      const schemas = components.schemas || {};
+      const messages = components.messages || {};
+
+      function esc(s) {
+        return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      }
+
+      function resolveRef(ref) {
+        if (!ref) return null;
+        const parts = ref.replace(/^#\//, '').split('/');
+        let cur = doc;
+        for (const p of parts) { cur = cur?.[p]; if (!cur) return null; }
+        return cur;
+      }
+
+      function schemaToType(schema) {
+        if (!schema) return '—';
+        if (schema['$ref']) {
+          const name = schema['$ref'].split('/').pop();
+          return `<a href="#schema-${esc(name)}">${esc(name)}</a>${schema.nullable ? '?' : ''}`;
+        }
+        if (schema.type === 'array') return `${schemaToType(schema.items)}[]`;
+        if (schema.type === 'string' && schema.format) return `${esc(schema.format)}${schema.nullable ? '?' : ''}`;
+        if (schema.type) return `${esc(schema.type)}${schema.nullable ? '?' : ''}`;
+        if (schema.enum) return schema.enum.map(esc).join(' | ');
+        return 'object';
+      }
+
+      function renderSchemaProperties(schema) {
+        if (!schema) return '<span class="no-payload">No payload</span>';
+        const resolved = schema['$ref'] ? resolveRef(schema['$ref']) : schema;
+        if (!resolved || (!resolved.properties && !resolved.enum)) {
+          return `<code>${schemaToType(schema)}</code>`;
+        }
+        if (resolved.enum) {
+          return `<code>string</code> — values: ${resolved.enum.map(v => `<code>${esc(v)}</code>`).join(', ')}`;
+        }
+        const props = resolved.properties || {};
+        const rows = Object.entries(props).map(([name, s]) =>
+          `<tr><td><code>${esc(name)}</code></td><td><code>${schemaToType(s)}</code></td></tr>`
+        ).join('');
+        return `<table><thead><tr><th>Property</th><th>Type</th></tr></thead><tbody>${rows}</tbody></table>`;
+      }
+
+      function toggle(id) {
+        const body = document.getElementById('body-' + id);
+        const chev = document.getElementById('chev-' + id);
+        if (body) { body.classList.toggle('open'); }
+        if (chev) { chev.classList.toggle('open'); }
+      }
+
+      let html = `
+        <div class="header">
+          <h1>${esc(info.title || 'SignalR API')}</h1>
+          <div class="meta">
+            <span class="badge">asyncapi ${esc(doc.asyncapi || '3.1.0')}</span>
+            <span class="badge version">v${esc(info.version || '1.0.0')}</span>
+          </div>
+          ${info.description ? `<p class="description">${esc(info.description)}</p>` : ''}
+        </div>`;
+
+      // Servers
+      const serverEntries = Object.entries(servers);
+      if (serverEntries.length > 0) {
+        html += `<div class="section"><div class="section-title">Servers</div>`;
+        for (const [key, srv] of serverEntries) {
+          html += `<div class="card"><div class="card-header">
+            <span class="op-name">${esc(key)}</span>
+            <span class="server-host">${esc(srv.host)}</span>
+            <span class="badge">${esc(srv.protocol)}</span>
+          </div></div>`;
+        }
+        html += `</div>`;
+      }
+
+      // Channels & Operations
+      const channelEntries = Object.entries(channels);
+      if (channelEntries.length > 0) {
+        html += `<div class="section"><div class="section-title">Channels &amp; Operations</div>`;
+
+        for (const [chKey, channel] of channelEntries) {
+          const chOps = Object.entries(operations).filter(([, op]) => {
+            const ref = op.channel?.['$ref'] || '';
+            return ref.endsWith('/' + chKey);
+          });
+
+          html += `<div class="card">
+            <div class="card-header" onclick="toggle('ch-${esc(chKey)}')">
+              <span class="op-name">${esc(chKey)}</span>
+              <span class="channel-pill">${esc(channel.address)}</span>
+              <span class="badge">${chOps.length} operation${chOps.length !== 1 ? 's' : ''}</span>
+              <span class="chevron" id="chev-ch-${esc(chKey)}">&#9654;</span>
+            </div>
+            <div class="card-body" id="body-ch-${esc(chKey)}">`;
+
+          for (const [opKey, op] of chOps) {
+            const msgRef = op.messages?.[0]?.['$ref'];
+            const msg = msgRef ? resolveRef(msgRef) : null;
+            const payload = msg?.payload;
+            const opId = opKey.replace(/\./g, '-');
+
+            html += `<div class="card" style="margin-bottom:10px">
+              <div class="card-header" onclick="toggle('op-${esc(opId)}')">
+                <span class="tag ${op.action === 'send' ? 'send' : 'receive'}">${esc(op.action === 'send' ? '→ client' : '← client')}</span>
+                <span class="op-name">${esc(opKey.split('.').slice(1).join('.'))}</span>
+                ${op.summary ? `<span style="color:var(--muted);font-size:13px">${esc(op.summary)}</span>` : ''}
+                <span class="chevron" id="chev-op-${esc(opId)}">&#9654;</span>
+              </div>
+              <div class="card-body" id="body-op-${esc(opId)}">
+                <div class="schema-block">
+                  <div class="schema-label">Payload</div>
+                  ${payload ? renderSchemaProperties(payload) : '<span class="no-payload">No payload</span>'}
+                </div>
+              </div>
+            </div>`;
+          }
+
+          html += `</div></div>`;
+        }
+
+        html += `</div>`;
+      }
+
+      // Schemas
+      const schemaEntries = Object.entries(schemas);
+      if (schemaEntries.length > 0) {
+        html += `<div class="section"><div class="section-title">Schemas</div>`;
+        for (const [name, schema] of schemaEntries) {
+          const props = schema.properties || {};
+          const propEntries = Object.entries(props);
+          const id = name.replace(/\./g, '-');
+          html += `<div class="card" id="schema-${esc(name)}">
+            <div class="card-header" onclick="toggle('sc-${esc(id)}')">
+              <span class="op-name">${esc(name)}</span>
+              <span class="badge">${schema.type || 'object'}</span>
+              ${propEntries.length > 0 ? `<span class="badge">${propEntries.length} propert${propEntries.length !== 1 ? 'ies' : 'y'}</span>` : ''}
+              <span class="chevron" id="chev-sc-${esc(id)}">&#9654;</span>
+            </div>
+            <div class="card-body" id="body-sc-${esc(id)}">`;
+
+          if (schema.enum) {
+            html += `<p>Values: ${schema.enum.map(v => `<code>${esc(v)}</code>`).join(', ')}</p>`;
+          } else if (propEntries.length > 0) {
+            html += `<table><thead><tr><th>Property</th><th>Type</th></tr></thead><tbody>`;
+            for (const [pname, pschema] of propEntries) {
+              html += `<tr><td><code>${esc(pname)}</code></td><td><code>${schemaToType(pschema)}</code></td></tr>`;
+            }
+            html += `</tbody></table>`;
+          } else {
+            html += `<span class="no-payload">No properties</span>`;
+          }
+
+          html += `</div></div>`;
+        }
+        html += `</div>`;
+      }
+
+      app.innerHTML = html;
+    })();
+  </script>
+</body>
+</html>

--- a/src/Harmonie.API/SignalRDoc/Assets/asyncapi-ui.html
+++ b/src/Harmonie.API/SignalRDoc/Assets/asyncapi-ui.html
@@ -45,10 +45,26 @@
     .chevron { margin-left: auto; color: var(--muted); transition: transform 0.2s; }
     .chevron.open { transform: rotate(90deg); }
 
-    /* Operation tags */
+    /* Direction tags */
     .tag { display: inline-flex; align-items: center; padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; }
     .tag.send { background: #064e3b; color: var(--send); }
     .tag.receive { background: #451a03; color: var(--receive); }
+
+    /* Domain tags (filter buttons) */
+    .filter-bar { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; align-items: center; }
+    .filter-bar-label { font-size: 11px; font-weight: 600; text-transform: uppercase; color: var(--muted); letter-spacing: 0.05em; margin-right: 4px; }
+    .filter-btn {
+      padding: 4px 12px; border-radius: 20px; font-size: 12px; font-weight: 600;
+      border: 1px solid var(--border); background: var(--tag-bg); color: var(--muted);
+      cursor: pointer; transition: all 0.15s; user-select: none;
+    }
+    .filter-btn:hover { border-color: var(--accent); color: var(--accent); }
+    .filter-btn.active { background: var(--accent); border-color: var(--accent); color: #fff; }
+    .domain-pill {
+      font-size: 11px; padding: 1px 7px; border-radius: 10px;
+      background: #1e2540; border: 1px solid #3a4470; color: #9aadff;
+      font-weight: 600;
+    }
 
     /* Channel pill */
     .channel-pill { font-size: 12px; color: var(--muted); background: var(--tag-bg); border-radius: 4px; padding: 2px 6px; font-family: monospace; }
@@ -65,11 +81,13 @@
     td code { font-family: monospace; font-size: 12px; color: var(--accent); background: var(--tag-bg); padding: 1px 5px; border-radius: 3px; }
 
     /* Server */
-    .server-row { display: flex; gap: 8px; align-items: center; padding: 8px 0; }
     .server-host { font-family: monospace; color: var(--send); }
 
     /* No payload */
     .no-payload { color: var(--muted); font-style: italic; font-size: 13px; }
+
+    /* Hidden by filter */
+    .op-card.filtered-out { display: none; }
   </style>
 </head>
 <body>
@@ -80,6 +98,49 @@
       const chev = document.getElementById('chev-' + id);
       if (body) body.classList.toggle('open');
       if (chev) chev.classList.toggle('open');
+    }
+
+    let _activeTag = null;
+
+    function filterByTag(tag) {
+      const btn = document.querySelector(`.filter-btn[data-tag="${tag}"]`);
+      const isActive = btn && btn.classList.contains('active');
+
+      // Reset all buttons
+      document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+
+      if (isActive) {
+        // Toggle off — show all
+        _activeTag = null;
+        document.querySelectorAll('.op-card').forEach(c => c.classList.remove('filtered-out'));
+        updateChannelCounts();
+        return;
+      }
+
+      _activeTag = tag;
+      if (btn) btn.classList.add('active');
+
+      document.querySelectorAll('.op-card').forEach(card => {
+        const tags = (card.dataset.tags || '').split(',').map(t => t.trim()).filter(Boolean);
+        if (tags.includes(tag)) {
+          card.classList.remove('filtered-out');
+        } else {
+          card.classList.add('filtered-out');
+        }
+      });
+
+      updateChannelCounts();
+    }
+
+    function updateChannelCounts() {
+      document.querySelectorAll('.ch-count').forEach(counter => {
+        const chKey = counter.dataset.ch;
+        const total = document.querySelectorAll(`.op-card[data-channel="${chKey}"]`).length;
+        const visible = document.querySelectorAll(`.op-card[data-channel="${chKey}"]:not(.filtered-out)`).length;
+        counter.textContent = _activeTag
+          ? `${visible} / ${total} operation${total !== 1 ? 's' : ''}`
+          : `${total} operation${total !== 1 ? 's' : ''}`;
+      });
     }
 
     (async () => {
@@ -101,7 +162,6 @@
       const operations = doc.operations || {};
       const components = doc.components || {};
       const schemas = components.schemas || {};
-      const messages = components.messages || {};
 
       function esc(s) {
         return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
@@ -144,6 +204,11 @@
         return `<table><thead><tr><th>Property</th><th>Type</th></tr></thead><tbody>${rows}</tbody></table>`;
       }
 
+      // Collect all tags across all operations
+      const allTags = [...new Set(
+        Object.values(operations).flatMap(op => (op.tags || []).map(t => t.name))
+      )].sort();
+
       let html = `
         <div class="header">
           <h1>${esc(info.title || 'SignalR API')}</h1>
@@ -171,7 +236,18 @@
       // Channels & Operations
       const channelEntries = Object.entries(channels);
       if (channelEntries.length > 0) {
-        html += `<div class="section"><div class="section-title">Channels &amp; Operations</div>`;
+        html += `<div class="section">`;
+        html += `<div class="section-title">Channels &amp; Operations</div>`;
+
+        // Tag filter bar
+        if (allTags.length > 0) {
+          html += `<div class="filter-bar">
+            <span class="filter-bar-label">Filter:</span>`;
+          for (const tag of allTags) {
+            html += `<button class="filter-btn" data-tag="${esc(tag)}" onclick="filterByTag('${esc(tag)}')">${esc(tag)}</button>`;
+          }
+          html += `</div>`;
+        }
 
         for (const [chKey, channel] of channelEntries) {
           const chOps = Object.entries(operations).filter(([, op]) => {
@@ -183,7 +259,7 @@
             <div class="card-header" onclick="toggle('ch-${esc(chKey)}')">
               <span class="op-name">${esc(chKey)}</span>
               <span class="channel-pill">${esc(channel.address)}</span>
-              <span class="badge">${chOps.length} operation${chOps.length !== 1 ? 's' : ''}</span>
+              <span class="badge ch-count" data-ch="${esc(chKey)}">${chOps.length} operation${chOps.length !== 1 ? 's' : ''}</span>
               <span class="chevron" id="chev-ch-${esc(chKey)}">&#9654;</span>
             </div>
             <div class="card-body" id="body-ch-${esc(chKey)}">`;
@@ -193,11 +269,16 @@
             const msg = msgRef ? resolveRef(msgRef) : null;
             const payload = msg?.payload;
             const opId = opKey.replace(/\./g, '-');
+            const opTags = (op.tags || []).map(t => t.name);
+            const tagsAttr = opTags.join(',');
 
-            html += `<div class="card" style="margin-bottom:10px">
+            const domainPills = opTags.map(t => `<span class="domain-pill">${esc(t)}</span>`).join(' ');
+
+            html += `<div class="card op-card" style="margin-bottom:10px" data-tags="${esc(tagsAttr)}" data-channel="${esc(chKey)}">
               <div class="card-header" onclick="toggle('op-${esc(opId)}')">
                 <span class="tag ${op.action === 'send' ? 'send' : 'receive'}">${esc(op.action === 'send' ? '→ client' : '← client')}</span>
                 <span class="op-name">${esc(opKey.split('.').slice(1).join('.'))}</span>
+                ${domainPills}
                 ${op.summary ? `<span style="color:var(--muted);font-size:13px">${esc(op.summary)}</span>` : ''}
                 <span class="chevron" id="chev-op-${esc(opId)}">&#9654;</span>
               </div>

--- a/src/Harmonie.API/SignalRDoc/Assets/asyncapi-ui.html
+++ b/src/Harmonie.API/SignalRDoc/Assets/asyncapi-ui.html
@@ -75,6 +75,13 @@
 <body>
   <div id="app"><div id="loading">Loading AsyncAPI document…</div></div>
   <script>
+    function toggle(id) {
+      const body = document.getElementById('body-' + id);
+      const chev = document.getElementById('chev-' + id);
+      if (body) body.classList.toggle('open');
+      if (chev) chev.classList.toggle('open');
+    }
+
     (async () => {
       const app = document.getElementById('app');
 
@@ -135,13 +142,6 @@
           `<tr><td><code>${esc(name)}</code></td><td><code>${schemaToType(s)}</code></td></tr>`
         ).join('');
         return `<table><thead><tr><th>Property</th><th>Type</th></tr></thead><tbody>${rows}</tbody></table>`;
-      }
-
-      function toggle(id) {
-        const body = document.getElementById('body-' + id);
-        const chev = document.getElementById('chev-' + id);
-        if (body) { body.classList.toggle('open'); }
-        if (chev) { chev.classList.toggle('open'); }
       }
 
       let html = `

--- a/src/Harmonie.API/SignalRDoc/Extensions/SignalRDocExtensions.cs
+++ b/src/Harmonie.API/SignalRDoc/Extensions/SignalRDocExtensions.cs
@@ -1,0 +1,51 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Harmonie.API.SignalRDoc.Generator;
+using Harmonie.API.SignalRDoc.Middleware;
+using Harmonie.API.SignalRDoc.Models;
+using Microsoft.Extensions.Options;
+
+namespace Harmonie.API.SignalRDoc.Extensions;
+
+public static class SignalRDocExtensions
+{
+    internal static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    public static IServiceCollection AddSignalRAsyncApiDoc(
+        this IServiceCollection services,
+        Action<SignalRDocOptions> configure)
+    {
+        services.Configure(configure);
+        services.AddSingleton<HubDiscovery>();
+        services.AddSingleton<SchemaGenerator>();
+        services.AddSingleton<AsyncApiGenerator>();
+        return services;
+    }
+
+    public static IEndpointRouteBuilder MapSignalRAsyncApiDoc(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/asyncapi/v1.json", (AsyncApiGenerator generator) =>
+            Results.Json(generator.Generate(), SerializerOptions));
+
+        app.MapGet("/asyncapi/ui", () =>
+            Results.Content(EmbeddedAssets.LoadHtmlPage(), "text/html"));
+
+        return app;
+    }
+}
+
+public sealed class SignalRDocOptions
+{
+    public string Title { get; set; } = "SignalR API";
+    public string Version { get; set; } = "1.0.0";
+    public string? Description { get; set; }
+    public string? ServerHost { get; set; }
+    public Dictionary<Type, string> HubRoutes { get; set; } = new();
+    public List<Assembly> Assemblies { get; set; } = new();
+}

--- a/src/Harmonie.API/SignalRDoc/Extensions/SignalRDocExtensions.cs
+++ b/src/Harmonie.API/SignalRDoc/Extensions/SignalRDocExtensions.cs
@@ -48,4 +48,11 @@ public sealed class SignalRDocOptions
     public string? ServerHost { get; set; }
     public Dictionary<Type, string> HubRoutes { get; set; } = new();
     public List<Assembly> Assemblies { get; set; } = new();
+
+    /// <summary>
+    /// Maps tag names to method name prefixes (case-insensitive StartsWith).
+    /// Operations whose method name starts with any prefix get the corresponding tag.
+    /// Example: { "Guild" = ["Guild", "Member", "Channel"] }
+    /// </summary>
+    public Dictionary<string, string[]> MethodTags { get; set; } = new();
 }

--- a/src/Harmonie.API/SignalRDoc/Generator/AsyncApiGenerator.cs
+++ b/src/Harmonie.API/SignalRDoc/Generator/AsyncApiGenerator.cs
@@ -3,6 +3,7 @@ using Harmonie.API.SignalRDoc.Extensions;
 using Harmonie.API.SignalRDoc.Models;
 using Microsoft.Extensions.Options;
 
+
 namespace Harmonie.API.SignalRDoc.Generator;
 
 public sealed class AsyncApiGenerator
@@ -36,10 +37,10 @@ public sealed class AsyncApiGenerator
             var channelMessages = new Dictionary<string, AsyncApiRef>();
 
             foreach (var method in hub.ClientToServerMethods)
-                AddMethodToDocument(hub, method, channelKey, "receive", channelMessages, operations, componentMessages, componentSchemas, schemaGenerator);
+                AddMethodToDocument(hub, method, channelKey, "receive", channelMessages, operations, componentMessages, componentSchemas, schemaGenerator, options.MethodTags);
 
             foreach (var method in hub.ServerToClientMethods)
-                AddMethodToDocument(hub, method, channelKey, "send", channelMessages, operations, componentMessages, componentSchemas, schemaGenerator);
+                AddMethodToDocument(hub, method, channelKey, "send", channelMessages, operations, componentMessages, componentSchemas, schemaGenerator, options.MethodTags);
 
             channels[channelKey] = new AsyncApiChannel
             {
@@ -92,7 +93,8 @@ public sealed class AsyncApiGenerator
         Dictionary<string, AsyncApiOperation> operations,
         Dictionary<string, AsyncApiMessage> componentMessages,
         Dictionary<string, AsyncApiSchema> componentSchemas,
-        SchemaGenerator schemaGenerator)
+        SchemaGenerator schemaGenerator,
+        IReadOnlyDictionary<string, string[]> methodTags)
     {
         var operationKey = $"{channelKey}.{JsonNamingPolicy.CamelCase.ConvertName(method.Name)}";
         var messageKey = $"{operationKey}.Message";
@@ -107,12 +109,15 @@ public sealed class AsyncApiGenerator
 
         channelMessages[messageKey] = new AsyncApiRef { Ref = $"#/components/messages/{messageKey}" };
 
+        var tags = ResolveMethodTags(method.Name, methodTags);
+
         operations[operationKey] = new AsyncApiOperation
         {
             Action = action,
             Channel = new AsyncApiRef { Ref = $"#/channels/{channelKey}" },
             Messages = new[] { new AsyncApiRef { Ref = $"#/components/messages/{messageKey}" } },
             Summary = method.Summary,
+            Tags = tags,
         };
     }
 
@@ -144,6 +149,29 @@ public sealed class AsyncApiGenerator
         var objectSchema = new AsyncApiSchema { Type = "object", Properties = props.Count > 0 ? props : null };
         schemas[schemaKey] = objectSchema;
         return new AsyncApiSchema { Ref = $"#/components/schemas/{schemaKey}" };
+    }
+
+    private static IReadOnlyList<AsyncApiTag>? ResolveMethodTags(
+        string methodName,
+        IReadOnlyDictionary<string, string[]> methodTags)
+    {
+        if (methodTags.Count == 0)
+            return null;
+
+        var matched = new List<AsyncApiTag>();
+        foreach (var (tag, prefixes) in methodTags)
+        {
+            foreach (var prefix in prefixes)
+            {
+                if (methodName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    matched.Add(new AsyncApiTag { Name = tag });
+                    break;
+                }
+            }
+        }
+
+        return matched.Count > 0 ? matched : null;
     }
 
     internal static string HubChannelKey(Type hubType)

--- a/src/Harmonie.API/SignalRDoc/Generator/AsyncApiGenerator.cs
+++ b/src/Harmonie.API/SignalRDoc/Generator/AsyncApiGenerator.cs
@@ -1,0 +1,156 @@
+using System.Text.Json;
+using Harmonie.API.SignalRDoc.Extensions;
+using Harmonie.API.SignalRDoc.Models;
+using Microsoft.Extensions.Options;
+
+namespace Harmonie.API.SignalRDoc.Generator;
+
+public sealed class AsyncApiGenerator
+{
+    private readonly Lazy<AsyncApiDocument> _document;
+
+    public AsyncApiGenerator(IOptions<SignalRDocOptions> options, HubDiscovery discovery, SchemaGenerator schemaGenerator)
+    {
+        _document = new Lazy<AsyncApiDocument>(
+            () => BuildDocument(options.Value, discovery, schemaGenerator),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    public AsyncApiDocument Generate() => _document.Value;
+
+    private static AsyncApiDocument BuildDocument(
+        SignalRDocOptions options,
+        HubDiscovery discovery,
+        SchemaGenerator schemaGenerator)
+    {
+        var hubs = discovery.Discover(options.Assemblies, options.HubRoutes);
+
+        var channels = new Dictionary<string, AsyncApiChannel>();
+        var operations = new Dictionary<string, AsyncApiOperation>();
+        var componentMessages = new Dictionary<string, AsyncApiMessage>();
+        var componentSchemas = new Dictionary<string, AsyncApiSchema>();
+
+        foreach (var hub in hubs)
+        {
+            var channelKey = HubChannelKey(hub.HubType);
+            var channelMessages = new Dictionary<string, AsyncApiRef>();
+
+            foreach (var method in hub.ClientToServerMethods)
+                AddMethodToDocument(hub, method, channelKey, "receive", channelMessages, operations, componentMessages, componentSchemas, schemaGenerator);
+
+            foreach (var method in hub.ServerToClientMethods)
+                AddMethodToDocument(hub, method, channelKey, "send", channelMessages, operations, componentMessages, componentSchemas, schemaGenerator);
+
+            channels[channelKey] = new AsyncApiChannel
+            {
+                Address = hub.Route,
+                Messages = channelMessages.Count > 0 ? channelMessages : null,
+            };
+        }
+
+        var doc = new AsyncApiDocument
+        {
+            Info = new AsyncApiInfo
+            {
+                Title = options.Title,
+                Version = options.Version,
+                Description = options.Description,
+            },
+            Channels = channels.Count > 0 ? channels : null,
+            Operations = operations.Count > 0 ? operations : null,
+            Components = componentMessages.Count > 0 || componentSchemas.Count > 0
+                ? new AsyncApiComponents
+                {
+                    Messages = componentMessages.Count > 0 ? componentMessages : null,
+                    Schemas = componentSchemas.Count > 0 ? componentSchemas : null,
+                }
+                : null,
+        };
+
+        if (!string.IsNullOrWhiteSpace(options.ServerHost))
+        {
+            doc.Servers = new Dictionary<string, AsyncApiServer>
+            {
+                ["default"] = new AsyncApiServer
+                {
+                    Host = options.ServerHost,
+                    Protocol = "wss",
+                    Description = "Harmonie SignalR server",
+                },
+            };
+        }
+
+        return doc;
+    }
+
+    private static void AddMethodToDocument(
+        HubDescriptor hub,
+        HubMethodDescriptor method,
+        string channelKey,
+        string action,
+        Dictionary<string, AsyncApiRef> channelMessages,
+        Dictionary<string, AsyncApiOperation> operations,
+        Dictionary<string, AsyncApiMessage> componentMessages,
+        Dictionary<string, AsyncApiSchema> componentSchemas,
+        SchemaGenerator schemaGenerator)
+    {
+        var operationKey = $"{channelKey}.{JsonNamingPolicy.CamelCase.ConvertName(method.Name)}";
+        var messageKey = $"{operationKey}.Message";
+
+        var payload = BuildPayloadSchema(hub.HubType, method, channelKey, componentSchemas, schemaGenerator);
+
+        componentMessages[messageKey] = new AsyncApiMessage
+        {
+            Name = JsonNamingPolicy.CamelCase.ConvertName(method.Name),
+            Payload = payload,
+        };
+
+        channelMessages[messageKey] = new AsyncApiRef { Ref = $"#/components/messages/{messageKey}" };
+
+        operations[operationKey] = new AsyncApiOperation
+        {
+            Action = action,
+            Channel = new AsyncApiRef { Ref = $"#/channels/{channelKey}" },
+            Messages = new[] { new AsyncApiRef { Ref = $"#/components/messages/{messageKey}" } },
+            Summary = method.Summary,
+        };
+    }
+
+    private static AsyncApiSchema? BuildPayloadSchema(
+        Type hubType,
+        HubMethodDescriptor method,
+        string channelKey,
+        Dictionary<string, AsyncApiSchema> schemas,
+        SchemaGenerator schemaGenerator)
+    {
+        var parameters = method.Parameters;
+
+        if (parameters.Count == 0)
+            return null;
+
+        if (parameters.Count == 1)
+            return schemaGenerator.GetSchema(parameters[0].Type, schemas);
+
+        // Multiple parameters: create an inline object schema stored in components/schemas
+        var schemaKey = $"{channelKey}.{JsonNamingPolicy.CamelCase.ConvertName(method.Name)}.Parameters";
+        var props = new Dictionary<string, AsyncApiSchema>();
+        foreach (var param in parameters)
+        {
+            var paramSchema = schemaGenerator.GetSchema(param.Type, schemas);
+            if (paramSchema is not null)
+                props[param.Name] = paramSchema;
+        }
+
+        var objectSchema = new AsyncApiSchema { Type = "object", Properties = props.Count > 0 ? props : null };
+        schemas[schemaKey] = objectSchema;
+        return new AsyncApiSchema { Ref = $"#/components/schemas/{schemaKey}" };
+    }
+
+    internal static string HubChannelKey(Type hubType)
+    {
+        var name = hubType.Name;
+        if (name.EndsWith("Hub", StringComparison.OrdinalIgnoreCase))
+            name = name[..^3];
+        return name;
+    }
+}

--- a/src/Harmonie.API/SignalRDoc/Generator/HubDiscovery.cs
+++ b/src/Harmonie.API/SignalRDoc/Generator/HubDiscovery.cs
@@ -1,0 +1,147 @@
+using System.Reflection;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Harmonie.API.SignalRDoc.Generator;
+
+public sealed class HubDiscovery
+{
+    private static readonly HashSet<string> ExcludedMethods = new(StringComparer.Ordinal)
+    {
+        "OnConnectedAsync",
+        "OnDisconnectedAsync",
+        "Dispose",
+    };
+
+    public IReadOnlyList<HubDescriptor> Discover(
+        IEnumerable<Assembly> assemblies,
+        IReadOnlyDictionary<Type, string>? routeOverrides = null)
+    {
+        var result = new List<HubDescriptor>();
+
+        foreach (var assembly in assemblies)
+        {
+            IEnumerable<Type> types;
+            try
+            {
+                types = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                types = ex.Types.OfType<Type>();
+            }
+
+            foreach (var type in types)
+            {
+                if (type.IsAbstract || !type.IsClass)
+                    continue;
+
+                if (!TryGetClientInterface(type, out var clientInterface) || clientInterface is null)
+                    continue;
+
+                var route = ResolveRoute(type, routeOverrides);
+                var clientToServer = ExtractClientToServerMethods(type);
+                var serverToClient = ExtractServerToClientMethods(clientInterface);
+
+                result.Add(new HubDescriptor(type, clientInterface, route, clientToServer, serverToClient));
+            }
+        }
+
+        return result;
+    }
+
+    private static bool TryGetClientInterface(Type type, out Type? clientInterface)
+    {
+        clientInterface = null;
+        var current = type.BaseType;
+        while (current is not null)
+        {
+            if (current.IsGenericType && current.GetGenericTypeDefinition() == typeof(Hub<>))
+            {
+                clientInterface = current.GetGenericArguments()[0];
+                return true;
+            }
+            current = current.BaseType;
+        }
+        return false;
+    }
+
+    private static string ResolveRoute(Type hubType, IReadOnlyDictionary<Type, string>? routeOverrides)
+    {
+        if (routeOverrides is not null && routeOverrides.TryGetValue(hubType, out var override_))
+            return override_;
+
+        var name = hubType.Name;
+        if (name.EndsWith("Hub", StringComparison.OrdinalIgnoreCase))
+            name = name[..^3];
+
+        return $"/hubs/{name.ToLowerInvariant()}";
+    }
+
+    private static IReadOnlyList<HubMethodDescriptor> ExtractClientToServerMethods(Type hubType)
+    {
+        var methods = hubType.GetMethods(
+            BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+        var result = new List<HubMethodDescriptor>();
+        foreach (var method in methods)
+        {
+            if (ExcludedMethods.Contains(method.Name))
+                continue;
+
+            var parameters = method.GetParameters()
+                .Where(p => p.ParameterType != typeof(CancellationToken))
+                .Select(p => new ParameterDescriptor(p.Name ?? p.Position.ToString(), p.ParameterType))
+                .ToList();
+
+            var returnType = UnwrapTask(method.ReturnType);
+            result.Add(new HubMethodDescriptor(method.Name, parameters, returnType, null));
+        }
+        return result;
+    }
+
+    private static IReadOnlyList<HubMethodDescriptor> ExtractServerToClientMethods(Type clientInterface)
+    {
+        var result = new List<HubMethodDescriptor>();
+        foreach (var method in clientInterface.GetMethods())
+        {
+            var parameters = method.GetParameters()
+                .Where(p => p.ParameterType != typeof(CancellationToken))
+                .Select(p => new ParameterDescriptor(p.Name ?? p.Position.ToString(), p.ParameterType))
+                .ToList();
+
+            var returnType = UnwrapTask(method.ReturnType);
+            result.Add(new HubMethodDescriptor(method.Name, parameters, returnType, null));
+        }
+        return result;
+    }
+
+    private static Type UnwrapTask(Type type)
+    {
+        if (type == typeof(void) || type == typeof(Task) || type == typeof(ValueTask))
+            return typeof(void);
+
+        if (type.IsGenericType)
+        {
+            var def = type.GetGenericTypeDefinition();
+            if (def == typeof(Task<>) || def == typeof(ValueTask<>))
+                return type.GetGenericArguments()[0];
+        }
+
+        return type;
+    }
+}
+
+public sealed record HubDescriptor(
+    Type HubType,
+    Type ClientInterface,
+    string Route,
+    IReadOnlyList<HubMethodDescriptor> ClientToServerMethods,
+    IReadOnlyList<HubMethodDescriptor> ServerToClientMethods);
+
+public sealed record HubMethodDescriptor(
+    string Name,
+    IReadOnlyList<ParameterDescriptor> Parameters,
+    Type ReturnType,
+    string? Summary);
+
+public sealed record ParameterDescriptor(string Name, Type Type);

--- a/src/Harmonie.API/SignalRDoc/Generator/SchemaGenerator.cs
+++ b/src/Harmonie.API/SignalRDoc/Generator/SchemaGenerator.cs
@@ -1,0 +1,119 @@
+using System.Reflection;
+using System.Text.Json;
+using Harmonie.API.SignalRDoc.Models;
+
+namespace Harmonie.API.SignalRDoc.Generator;
+
+public sealed class SchemaGenerator
+{
+    private static readonly HashSet<Type> CollectionGenericDefs = new()
+    {
+        typeof(List<>),
+        typeof(IEnumerable<>),
+        typeof(IReadOnlyList<>),
+        typeof(IList<>),
+        typeof(ICollection<>),
+        typeof(HashSet<>),
+    };
+
+    /// <summary>
+    /// Returns an AsyncApiSchema for the given type, registering complex schemas in the provided dict.
+    /// Returns null for void/Task (no payload).
+    /// </summary>
+    public AsyncApiSchema? GetSchema(Type type, Dictionary<string, AsyncApiSchema> schemas)
+    {
+        // Nullable<T>
+        var underlying = Nullable.GetUnderlyingType(type);
+        if (underlying is not null)
+        {
+            var inner = GetSchema(underlying, schemas);
+            return inner is null ? null : WithNullable(inner);
+        }
+
+        // void / Task (no payload)
+        if (type == typeof(void) || type == typeof(Task) || type == typeof(ValueTask))
+            return null;
+
+        // Task<T> / ValueTask<T>
+        if (type.IsGenericType)
+        {
+            var def = type.GetGenericTypeDefinition();
+            if (def == typeof(Task<>) || def == typeof(ValueTask<>))
+                return GetSchema(type.GetGenericArguments()[0], schemas);
+        }
+
+        // Primitives
+        if (type == typeof(string)) return new AsyncApiSchema { Type = "string" };
+        if (type == typeof(bool)) return new AsyncApiSchema { Type = "boolean" };
+        if (type == typeof(int) || type == typeof(long) || type == typeof(short)
+            || type == typeof(byte) || type == typeof(uint) || type == typeof(ulong))
+            return new AsyncApiSchema { Type = "integer" };
+        if (type == typeof(float) || type == typeof(double) || type == typeof(decimal))
+            return new AsyncApiSchema { Type = "number" };
+        if (type == typeof(Guid)) return new AsyncApiSchema { Type = "string", Format = "uuid" };
+        if (type == typeof(DateTime) || type == typeof(DateTimeOffset))
+            return new AsyncApiSchema { Type = "string", Format = "date-time" };
+
+        // Enum
+        if (type.IsEnum)
+            return new AsyncApiSchema { Type = "string", Enum = System.Enum.GetNames(type) };
+
+        // Array
+        if (type.IsArray)
+        {
+            var elemType = type.GetElementType()!;
+            return new AsyncApiSchema { Type = "array", Items = GetSchema(elemType, schemas) };
+        }
+
+        // Generic collection
+        if (type.IsGenericType && CollectionGenericDefs.Contains(type.GetGenericTypeDefinition()))
+        {
+            var elemType = type.GetGenericArguments()[0];
+            return new AsyncApiSchema { Type = "array", Items = GetSchema(elemType, schemas) };
+        }
+
+        // Complex object — register in components/schemas and return $ref
+        return BuildComplexSchema(type, schemas);
+    }
+
+    private AsyncApiSchema? BuildComplexSchema(Type type, Dictionary<string, AsyncApiSchema> schemas)
+    {
+        var typeName = type.Name;
+
+        // Already registered (completed or in-progress placeholder) — return $ref immediately
+        if (schemas.ContainsKey(typeName))
+            return new AsyncApiSchema { Ref = $"#/components/schemas/{typeName}" };
+
+        // Add placeholder before recursing properties to break circular references
+        var objectSchema = new AsyncApiSchema { Type = "object" };
+        schemas[typeName] = objectSchema;
+
+        var properties = new Dictionary<string, AsyncApiSchema>();
+        foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var propSchema = GetSchema(prop.PropertyType, schemas);
+            if (propSchema is not null)
+                properties[JsonNamingPolicy.CamelCase.ConvertName(prop.Name)] = propSchema;
+        }
+
+        if (properties.Count > 0)
+            objectSchema.Properties = properties;
+
+        return new AsyncApiSchema { Ref = $"#/components/schemas/{typeName}" };
+    }
+
+    private static AsyncApiSchema WithNullable(AsyncApiSchema schema)
+    {
+        return new AsyncApiSchema
+        {
+            Ref = schema.Ref,
+            Type = schema.Type,
+            Format = schema.Format,
+            Properties = schema.Properties,
+            Items = schema.Items,
+            Description = schema.Description,
+            Enum = schema.Enum,
+            Nullable = true,
+        };
+    }
+}

--- a/src/Harmonie.API/SignalRDoc/Middleware/EmbeddedAssets.cs
+++ b/src/Harmonie.API/SignalRDoc/Middleware/EmbeddedAssets.cs
@@ -1,0 +1,24 @@
+namespace Harmonie.API.SignalRDoc.Middleware;
+
+internal static class EmbeddedAssets
+{
+    private static string? _htmlPage;
+
+    internal static string LoadHtmlPage()
+    {
+        if (_htmlPage is not null)
+            return _htmlPage;
+
+        var assembly = typeof(EmbeddedAssets).Assembly;
+        using var stream = assembly.GetManifestResourceStream(
+            "Harmonie.API.SignalRDoc.Assets.asyncapi-ui.html");
+
+        if (stream is null)
+            throw new InvalidOperationException(
+                "Embedded resource 'Harmonie.API.SignalRDoc.Assets.asyncapi-ui.html' not found.");
+
+        using var reader = new StreamReader(stream);
+        _htmlPage = reader.ReadToEnd();
+        return _htmlPage;
+    }
+}

--- a/src/Harmonie.API/SignalRDoc/Models/AsyncApiDocument.cs
+++ b/src/Harmonie.API/SignalRDoc/Models/AsyncApiDocument.cs
@@ -86,6 +86,16 @@ public sealed class AsyncApiOperation
     [JsonPropertyName("description")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Description { get; set; }
+
+    [JsonPropertyName("tags")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<AsyncApiTag>? Tags { get; set; }
+}
+
+public sealed class AsyncApiTag
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
 }
 
 public sealed class AsyncApiMessage

--- a/src/Harmonie.API/SignalRDoc/Models/AsyncApiDocument.cs
+++ b/src/Harmonie.API/SignalRDoc/Models/AsyncApiDocument.cs
@@ -1,0 +1,151 @@
+using System.Text.Json.Serialization;
+
+namespace Harmonie.API.SignalRDoc.Models;
+
+public sealed class AsyncApiDocument
+{
+    [JsonPropertyName("asyncapi")]
+    public string Asyncapi { get; set; } = "3.1.0";
+
+    [JsonPropertyName("info")]
+    public AsyncApiInfo Info { get; set; } = new();
+
+    [JsonPropertyName("servers")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Dictionary<string, AsyncApiServer>? Servers { get; set; }
+
+    [JsonPropertyName("channels")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Dictionary<string, AsyncApiChannel>? Channels { get; set; }
+
+    [JsonPropertyName("operations")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Dictionary<string, AsyncApiOperation>? Operations { get; set; }
+
+    [JsonPropertyName("components")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public AsyncApiComponents? Components { get; set; }
+}
+
+public sealed class AsyncApiInfo
+{
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = "";
+
+    [JsonPropertyName("version")]
+    public string Version { get; set; } = "1.0.0";
+
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+}
+
+public sealed class AsyncApiServer
+{
+    [JsonPropertyName("host")]
+    public string Host { get; set; } = "";
+
+    [JsonPropertyName("protocol")]
+    public string Protocol { get; set; } = "wss";
+
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+}
+
+public sealed class AsyncApiChannel
+{
+    [JsonPropertyName("address")]
+    public string Address { get; set; } = "";
+
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("messages")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Dictionary<string, AsyncApiRef>? Messages { get; set; }
+}
+
+public sealed class AsyncApiOperation
+{
+    [JsonPropertyName("action")]
+    public string Action { get; set; } = "";
+
+    [JsonPropertyName("channel")]
+    public AsyncApiRef Channel { get; set; } = new();
+
+    [JsonPropertyName("messages")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<AsyncApiRef>? Messages { get; set; }
+
+    [JsonPropertyName("summary")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Summary { get; set; }
+
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+}
+
+public sealed class AsyncApiMessage
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    [JsonPropertyName("payload")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public AsyncApiSchema? Payload { get; set; }
+}
+
+public sealed class AsyncApiSchema
+{
+    [JsonPropertyName("$ref")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Ref { get; set; }
+
+    [JsonPropertyName("type")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("format")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Format { get; set; }
+
+    [JsonPropertyName("properties")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Dictionary<string, AsyncApiSchema>? Properties { get; set; }
+
+    [JsonPropertyName("items")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public AsyncApiSchema? Items { get; set; }
+
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("enum")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string[]? Enum { get; set; }
+
+    [JsonPropertyName("nullable")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Nullable { get; set; }
+}
+
+public sealed class AsyncApiComponents
+{
+    [JsonPropertyName("schemas")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Dictionary<string, AsyncApiSchema>? Schemas { get; set; }
+
+    [JsonPropertyName("messages")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Dictionary<string, AsyncApiMessage>? Messages { get; set; }
+}
+
+public sealed class AsyncApiRef
+{
+    [JsonPropertyName("$ref")]
+    public string Ref { get; set; } = "";
+}

--- a/tests/Harmonie.API.IntegrationTests/AsyncApiDocumentTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/AsyncApiDocumentTests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using Harmonie.API.IntegrationTests.Common;
+using Microsoft.AspNetCore.Hosting;
+using System.Net;
+using System.Text.Json.Nodes;
+using Xunit;
+
+namespace Harmonie.API.IntegrationTests;
+
+public sealed class AsyncApiDocumentTests : IClassFixture<HarmonieWebApplicationFactory>
+{
+    private readonly HarmonieWebApplicationFactory _factory;
+
+    public AsyncApiDocumentTests(HarmonieWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetAsyncApiJson_ReturnsOkWithApplicationJsonContentType()
+    {
+        using var factory = _factory.WithWebHostBuilder(b => b.UseEnvironment("Development"));
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/asyncapi/v1.json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+    }
+
+    [Fact]
+    public async Task GetAsyncApiJson_ReturnsParseableDocumentWithAtLeastOneChannel()
+    {
+        using var factory = _factory.WithWebHostBuilder(b => b.UseEnvironment("Development"));
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/asyncapi/v1.json");
+        var body = await response.Content.ReadAsStringAsync();
+
+        var document = JsonNode.Parse(body);
+        document.Should().NotBeNull();
+        document!["asyncapi"]?.GetValue<string>().Should().Be("3.1.0");
+        document["channels"].Should().NotBeNull();
+        document["channels"]!.AsObject().Count.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task GetAsyncApiJson_DocumentContainsRealtimeChannel()
+    {
+        using var factory = _factory.WithWebHostBuilder(b => b.UseEnvironment("Development"));
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/asyncapi/v1.json");
+        var body = await response.Content.ReadAsStringAsync();
+        var document = JsonNode.Parse(body);
+
+        document!["channels"]!["Realtime"].Should().NotBeNull();
+        document["channels"]!["Realtime"]!["address"]?.GetValue<string>().Should().Be("/hubs/realtime");
+    }
+
+    [Fact]
+    public async Task GetAsyncApiUi_ReturnsOkWithTextHtmlContentType()
+    {
+        using var factory = _factory.WithWebHostBuilder(b => b.UseEnvironment("Development"));
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/asyncapi/ui");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("text/html");
+    }
+
+}

--- a/tests/Harmonie.API.Tests/Harmonie.API.Tests.csproj
+++ b/tests/Harmonie.API.Tests/Harmonie.API.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Harmonie.API\Harmonie.API.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Harmonie.API.Tests/SignalRDoc/AsyncApiGeneratorTests.cs
+++ b/tests/Harmonie.API.Tests/SignalRDoc/AsyncApiGeneratorTests.cs
@@ -1,0 +1,150 @@
+using FluentAssertions;
+using Harmonie.API.SignalRDoc.Extensions;
+using Harmonie.API.SignalRDoc.Generator;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Harmonie.API.Tests.SignalRDoc;
+
+public sealed class AsyncApiGeneratorTests
+{
+    private static AsyncApiGenerator CreateGenerator(Action<SignalRDocOptions>? configure = null)
+    {
+        var options = new SignalRDocOptions
+        {
+            Title = "Test API",
+            Version = "0.1.0",
+            Assemblies = { typeof(FakeHub).Assembly },
+        };
+        configure?.Invoke(options);
+
+        return new AsyncApiGenerator(
+            Options.Create(options),
+            new HubDiscovery(),
+            new SchemaGenerator());
+    }
+
+    [Fact]
+    public void Generate_ReturnsValidAsyncApiVersion()
+    {
+        var doc = CreateGenerator().Generate();
+        doc.Asyncapi.Should().Be("3.1.0");
+    }
+
+    [Fact]
+    public void Generate_PopulatesInfoFromOptions()
+    {
+        var doc = CreateGenerator(o =>
+        {
+            o.Title = "My Hub API";
+            o.Version = "2.0.0";
+            o.Description = "Test description";
+        }).Generate();
+
+        doc.Info.Title.Should().Be("My Hub API");
+        doc.Info.Version.Should().Be("2.0.0");
+        doc.Info.Description.Should().Be("Test description");
+    }
+
+    [Fact]
+    public void Generate_CreatesChannelForFakeHub()
+    {
+        var doc = CreateGenerator().Generate();
+
+        doc.Channels.Should().NotBeNull();
+        doc.Channels.Should().ContainKey("Fake");
+        doc.Channels!["Fake"].Address.Should().Be("/hubs/fake");
+    }
+
+    [Fact]
+    public void Generate_CreatesOperationForClientToServerMethod()
+    {
+        var doc = CreateGenerator().Generate();
+
+        doc.Operations.Should().NotBeNull();
+        doc.Operations.Should().ContainKey("Fake.sendMessage");
+        doc.Operations!["Fake.sendMessage"].Action.Should().Be("receive");
+        doc.Operations["Fake.sendMessage"].Channel.Ref.Should().Be("#/channels/Fake");
+    }
+
+    [Fact]
+    public void Generate_CreatesOperationForServerToClientMethod()
+    {
+        var doc = CreateGenerator().Generate();
+
+        doc.Operations.Should().ContainKey("Fake.onMessage");
+        doc.Operations!["Fake.onMessage"].Action.Should().Be("send");
+    }
+
+    [Fact]
+    public void Generate_OperationWithNoPayload_HasNoPayloadInMessage()
+    {
+        var doc = CreateGenerator().Generate();
+
+        var messageKey = "Fake.onReady.Message";
+        doc.Components!.Messages.Should().ContainKey(messageKey);
+        doc.Components.Messages![messageKey].Payload.Should().BeNull();
+    }
+
+    [Fact]
+    public void Generate_OperationWithSingleParam_HasPayload()
+    {
+        var doc = CreateGenerator().Generate();
+
+        var messageKey = "Fake.onMessage.Message";
+        doc.Components!.Messages.Should().ContainKey(messageKey);
+        doc.Components.Messages![messageKey].Payload.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Generate_MessageReferencesAreConsistent()
+    {
+        var doc = CreateGenerator().Generate();
+
+        var messageKey = "Fake.sendMessage.Message";
+        var opRef = doc.Operations!["Fake.sendMessage"].Messages!.Single().Ref;
+        opRef.Should().Be($"#/components/messages/{messageKey}");
+
+        var channelRef = doc.Channels!["Fake"].Messages![messageKey].Ref;
+        channelRef.Should().Be($"#/components/messages/{messageKey}");
+
+        doc.Components!.Messages.Should().ContainKey(messageKey);
+    }
+
+    [Fact]
+    public void Generate_WithServerHost_IncludesServersSection()
+    {
+        var doc = CreateGenerator(o => o.ServerHost = "wss://api.example.com").Generate();
+
+        doc.Servers.Should().NotBeNull();
+        doc.Servers!.Should().ContainKey("default");
+        doc.Servers!["default"].Host.Should().Be("wss://api.example.com");
+        doc.Servers["default"].Protocol.Should().Be("wss");
+    }
+
+    [Fact]
+    public void Generate_WithoutServerHost_OmitsServersSection()
+    {
+        var doc = CreateGenerator().Generate();
+        doc.Servers.Should().BeNull();
+    }
+
+    [Fact]
+    public void Generate_ReturnsCachedDocumentOnSubsequentCalls()
+    {
+        var generator = CreateGenerator();
+        var first = generator.Generate();
+        var second = generator.Generate();
+
+        first.Should().BeSameAs(second);
+    }
+
+    [Fact]
+    public void Generate_ComplexPayloadType_RegistersSchema()
+    {
+        var doc = CreateGenerator().Generate();
+
+        // FakeHub has JoinRoom(string roomId, int userId) — multi-param creates a Parameters schema
+        doc.Components!.Schemas!.Should().ContainKey("Fake.joinRoom.Parameters");
+    }
+}

--- a/tests/Harmonie.API.Tests/SignalRDoc/HubDiscoveryTests.cs
+++ b/tests/Harmonie.API.Tests/SignalRDoc/HubDiscoveryTests.cs
@@ -1,0 +1,134 @@
+using FluentAssertions;
+using Harmonie.API.SignalRDoc.Generator;
+using Microsoft.AspNetCore.SignalR;
+using Xunit;
+
+namespace Harmonie.API.Tests.SignalRDoc;
+
+// Fake types used as test fixtures
+public interface IFakeClient
+{
+    Task OnMessage(string message, CancellationToken ct = default);
+    Task OnReady(CancellationToken ct = default);
+    Task OnMulti(string a, int b, CancellationToken ct = default);
+}
+
+public sealed class FakeHub : Hub<IFakeClient>
+{
+    public async Task SendMessage(string content) { await Task.CompletedTask; }
+    public async Task JoinRoom(string roomId, int userId) { await Task.CompletedTask; }
+    public override Task OnConnectedAsync() => base.OnConnectedAsync();
+    public override Task OnDisconnectedAsync(Exception? exception) => base.OnDisconnectedAsync(exception);
+}
+
+public abstract class AbstractHub : Hub<IFakeClient> { }
+
+public sealed class HubDiscoveryTests
+{
+    private readonly HubDiscovery _discovery = new();
+
+    [Fact]
+    public void Discover_FindsConcreteTypedHub()
+    {
+        var result = _discovery.Discover(new[] { typeof(FakeHub).Assembly });
+
+        result.Should().Contain(h => h.HubType == typeof(FakeHub));
+    }
+
+    [Fact]
+    public void Discover_IgnoresAbstractHubs()
+    {
+        var result = _discovery.Discover(new[] { typeof(FakeHub).Assembly });
+
+        result.Should().NotContain(h => h.HubType == typeof(AbstractHub));
+    }
+
+    [Fact]
+    public void Discover_ExtractsClientInterface()
+    {
+        var result = _discovery.Discover(new[] { typeof(FakeHub).Assembly });
+        var hub = result.Single(h => h.HubType == typeof(FakeHub));
+
+        hub.ClientInterface.Should().Be(typeof(IFakeClient));
+    }
+
+    [Fact]
+    public void Discover_ExcludesLifecycleMethods()
+    {
+        var result = _discovery.Discover(new[] { typeof(FakeHub).Assembly });
+        var hub = result.Single(h => h.HubType == typeof(FakeHub));
+
+        hub.ClientToServerMethods.Should().NotContain(m => m.Name == "OnConnectedAsync");
+        hub.ClientToServerMethods.Should().NotContain(m => m.Name == "OnDisconnectedAsync");
+        hub.ClientToServerMethods.Should().NotContain(m => m.Name == "Dispose");
+    }
+
+    [Fact]
+    public void Discover_ExtractsClientToServerMethods()
+    {
+        var result = _discovery.Discover(new[] { typeof(FakeHub).Assembly });
+        var hub = result.Single(h => h.HubType == typeof(FakeHub));
+
+        hub.ClientToServerMethods.Should().Contain(m => m.Name == "SendMessage");
+        hub.ClientToServerMethods.Should().Contain(m => m.Name == "JoinRoom");
+    }
+
+    [Fact]
+    public void Discover_ExtractsServerToClientMethods()
+    {
+        var result = _discovery.Discover(new[] { typeof(FakeHub).Assembly });
+        var hub = result.Single(h => h.HubType == typeof(FakeHub));
+
+        hub.ServerToClientMethods.Should().Contain(m => m.Name == "OnMessage");
+        hub.ServerToClientMethods.Should().Contain(m => m.Name == "OnReady");
+    }
+
+    [Fact]
+    public void Discover_ExcludesCancellationTokenParameters()
+    {
+        var result = _discovery.Discover(new[] { typeof(FakeHub).Assembly });
+        var hub = result.Single(h => h.HubType == typeof(FakeHub));
+
+        var onMessage = hub.ServerToClientMethods.Single(m => m.Name == "OnMessage");
+        onMessage.Parameters.Should().NotContain(p => p.Type == typeof(CancellationToken));
+        onMessage.Parameters.Should().ContainSingle(p => p.Type == typeof(string));
+
+        var onReady = hub.ServerToClientMethods.Single(m => m.Name == "OnReady");
+        onReady.Parameters.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Discover_ExtractsMultipleParameters()
+    {
+        var result = _discovery.Discover(new[] { typeof(FakeHub).Assembly });
+        var hub = result.Single(h => h.HubType == typeof(FakeHub));
+
+        var joinRoom = hub.ClientToServerMethods.Single(m => m.Name == "JoinRoom");
+        joinRoom.Parameters.Should().HaveCount(2);
+        joinRoom.Parameters[0].Type.Should().Be(typeof(string));
+        joinRoom.Parameters[1].Type.Should().Be(typeof(int));
+    }
+
+    [Fact]
+    public void Discover_DerivesRouteFromHubName()
+    {
+        var result = _discovery.Discover(new[] { typeof(FakeHub).Assembly });
+        var hub = result.Single(h => h.HubType == typeof(FakeHub));
+
+        hub.Route.Should().Be("/hubs/fake");
+    }
+
+    [Fact]
+    public void Discover_UsesRouteOverrideWhenProvided()
+    {
+        var overrides = new Dictionary<Type, string>
+        {
+            [typeof(FakeHub)] = "/custom/route",
+        };
+
+        var result = _discovery.Discover(new[] { typeof(FakeHub).Assembly }, overrides);
+        var hub = result.Single(h => h.HubType == typeof(FakeHub));
+
+        hub.Route.Should().Be("/custom/route");
+    }
+}

--- a/tests/Harmonie.API.Tests/SignalRDoc/SchemaGeneratorTests.cs
+++ b/tests/Harmonie.API.Tests/SignalRDoc/SchemaGeneratorTests.cs
@@ -1,0 +1,209 @@
+using FluentAssertions;
+using Harmonie.API.SignalRDoc.Generator;
+using Harmonie.API.SignalRDoc.Models;
+using Xunit;
+
+namespace Harmonie.API.Tests.SignalRDoc;
+
+public enum FakeColor { Red, Green, Blue }
+
+public sealed class FakePayload
+{
+    public string Name { get; set; } = "";
+    public int Count { get; set; }
+    public Guid Id { get; set; }
+}
+
+public sealed class FakeRecursive
+{
+    public string Label { get; set; } = "";
+    public FakeRecursive? Child { get; set; }
+}
+
+public sealed class SchemaGeneratorTests
+{
+    private readonly SchemaGenerator _generator = new();
+
+    private AsyncApiSchema? Get(Type type) => _generator.GetSchema(type, new Dictionary<string, AsyncApiSchema>());
+
+    [Fact]
+    public void GetSchema_String_ReturnsStringType()
+    {
+        var schema = Get(typeof(string));
+        schema.Should().NotBeNull();
+        schema!.Type.Should().Be("string");
+    }
+
+    [Fact]
+    public void GetSchema_Bool_ReturnsBooleanType()
+    {
+        var schema = Get(typeof(bool));
+        schema!.Type.Should().Be("boolean");
+    }
+
+    [Fact]
+    public void GetSchema_Int_ReturnsIntegerType()
+    {
+        var schema = Get(typeof(int));
+        schema!.Type.Should().Be("integer");
+    }
+
+    [Fact]
+    public void GetSchema_Long_ReturnsIntegerType()
+    {
+        var schema = Get(typeof(long));
+        schema!.Type.Should().Be("integer");
+    }
+
+    [Fact]
+    public void GetSchema_Double_ReturnsNumberType()
+    {
+        var schema = Get(typeof(double));
+        schema!.Type.Should().Be("number");
+    }
+
+    [Fact]
+    public void GetSchema_Decimal_ReturnsNumberType()
+    {
+        var schema = Get(typeof(decimal));
+        schema!.Type.Should().Be("number");
+    }
+
+    [Fact]
+    public void GetSchema_Guid_ReturnsStringWithUuidFormat()
+    {
+        var schema = Get(typeof(Guid));
+        schema!.Type.Should().Be("string");
+        schema.Format.Should().Be("uuid");
+    }
+
+    [Fact]
+    public void GetSchema_DateTime_ReturnsStringWithDateTimeFormat()
+    {
+        var schema = Get(typeof(DateTime));
+        schema!.Type.Should().Be("string");
+        schema.Format.Should().Be("date-time");
+    }
+
+    [Fact]
+    public void GetSchema_DateTimeOffset_ReturnsStringWithDateTimeFormat()
+    {
+        var schema = Get(typeof(DateTimeOffset));
+        schema!.Type.Should().Be("string");
+        schema.Format.Should().Be("date-time");
+    }
+
+    [Fact]
+    public void GetSchema_Enum_ReturnsStringWithEnumValues()
+    {
+        var schema = Get(typeof(FakeColor));
+        schema!.Type.Should().Be("string");
+        schema.Enum.Should().BeEquivalentTo(new[] { "Red", "Green", "Blue" });
+    }
+
+    [Fact]
+    public void GetSchema_Array_ReturnsArrayTypeWithItems()
+    {
+        var schema = Get(typeof(string[]));
+        schema!.Type.Should().Be("array");
+        schema.Items.Should().NotBeNull();
+        schema.Items!.Type.Should().Be("string");
+    }
+
+    [Fact]
+    public void GetSchema_ListOfGuid_ReturnsArrayTypeWithUuidItems()
+    {
+        var schema = Get(typeof(List<Guid>));
+        schema!.Type.Should().Be("array");
+        schema.Items!.Type.Should().Be("string");
+        schema.Items.Format.Should().Be("uuid");
+    }
+
+    [Fact]
+    public void GetSchema_NullableInt_ReturnsIntegerWithNullable()
+    {
+        var schema = Get(typeof(int?));
+        schema!.Type.Should().Be("integer");
+        schema.Nullable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetSchema_NullableGuid_ReturnsUuidWithNullable()
+    {
+        var schema = Get(typeof(Guid?));
+        schema!.Type.Should().Be("string");
+        schema.Format.Should().Be("uuid");
+        schema.Nullable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetSchema_Void_ReturnsNull()
+    {
+        var schema = Get(typeof(void));
+        schema.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetSchema_Task_ReturnsNull()
+    {
+        var schema = Get(typeof(Task));
+        schema.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetSchema_TaskOfString_UnwrapsToString()
+    {
+        var schema = Get(typeof(Task<string>));
+        schema!.Type.Should().Be("string");
+    }
+
+    [Fact]
+    public void GetSchema_ValueTaskOfInt_UnwrapsToInteger()
+    {
+        var schema = Get(typeof(ValueTask<int>));
+        schema!.Type.Should().Be("integer");
+    }
+
+    [Fact]
+    public void GetSchema_ComplexObject_ReturnsRefAndRegistersSchema()
+    {
+        var schemas = new Dictionary<string, AsyncApiSchema>();
+        var schema = _generator.GetSchema(typeof(FakePayload), schemas);
+
+        schema!.Ref.Should().Be("#/components/schemas/FakePayload");
+        schemas.Should().ContainKey("FakePayload");
+        schemas["FakePayload"].Type.Should().Be("object");
+        schemas["FakePayload"].Properties.Should().ContainKey("name");
+        schemas["FakePayload"].Properties.Should().ContainKey("count");
+        schemas["FakePayload"].Properties.Should().ContainKey("id");
+    }
+
+    [Fact]
+    public void GetSchema_ComplexObjectCalledTwice_ReturnsSameRef()
+    {
+        var schemas = new Dictionary<string, AsyncApiSchema>();
+
+        var schema1 = _generator.GetSchema(typeof(FakePayload), schemas);
+        var schema2 = _generator.GetSchema(typeof(FakePayload), schemas);
+
+        schema1!.Ref.Should().Be(schema2!.Ref);
+        schemas.Should().ContainKey("FakePayload");
+    }
+
+    [Fact]
+    public void GetSchema_CircularReference_DoesNotStackOverflow()
+    {
+        var schemas = new Dictionary<string, AsyncApiSchema>();
+        var schema = _generator.GetSchema(typeof(FakeRecursive), schemas);
+
+        schema!.Ref.Should().Be("#/components/schemas/FakeRecursive");
+        schemas.Should().ContainKey("FakeRecursive");
+
+        // The child property references itself without infinite recursion.
+        // Note: reference-type nullability (FakeRecursive?) is erased at runtime,
+        // so nullable is not set on reference-type properties.
+        var childSchema = schemas["FakeRecursive"].Properties?.GetValueOrDefault("child");
+        childSchema.Should().NotBeNull();
+        childSchema!.Ref.Should().Be("#/components/schemas/FakeRecursive");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a zero-dependency, reflection-based AsyncAPI 3.1 generator in `src/Harmonie.API/SignalRDoc/`
- `HubDiscovery` scans assemblies for `Hub<T>` types and extracts client→server (hub methods) and server→client (interface methods) descriptors, with route derivation from hub name
- `SchemaGenerator` converts C# types to JSON Schema (primitives, enums, arrays, nullable, complex objects, circular-reference guard)
- `AsyncApiGenerator` assembles the `AsyncApiDocument` (lazy singleton, cached after first call)
- `GET /asyncapi/v1.json` serves the AsyncAPI 3.1 document; `GET /asyncapi/ui` serves a standalone dark-mode HTML viewer — both exposed dev-only
- Wire-up via `AddSignalRAsyncApiDoc()` in `RealTimeConfiguration` and `MapSignalRAsyncApiDoc()` in `Program.cs`

## Test plan

- [ ] `dotnet test` — all suites green (43 new unit tests in `Harmonie.API.Tests`, 4 new integration tests in `Harmonie.API.IntegrationTests`)
- [ ] `GET /asyncapi/v1.json` returns 200 with valid AsyncAPI 3.1.0 JSON containing the `Realtime` channel
- [ ] `GET /asyncapi/ui` returns 200 HTML with the dark-mode viewer
- [ ] Both endpoints return 404 outside Development environment
- [ ] Zero new NuGet dependencies

Closes #321