### PR TITLE
feat(logging): add TraceId middleware for request correlation (#326)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,15 +6,15 @@
 
   <!-- Database -->
   <ItemGroup>
-    <PackageVersion Include="Dapper" Version="2.1.66" />
-    <PackageVersion Include="Npgsql" Version="10.0.0" />
+    <PackageVersion Include="Dapper" Version="2.1.72" />
+    <PackageVersion Include="Npgsql" Version="10.0.2" />
     <PackageVersion Include="dbup-postgresql" Version="6.1.5" />
   </ItemGroup>
 
   <!-- Auth / JWT -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.6" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
   </ItemGroup>
 
   <!-- Validation -->
@@ -25,8 +25,8 @@
 
   <!-- API / Docs -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.12.40" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.14.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
   </ItemGroup>
 
@@ -37,14 +37,14 @@
 
   <!-- External services -->
   <ItemGroup>
-    <PackageVersion Include="Livekit.Server.Sdk.Dotnet" Version="1.2.0" />
+    <PackageVersion Include="Livekit.Server.Sdk.Dotnet" Version="1.2.1" />
   </ItemGroup>
 
   <!-- Configuration -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.0" />
   </ItemGroup>
 
@@ -52,10 +52,10 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="FluentAssertions" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.6" />
     <PackageVersion Include="Moq" Version="4.20.72" />
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,7 +53,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="FluentAssertions" Version="7.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.9.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.6" />
     <PackageVersion Include="Moq" Version="4.20.72" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,62 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <!-- Database -->
+  <ItemGroup>
+    <PackageVersion Include="Dapper" Version="2.1.66" />
+    <PackageVersion Include="Npgsql" Version="10.0.0" />
+    <PackageVersion Include="dbup-postgresql" Version="6.1.5" />
+  </ItemGroup>
+
+  <!-- Auth / JWT -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
+  </ItemGroup>
+
+  <!-- Validation -->
+  <ItemGroup>
+    <PackageVersion Include="FluentValidation" Version="11.11.0" />
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
+  </ItemGroup>
+
+  <!-- API / Docs -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.12.40" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
+  </ItemGroup>
+
+  <!-- Image processing -->
+  <ItemGroup>
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
+  </ItemGroup>
+
+  <!-- External services -->
+  <ItemGroup>
+    <PackageVersion Include="Livekit.Server.Sdk.Dotnet" Version="1.2.0" />
+  </ItemGroup>
+
+  <!-- Configuration -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.0" />
+  </ItemGroup>
+
+  <!-- Testing -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+  </ItemGroup>
+
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageVersion Include="Dapper" Version="2.1.72" />
     <PackageVersion Include="Npgsql" Version="10.0.2" />
-    <PackageVersion Include="dbup-postgresql" Version="6.1.5" />
+    <PackageVersion Include="dbup-postgresql" Version="7.0.1" />
   </ItemGroup>
 
   <!-- Auth / JWT -->
@@ -19,8 +19,8 @@
 
   <!-- Validation -->
   <ItemGroup>
-    <PackageVersion Include="FluentValidation" Version="11.11.0" />
-    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
+    <PackageVersion Include="FluentValidation" Version="12.1.1" />
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
   </ItemGroup>
 
   <!-- API / Docs -->
@@ -50,7 +50,7 @@
 
   <!-- Testing -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="FluentAssertions" Version="7.0.0" />

--- a/src/Harmonie.API/Harmonie.API.csproj
+++ b/src/Harmonie.API/Harmonie.API.csproj
@@ -18,9 +18,9 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
-<PackageReference Include="Scalar.AspNetCore" Version="2.12.40" />
-    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+<PackageReference Include="Scalar.AspNetCore" />
+    <PackageReference Include="Serilog.AspNetCore" />
   </ItemGroup>
 </Project>

--- a/src/Harmonie.API/Middleware/TraceIdMiddleware.cs
+++ b/src/Harmonie.API/Middleware/TraceIdMiddleware.cs
@@ -5,7 +5,6 @@ namespace Harmonie.API.Middleware;
 
 public sealed class TraceIdMiddleware
 {
-    private const string TraceParentHeaderName = "traceparent";
     private const string TraceIdItemKey = "TraceId";
     private const string ResponseHeaderName = "X-Trace-Id";
     private readonly RequestDelegate _next;
@@ -17,17 +16,8 @@ public sealed class TraceIdMiddleware
 
     public async Task InvokeAsync(HttpContext context)
     {
-        string traceId;
-
-        var traceParent = context.Request.Headers[TraceParentHeaderName].FirstOrDefault();
-        if (!string.IsNullOrWhiteSpace(traceParent) && TryParseTraceParent(traceParent, out var parsedTraceId))
-        {
-            traceId = parsedTraceId;
-        }
-        else
-        {
-            traceId = ActivityTraceId.CreateRandom().ToHexString();
-        }
+        var traceId = Activity.Current?.TraceId.ToHexString()
+                      ?? ActivityTraceId.CreateRandom().ToHexString();
 
         using (LogContext.PushProperty("TraceId", traceId))
         {
@@ -35,40 +25,5 @@ public sealed class TraceIdMiddleware
             context.Response.Headers[ResponseHeaderName] = traceId;
             await _next(context);
         }
-    }
-
-    private static bool TryParseTraceParent(string traceParent, out string traceId)
-    {
-        // W3C traceparent format: "00-traceId-spanId-flags"
-        var parts = traceParent.Split('-', StringSplitOptions.RemoveEmptyEntries);
-        if (parts.Length != 4)
-        {
-            traceId = default!;
-            return false;
-        }
-
-        traceId = parts[1].ToLowerInvariant();
-        return IsValidTraceId(traceId);
-    }
-
-    private static bool IsValidTraceId(string traceId)
-    {
-        if (traceId.Length != 32)
-            return false;
-
-        foreach (char c in traceId)
-        {
-            if (!IsHex(c))
-                return false;
-        }
-
-        return true;
-    }
-
-    private static bool IsHex(char c)
-    {
-        return (c >= '0' && c <= '9')
-            || (c >= 'a' && c <= 'f')
-            || (c >= 'A' && c <= 'F');
     }
 }

--- a/src/Harmonie.API/Middleware/TraceIdMiddleware.cs
+++ b/src/Harmonie.API/Middleware/TraceIdMiddleware.cs
@@ -1,0 +1,79 @@
+using System.Diagnostics;
+using Serilog.Context;
+
+namespace Harmonie.API.Middleware;
+
+/// <summary>
+/// Middleware that establishes a TraceId for every request.
+/// Reads the W3C traceparent header if present, otherwise generates a new TraceId.
+/// Pushes the TraceId into LogContext so Serilog automatically includes it in all log entries.
+/// </summary>
+public sealed class TraceIdMiddleware
+{
+    private const string TraceParentHeaderName = "traceparent";
+    private const string TraceIdItemKey = "TraceId";
+    private const string ResponseHeaderName = "X-Trace-Id";
+    private readonly RequestDelegate _next;
+
+    public TraceIdMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        string traceId;
+
+        var traceParent = context.Request.Headers[TraceParentHeaderName].FirstOrDefault();
+        if (!string.IsNullOrWhiteSpace(traceParent) && TryParseTraceParent(traceParent, out var parsedTraceId))
+        {
+            traceId = parsedTraceId;
+        }
+        else
+        {
+            traceId = ActivityTraceId.CreateRandom().ToHexString();
+        }
+
+        using (LogContext.PushProperty("TraceId", traceId))
+        {
+            context.Items[TraceIdItemKey] = traceId;
+            context.Response.Headers[ResponseHeaderName] = traceId;
+            await _next(context);
+        }
+    }
+
+    private static bool TryParseTraceParent(string traceParent, out string traceId)
+    {
+        // W3C traceparent format: "00-traceId-spanId-flags"
+        var parts = traceParent.Split('-', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length < 2)
+        {
+            traceId = default!;
+            return false;
+        }
+
+        traceId = parts[1];
+        return IsValidTraceId(traceId);
+    }
+
+    private static bool IsValidTraceId(string traceId)
+    {
+        if (traceId.Length != 32)
+            return false;
+
+        foreach (char c in traceId)
+        {
+            if (!IsHex(c))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsHex(char c)
+    {
+        return (c >= '0' && c <= '9')
+            || (c >= 'a' && c <= 'f')
+            || (c >= 'A' && c <= 'F');
+    }
+}

--- a/src/Harmonie.API/Middleware/TraceIdMiddleware.cs
+++ b/src/Harmonie.API/Middleware/TraceIdMiddleware.cs
@@ -3,11 +3,6 @@ using Serilog.Context;
 
 namespace Harmonie.API.Middleware;
 
-/// <summary>
-/// Middleware that establishes a TraceId for every request.
-/// Reads the W3C traceparent header if present, otherwise generates a new TraceId.
-/// Pushes the TraceId into LogContext so Serilog automatically includes it in all log entries.
-/// </summary>
 public sealed class TraceIdMiddleware
 {
     private const string TraceParentHeaderName = "traceparent";
@@ -46,13 +41,13 @@ public sealed class TraceIdMiddleware
     {
         // W3C traceparent format: "00-traceId-spanId-flags"
         var parts = traceParent.Split('-', StringSplitOptions.RemoveEmptyEntries);
-        if (parts.Length < 2)
+        if (parts.Length != 4)
         {
             traceId = default!;
             return false;
         }
 
-        traceId = parts[1];
+        traceId = parts[1].ToLowerInvariant();
         return IsValidTraceId(traceId);
     }
 

--- a/src/Harmonie.API/Program.cs
+++ b/src/Harmonie.API/Program.cs
@@ -48,6 +48,7 @@ if (app.Environment.IsDevelopment())
     app.MapSignalRAsyncApiDoc();
 }
 
+app.UseMiddleware<TraceIdMiddleware>();
 app.UseMiddleware<GlobalExceptionHandler>();
 app.UseSerilogRequestLogging();
 app.UseHttpsRedirection();

--- a/src/Harmonie.Application/Common/EndpointExtensions.cs
+++ b/src/Harmonie.Application/Common/EndpointExtensions.cs
@@ -181,10 +181,11 @@ public static class EndpointExtensions
                     {
                         Summary = code,
                         Value = ToOpenApiJsonNode(
-                            EnrichError(
-                                new ApplicationError(code, BuildExampleDetail(code), errors) with { TraceId = "trace-id" },
-                                status,
-                                httpContext: null))
+                            new ApplicationError(code, BuildExampleDetail(code), errors) with
+                            {
+                                Status = status,
+                                TraceId = "trace-id"
+                            })
                     };
                 }
             }

--- a/src/Harmonie.Application/Common/EndpointExtensions.cs
+++ b/src/Harmonie.Application/Common/EndpointExtensions.cs
@@ -2,7 +2,6 @@ using FluentValidation;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.OpenApi;
-using System.Diagnostics;
 using System.Net;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -50,7 +49,7 @@ public static class EndpointExtensions
     /// <summary>
     /// Convert an application response to a standardized HTTP response.
     /// </summary>
-    public static IResult ToHttpResult<T>(this ApplicationResponse<T> response)
+    public static IResult ToHttpResult<T>(this ApplicationResponse<T> response, HttpContext? httpContext = null)
     {
         if (response.Success)
         {
@@ -64,7 +63,7 @@ public static class EndpointExtensions
                     EnrichError(
                         failurePayload,
                         StatusCodes.Status500InternalServerError,
-                        Activity.Current?.Id),
+                        httpContext),
                     statusCode: StatusCodes.Status500InternalServerError);
             }
 
@@ -77,7 +76,7 @@ public static class EndpointExtensions
 
         var statusCode = (int)MapStatusCode(error.Code);
         return Results.Json(
-            EnrichError(error, statusCode, Activity.Current?.Id),
+            EnrichError(error, statusCode, httpContext),
             statusCode: statusCode);
     }
 
@@ -86,10 +85,11 @@ public static class EndpointExtensions
     /// </summary>
     public static IResult ToCreatedHttpResult<T>(
         this ApplicationResponse<T> response,
-        Func<T, string> locationFactory)
+        Func<T, string> locationFactory,
+        HttpContext? httpContext = null)
     {
         if (!response.Success)
-            return response.ToHttpResult();
+            return response.ToHttpResult(httpContext);
 
         if (response.Data is null)
         {
@@ -101,7 +101,7 @@ public static class EndpointExtensions
                 EnrichError(
                     payload,
                     StatusCodes.Status500InternalServerError,
-                    Activity.Current?.Id),
+                    httpContext),
                 statusCode: StatusCodes.Status500InternalServerError);
         }
 
@@ -116,7 +116,7 @@ public static class EndpointExtensions
         var statusCode = (int)MapStatusCode(error.Code);
         response.StatusCode = statusCode;
         return response.WriteAsJsonAsync(
-            EnrichError(error, statusCode, response.HttpContext.TraceIdentifier));
+            EnrichError(error, statusCode, response.HttpContext));
     }
 
     public static IReadOnlyDictionary<string, ApplicationValidationError[]> SingleValidationError(
@@ -182,9 +182,9 @@ public static class EndpointExtensions
                         Summary = code,
                         Value = ToOpenApiJsonNode(
                             EnrichError(
-                                new ApplicationError(code, BuildExampleDetail(code), errors),
+                                new ApplicationError(code, BuildExampleDetail(code), errors) with { TraceId = "trace-id" },
                                 status,
-                                "trace-id"))
+                                httpContext: null))
                     };
                 }
             }
@@ -262,11 +262,11 @@ public static class EndpointExtensions
     private static ApplicationError EnrichError(
         ApplicationError error,
         int status,
-        string? traceId)
+        HttpContext? httpContext)
         => error with
         {
             Status = status,
-            TraceId = string.IsNullOrWhiteSpace(traceId) ? error.TraceId : traceId
+            TraceId = (httpContext?.Items["TraceId"] as string) ?? error.TraceId
         };
 
     private static JsonNode? ToOpenApiJsonNode(object? value)

--- a/src/Harmonie.Application/Common/EndpointExtensions.cs
+++ b/src/Harmonie.Application/Common/EndpointExtensions.cs
@@ -181,11 +181,7 @@ public static class EndpointExtensions
                     {
                         Summary = code,
                         Value = ToOpenApiJsonNode(
-                            new ApplicationError(code, BuildExampleDetail(code), errors) with
-                            {
-                                Status = status,
-                                TraceId = "trace-id"
-                            })
+                            new ApplicationError(code, BuildExampleDetail(code), errors, status, "trace-id"))
                     };
                 }
             }

--- a/src/Harmonie.Application/Common/EndpointExtensions.cs
+++ b/src/Harmonie.Application/Common/EndpointExtensions.cs
@@ -49,7 +49,7 @@ public static class EndpointExtensions
     /// <summary>
     /// Convert an application response to a standardized HTTP response.
     /// </summary>
-    public static IResult ToHttpResult<T>(this ApplicationResponse<T> response, HttpContext? httpContext = null)
+    public static IResult ToHttpResult<T>(this ApplicationResponse<T> response, HttpContext httpContext)
     {
         if (response.Success)
         {
@@ -86,7 +86,7 @@ public static class EndpointExtensions
     public static IResult ToCreatedHttpResult<T>(
         this ApplicationResponse<T> response,
         Func<T, string> locationFactory,
-        HttpContext? httpContext = null)
+        HttpContext httpContext)
     {
         if (!response.Success)
             return response.ToHttpResult(httpContext);

--- a/src/Harmonie.Application/Features/Auth/Login/LoginEndpoint.cs
+++ b/src/Harmonie.Application/Features/Auth/Login/LoginEndpoint.cs
@@ -34,16 +34,15 @@ public static class LoginEndpoint
         [FromBody] LoginRequest request,
         [FromServices] IHandler<LoginRequest, LoginResponse> handler,
         [FromServices] IValidator<LoginRequest> validator,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        // Validate request
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<LoginResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<LoginResponse>.Fail(validationError).ToHttpResult(httpContext);
 
-        // Handle login
         var response = await handler.HandleAsync(request, cancellationToken);
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Auth/Logout/LogoutEndpoint.cs
+++ b/src/Harmonie.Application/Features/Auth/Logout/LogoutEndpoint.cs
@@ -36,13 +36,13 @@ public static class LogoutEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<LogoutResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<LogoutResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(request, currentUserId, cancellationToken);
         if (!response.Success)
-            return response.ToHttpResult();
+            return response.ToHttpResult(httpContext);
 
         return Results.NoContent();
     }

--- a/src/Harmonie.Application/Features/Auth/LogoutAll/LogoutAllEndpoint.cs
+++ b/src/Harmonie.Application/Features/Auth/LogoutAll/LogoutAllEndpoint.cs
@@ -33,7 +33,7 @@ public static class LogoutAllEndpoint
 
         var response = await handler.HandleAsync(Unit.Value, currentUserId, cancellationToken);
         if (!response.Success)
-            return response.ToHttpResult();
+            return response.ToHttpResult(httpContext);
 
         return Results.NoContent();
     }

--- a/src/Harmonie.Application/Features/Auth/RefreshToken/RefreshTokenEndpoint.cs
+++ b/src/Harmonie.Application/Features/Auth/RefreshToken/RefreshTokenEndpoint.cs
@@ -31,13 +31,14 @@ public static class RefreshTokenEndpoint
         [FromBody] RefreshTokenRequest request,
         [FromServices] IHandler<RefreshTokenRequest, RefreshTokenResponse> handler,
         [FromServices] IValidator<RefreshTokenRequest> validator,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<RefreshTokenResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<RefreshTokenResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var response = await handler.HandleAsync(request, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Auth/Register/RegisterEndpoint.cs
+++ b/src/Harmonie.Application/Features/Auth/Register/RegisterEndpoint.cs
@@ -32,17 +32,15 @@ public static class RegisterEndpoint
         [FromBody] RegisterRequest request,
         [FromServices] IHandler<RegisterRequest, RegisterResponse> handler,
         [FromServices] IValidator<RegisterRequest> validator,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        // Validate request
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<RegisterResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<RegisterResponse>.Fail(validationError).ToHttpResult(httpContext);
 
-        // Handle registration
         var response = await handler.HandleAsync(request, cancellationToken);
 
-        // Return created response
-        return response.ToCreatedHttpResult(data => $"/api/users/{data.UserId}");
+        return response.ToCreatedHttpResult(data => $"/api/users/{data.UserId}", httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/AcknowledgeRead/AcknowledgeReadEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/AcknowledgeRead/AcknowledgeReadEndpoint.cs
@@ -39,7 +39,7 @@ public static class AcknowledgeReadEndpoint
     {
         var bodyValidationError = await request.ValidateAsync(bodyValidator, cancellationToken);
         if (bodyValidationError is not null)
-            return ApplicationResponse<bool>.Fail(bodyValidationError).ToHttpResult();
+            return ApplicationResponse<bool>.Fail(bodyValidationError).ToHttpResult(httpContext);
 
         var parsedMessageId = request.MessageId.HasValue ? MessageId.From(request.MessageId.Value) : null;
 
@@ -50,6 +50,6 @@ public static class AcknowledgeReadEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/AddReaction/AddReactionEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/AddReaction/AddReactionEndpoint.cs
@@ -40,12 +40,12 @@ public static class AddReactionEndpoint
     {
         var routeValidationError = await routeRequest.ValidateAsync(routeValidator, cancellationToken);
         if (routeValidationError is not null)
-            return ApplicationResponse<bool>.Fail(routeValidationError).ToHttpResult();
+            return ApplicationResponse<bool>.Fail(routeValidationError).ToHttpResult(httpContext);
 
         if (routeRequest.Emoji is not string emoji)
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Common.InvalidState,
-                "Route validation succeeded but emoji was null.").ToHttpResult();
+                "Route validation succeeded but emoji was null.").ToHttpResult(httpContext);
 
         var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
@@ -54,6 +54,6 @@ public static class AddReactionEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/DeleteChannel/DeleteChannelEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/DeleteChannel/DeleteChannelEndpoint.cs
@@ -40,6 +40,6 @@ public static class DeleteChannelEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/DeleteMessage/DeleteMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/DeleteMessage/DeleteMessageEndpoint.cs
@@ -44,6 +44,6 @@ public static class DeleteMessageEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/DeleteMessageAttachment/DeleteMessageAttachmentEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/DeleteMessageAttachment/DeleteMessageAttachmentEndpoint.cs
@@ -48,6 +48,6 @@ public static class DeleteMessageAttachmentEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageEndpoint.cs
@@ -45,11 +45,11 @@ public static class EditMessageEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<EditMessageResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<EditMessageResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(new EditChannelMessageInput(channelId, messageId, request.Content), callerId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesEndpoint.cs
@@ -38,11 +38,11 @@ public static class GetMessagesEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<GetMessagesResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<GetMessagesResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(new GetChannelMessagesInput(channelId, request.Before, request.Limit), currentUserId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/JoinVoiceChannel/JoinVoiceChannelEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/JoinVoiceChannel/JoinVoiceChannelEndpoint.cs
@@ -36,6 +36,6 @@ public static class JoinVoiceChannelEndpoint
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(channelId, currentUserId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionEndpoint.cs
@@ -40,12 +40,12 @@ public static class RemoveReactionEndpoint
     {
         var routeValidationError = await routeRequest.ValidateAsync(routeValidator, cancellationToken);
         if (routeValidationError is not null)
-            return ApplicationResponse<bool>.Fail(routeValidationError).ToHttpResult();
+            return ApplicationResponse<bool>.Fail(routeValidationError).ToHttpResult(httpContext);
 
         if (routeRequest.Emoji is not string emoji)
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Common.InvalidState,
-                "Route validation succeeded but emoji was null.").ToHttpResult();
+                "Route validation succeeded but emoji was null.").ToHttpResult(httpContext);
 
         var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
@@ -54,6 +54,6 @@ public static class RemoveReactionEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageEndpoint.cs
@@ -43,11 +43,11 @@ public static class SendMessageEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<SendMessageResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<SendMessageResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(new SendChannelMessageInput(channelId, request.Content, request.AttachmentFileIds), currentUserId, cancellationToken);
-        return response.ToCreatedHttpResult(data => $"/api/channels/{data.ChannelId}/messages/{data.MessageId}");
+        return response.ToCreatedHttpResult(data => $"/api/channels/{data.ChannelId}/messages/{data.MessageId}", httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/UpdateChannel/UpdateChannelEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/UpdateChannel/UpdateChannelEndpoint.cs
@@ -55,11 +55,11 @@ public static class UpdateChannelEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<UpdateChannelResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<UpdateChannelResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(new UpdateChannelInput(channelId, request.Name, request.Position), callerId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/AcknowledgeRead/AcknowledgeReadEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/AcknowledgeRead/AcknowledgeReadEndpoint.cs
@@ -38,7 +38,7 @@ public static class AcknowledgeReadEndpoint
     {
         var bodyValidationError = await request.ValidateAsync(bodyValidator, cancellationToken);
         if (bodyValidationError is not null)
-            return ApplicationResponse<bool>.Fail(bodyValidationError).ToHttpResult();
+            return ApplicationResponse<bool>.Fail(bodyValidationError).ToHttpResult(httpContext);
 
         var parsedMessageId = request.MessageId.HasValue ? MessageId.From(request.MessageId.Value) : null;
 
@@ -49,6 +49,6 @@ public static class AcknowledgeReadEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/AddReaction/AddReactionEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/AddReaction/AddReactionEndpoint.cs
@@ -39,12 +39,12 @@ public static class AddReactionEndpoint
     {
         var routeValidationError = await routeRequest.ValidateAsync(routeValidator, cancellationToken);
         if (routeValidationError is not null)
-            return ApplicationResponse<bool>.Fail(routeValidationError).ToHttpResult();
+            return ApplicationResponse<bool>.Fail(routeValidationError).ToHttpResult(httpContext);
 
         if (routeRequest.Emoji is not string emoji)
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Common.InvalidState,
-                "Route validation succeeded but emoji was null.").ToHttpResult();
+                "Route validation succeeded but emoji was null.").ToHttpResult(httpContext);
 
         var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
@@ -53,6 +53,6 @@ public static class AddReactionEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/CreateGroupConversation/CreateGroupConversationEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/CreateGroupConversation/CreateGroupConversationEndpoint.cs
@@ -34,20 +34,20 @@ public static class CreateGroupConversationEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<CreateGroupConversationResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<CreateGroupConversationResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(request, currentUserId, cancellationToken);
         if (!response.Success)
-            return response.ToHttpResult();
+            return response.ToHttpResult(httpContext);
 
         if (response.Data is null)
         {
             return ApplicationResponse<CreateGroupConversationResponse>.Fail(
                 ApplicationErrorCodes.Common.InvalidState,
                 "Operation succeeded but no payload was returned.")
-                .ToHttpResult();
+                .ToHttpResult(httpContext);
         }
 
         return Results.Created($"/api/conversations/{response.Data.ConversationId}", response.Data);

--- a/src/Harmonie.Application/Features/Conversations/DeleteConversation/DeleteConversationEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteConversation/DeleteConversationEndpoint.cs
@@ -36,6 +36,6 @@ public static class DeleteConversationEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/DeleteMessage/DeleteMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteMessage/DeleteMessageEndpoint.cs
@@ -41,6 +41,6 @@ public static class DeleteMessageEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentEndpoint.cs
@@ -47,6 +47,6 @@ public static class DeleteMessageAttachmentEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageEndpoint.cs
@@ -43,11 +43,11 @@ public static class EditMessageEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<EditMessageResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<EditMessageResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(new EditConversationMessageInput(conversationId, messageId, request.Content), callerId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesEndpoint.cs
@@ -36,11 +36,11 @@ public static class GetMessagesEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<GetMessagesResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<GetMessagesResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(new GetConversationMessagesInput(conversationId, request.Cursor, request.Limit), currentUserId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/ListConversations/ListConversationsEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/ListConversations/ListConversationsEndpoint.cs
@@ -29,6 +29,6 @@ public static class ListConversationsEndpoint
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(Unit.Value, currentUserId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/OpenConversation/OpenConversationEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/OpenConversation/OpenConversationEndpoint.cs
@@ -35,20 +35,20 @@ public static class OpenConversationEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<OpenConversationResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<OpenConversationResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(request, currentUserId, cancellationToken);
         if (!response.Success)
-            return response.ToHttpResult();
+            return response.ToHttpResult(httpContext);
 
         if (response.Data is null)
         {
             return ApplicationResponse<OpenConversationResponse>.Fail(
                 ApplicationErrorCodes.Common.InvalidState,
                 "Operation succeeded but no payload was returned.")
-                .ToHttpResult();
+                .ToHttpResult(httpContext);
         }
 
         return response.Data.Created

--- a/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionEndpoint.cs
@@ -39,12 +39,12 @@ public static class RemoveReactionEndpoint
     {
         var routeValidationError = await routeRequest.ValidateAsync(routeValidator, cancellationToken);
         if (routeValidationError is not null)
-            return ApplicationResponse<bool>.Fail(routeValidationError).ToHttpResult();
+            return ApplicationResponse<bool>.Fail(routeValidationError).ToHttpResult(httpContext);
 
         if (routeRequest.Emoji is not string emoji)
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Common.InvalidState,
-                "Route validation succeeded but emoji was null.").ToHttpResult();
+                "Route validation succeeded but emoji was null.").ToHttpResult(httpContext);
 
         var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
@@ -53,6 +53,6 @@ public static class RemoveReactionEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/SearchConversationMessages/SearchConversationMessagesEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/SearchConversationMessages/SearchConversationMessagesEndpoint.cs
@@ -36,11 +36,11 @@ public static class SearchConversationMessagesEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<SearchConversationMessagesResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<SearchConversationMessagesResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(new SearchConversationMessagesInput(conversationId, request.Q, request.Before, request.After, request.Cursor, request.Limit), currentUserId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageEndpoint.cs
@@ -41,12 +41,12 @@ public static class SendMessageEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<SendMessageResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<SendMessageResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(new SendConversationMessageInput(conversationId, request.Content, request.AttachmentFileIds), currentUserId, cancellationToken);
         return response.ToCreatedHttpResult(
-            data => $"/api/conversations/{data.ConversationId}/messages/{data.MessageId}");
+            data => $"/api/conversations/{data.ConversationId}/messages/{data.MessageId}", httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/AcceptInvite/AcceptInviteEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/AcceptInvite/AcceptInviteEndpoint.cs
@@ -37,11 +37,11 @@ public static class AcceptInviteEndpoint
     {
         var routeValidationError = await routeRequest.ValidateAsync(routeValidator, cancellationToken);
         if (routeValidationError is not null)
-            return ApplicationResponse<AcceptInviteResponse>.Fail(routeValidationError).ToHttpResult();
+            return ApplicationResponse<AcceptInviteResponse>.Fail(routeValidationError).ToHttpResult(httpContext);
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(routeRequest.InviteCode!, currentUserId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/BanMember/BanMemberEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/BanMember/BanMemberEndpoint.cs
@@ -41,7 +41,7 @@ public static class BanMemberEndpoint
     {
         var bodyValidationError = await request.ValidateAsync(bodyValidator, cancellationToken);
         if (bodyValidationError is not null)
-            return ApplicationResponse<BanMemberResponse>.Fail(bodyValidationError).ToHttpResult();
+            return ApplicationResponse<BanMemberResponse>.Fail(bodyValidationError).ToHttpResult(httpContext);
 
         var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
@@ -50,6 +50,6 @@ public static class BanMemberEndpoint
             callerId,
             cancellationToken);
 
-        return response.ToCreatedHttpResult(data => $"/api/guilds/{data.GuildId}/bans");
+        return response.ToCreatedHttpResult(data => $"/api/guilds/{data.GuildId}/bans", httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/CreateChannel/CreateChannelEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/CreateChannel/CreateChannelEndpoint.cs
@@ -38,7 +38,7 @@ public static class CreateChannelEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<CreateChannelResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<CreateChannelResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
@@ -47,6 +47,6 @@ public static class CreateChannelEndpoint
             callerId,
             cancellationToken);
 
-        return response.ToCreatedHttpResult(data => $"/api/guilds/{data.GuildId}/channels/{data.ChannelId}");
+        return response.ToCreatedHttpResult(data => $"/api/guilds/{data.GuildId}/channels/{data.ChannelId}", httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/CreateGuild/CreateGuildEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/CreateGuild/CreateGuildEndpoint.cs
@@ -33,11 +33,11 @@ public static class CreateGuildEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<CreateGuildResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<CreateGuildResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(request, currentUserId, cancellationToken);
-        return response.ToCreatedHttpResult(data => $"/api/guilds/{data.GuildId}");
+        return response.ToCreatedHttpResult(data => $"/api/guilds/{data.GuildId}", httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/CreateGuildInvite/CreateGuildInviteEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/CreateGuildInvite/CreateGuildInviteEndpoint.cs
@@ -37,11 +37,11 @@ public static class CreateGuildInviteEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<CreateGuildInviteResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<CreateGuildInviteResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(new CreateGuildInviteInput(guildId, request.MaxUses, request.ExpiresInHours), currentUserId, cancellationToken);
-        return response.ToCreatedHttpResult(data => $"/api/guilds/{data.GuildId}/invites/{data.InviteId}");
+        return response.ToCreatedHttpResult(data => $"/api/guilds/{data.GuildId}/invites/{data.InviteId}", httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/DeleteGuild/DeleteGuildEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/DeleteGuild/DeleteGuildEndpoint.cs
@@ -37,6 +37,6 @@ public static class DeleteGuildEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/DeleteGuildIcon/DeleteGuildIconEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/DeleteGuildIcon/DeleteGuildIconEndpoint.cs
@@ -38,6 +38,6 @@ public static class DeleteGuildIconEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/GetGuildChannels/GetGuildChannelsEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/GetGuildChannels/GetGuildChannelsEndpoint.cs
@@ -34,6 +34,6 @@ public static class GetGuildChannelsEndpoint
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(guildId, currentUserId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/GetGuildMembers/GetGuildMembersEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/GetGuildMembers/GetGuildMembersEndpoint.cs
@@ -34,6 +34,6 @@ public static class GetGuildMembersEndpoint
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(guildId, currentUserId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/GetGuildVoiceParticipants/GetGuildVoiceParticipantsEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/GetGuildVoiceParticipants/GetGuildVoiceParticipantsEndpoint.cs
@@ -34,6 +34,6 @@ public static class GetGuildVoiceParticipantsEndpoint
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(guildId, currentUserId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/LeaveGuild/LeaveGuildEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/LeaveGuild/LeaveGuildEndpoint.cs
@@ -39,6 +39,6 @@ public static class LeaveGuildEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/ListBans/ListBansEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/ListBans/ListBansEndpoint.cs
@@ -34,6 +34,6 @@ public static class ListBansEndpoint
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(guildId, currentUserId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/ListGuildInvites/ListGuildInvitesEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/ListGuildInvites/ListGuildInvitesEndpoint.cs
@@ -34,6 +34,6 @@ public static class ListGuildInvitesEndpoint
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(guildId, currentUserId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/ListUserGuilds/ListUserGuildsEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/ListUserGuilds/ListUserGuildsEndpoint.cs
@@ -29,6 +29,6 @@ public static class ListUserGuildsEndpoint
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(Unit.Value, currentUserId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/PreviewInvite/PreviewInviteEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/PreviewInvite/PreviewInviteEndpoint.cs
@@ -28,13 +28,14 @@ public static class PreviewInviteEndpoint
         [AsParameters] PreviewInviteRouteRequest routeRequest,
         [FromServices] IHandler<string, PreviewInviteResponse> handler,
         [FromServices] IValidator<PreviewInviteRouteRequest> routeValidator,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
         var routeValidationError = await routeRequest.ValidateAsync(routeValidator, cancellationToken);
         if (routeValidationError is not null)
-            return ApplicationResponse<PreviewInviteResponse>.Fail(routeValidationError).ToHttpResult();
+            return ApplicationResponse<PreviewInviteResponse>.Fail(routeValidationError).ToHttpResult(httpContext);
 
         var response = await handler.HandleAsync(routeRequest.InviteCode!, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/RemoveMember/RemoveMemberEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/RemoveMember/RemoveMemberEndpoint.cs
@@ -42,6 +42,6 @@ public static class RemoveMemberEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/ReorderChannels/ReorderChannelsEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/ReorderChannels/ReorderChannelsEndpoint.cs
@@ -38,11 +38,11 @@ public static class ReorderChannelsEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<ReorderChannelsResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<ReorderChannelsResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(new ReorderChannelsInput(guildId, request.Channels), callerId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/RevokeInvite/RevokeInviteEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/RevokeInvite/RevokeInviteEndpoint.cs
@@ -36,13 +36,13 @@ public static class RevokeInviteEndpoint
     {
         var routeValidationError = await routeRequest.ValidateAsync(routeValidator, cancellationToken);
         if (routeValidationError is not null)
-            return ApplicationResponse<bool>.Fail(routeValidationError).ToHttpResult();
+            return ApplicationResponse<bool>.Fail(routeValidationError).ToHttpResult(httpContext);
 
         if (routeRequest.InviteCode is not string inviteCode)
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Common.InvalidState,
-                "Route validation succeeded but invite code was null.").ToHttpResult();
+                "Route validation succeeded but invite code was null.").ToHttpResult(httpContext);
         }
 
         var callerId = httpContext.GetRequiredAuthenticatedUserId();
@@ -51,6 +51,6 @@ public static class RevokeInviteEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/SearchMessages/SearchMessagesEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/SearchMessages/SearchMessagesEndpoint.cs
@@ -39,7 +39,7 @@ public static class SearchMessagesEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<SearchMessagesResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<SearchMessagesResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
@@ -47,6 +47,6 @@ public static class SearchMessagesEndpoint
             new SearchMessagesInput(guildId, request.Q, request.ChannelId, request.AuthorId, request.Before, request.After, request.Cursor, request.Limit),
             currentUserId,
             cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/TransferOwnership/TransferOwnershipEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/TransferOwnership/TransferOwnershipEndpoint.cs
@@ -39,7 +39,7 @@ public static class TransferOwnershipEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<bool>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<bool>.Fail(validationError).ToHttpResult(httpContext);
 
         var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
@@ -48,6 +48,6 @@ public static class TransferOwnershipEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/UnbanMember/UnbanMemberEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/UnbanMember/UnbanMemberEndpoint.cs
@@ -44,6 +44,6 @@ public static class UnbanMemberEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Guilds/UpdateGuild/UpdateGuildEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/UpdateGuild/UpdateGuildEndpoint.cs
@@ -62,7 +62,7 @@ public static class UpdateGuildEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<UpdateGuildResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<UpdateGuildResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
@@ -81,7 +81,7 @@ public static class UpdateGuildEndpoint
                 request.IconBgIsSet),
             callerId,
             cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 
     internal sealed record UpdateGuildOpenApiRequest(

--- a/src/Harmonie.Application/Features/Guilds/UpdateMemberRole/UpdateMemberRoleEndpoint.cs
+++ b/src/Harmonie.Application/Features/Guilds/UpdateMemberRole/UpdateMemberRoleEndpoint.cs
@@ -40,7 +40,7 @@ public static class UpdateMemberRoleEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<bool>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<bool>.Fail(validationError).ToHttpResult(httpContext);
 
         var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
@@ -49,6 +49,6 @@ public static class UpdateMemberRoleEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Uploads/DeleteFile/DeleteFileEndpoint.cs
+++ b/src/Harmonie.Application/Features/Uploads/DeleteFile/DeleteFileEndpoint.cs
@@ -37,6 +37,6 @@ public static class DeleteFileEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Uploads/DownloadFile/DownloadFileEndpoint.cs
+++ b/src/Harmonie.Application/Features/Uploads/DownloadFile/DownloadFileEndpoint.cs
@@ -40,7 +40,7 @@ public static class DownloadFileEndpoint
             cancellationToken);
 
         if (!response.Success || response.Data is null)
-            return response.ToHttpResult();
+            return response.ToHttpResult(httpContext);
 
         return Results.File(
             response.Data.Content,

--- a/src/Harmonie.Application/Features/Uploads/UploadFile/UploadFileEndpoint.cs
+++ b/src/Harmonie.Application/Features/Uploads/UploadFile/UploadFileEndpoint.cs
@@ -37,14 +37,14 @@ public static class UploadFileEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<UploadFileResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<UploadFileResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         if (request.File is not IFormFile file)
         {
             return ApplicationResponse<UploadFileResponse>.Fail(
                 ApplicationErrorCodes.Common.InvalidState,
                 "Request validation succeeded but file binding is missing.")
-                .ToHttpResult();
+                .ToHttpResult(httpContext);
         }
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
@@ -56,7 +56,7 @@ public static class UploadFileEndpoint
             return ApplicationResponse<UploadFileResponse>.Fail(
                 ApplicationErrorCodes.Common.InvalidState,
                 "Request validation succeeded but file metadata is invalid.")
-                .ToHttpResult();
+                .ToHttpResult(httpContext);
         }
 
         var purpose = UploadPurpose.Attachment;
@@ -67,6 +67,6 @@ public static class UploadFileEndpoint
         var input = new UploadFileInput(fileName, contentType, file.Length, stream, purpose);
         var response = await handler.HandleAsync(input, currentUserId, cancellationToken);
 
-        return response.ToCreatedHttpResult(data => $"/api/files/{data.FileId}");
+        return response.ToCreatedHttpResult(data => $"/api/files/{data.FileId}", httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Users/DeleteMyAvatar/DeleteMyAvatarEndpoint.cs
+++ b/src/Harmonie.Application/Features/Users/DeleteMyAvatar/DeleteMyAvatarEndpoint.cs
@@ -34,6 +34,6 @@ public static class DeleteMyAvatarEndpoint
         if (response.Success)
             return Results.NoContent();
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Users/GetMyProfile/GetMyProfileEndpoint.cs
+++ b/src/Harmonie.Application/Features/Users/GetMyProfile/GetMyProfileEndpoint.cs
@@ -30,6 +30,6 @@ public static class GetMyProfileEndpoint
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(Unit.Value, currentUserId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Users/SearchUsers/SearchUsersEndpoint.cs
+++ b/src/Harmonie.Application/Features/Users/SearchUsers/SearchUsersEndpoint.cs
@@ -34,11 +34,11 @@ public static class SearchUsersEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<SearchUsersResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<SearchUsersResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(request, currentUserId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Users/UpdateMyProfile/UpdateMyProfileEndpoint.cs
+++ b/src/Harmonie.Application/Features/Users/UpdateMyProfile/UpdateMyProfileEndpoint.cs
@@ -67,12 +67,12 @@ public static class UpdateMyProfileEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<UpdateMyProfileResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<UpdateMyProfileResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(request, currentUserId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 
     internal sealed record UpdateMyProfileOpenApiRequest(

--- a/src/Harmonie.Application/Features/Users/UpdateUserStatus/UpdateUserStatusEndpoint.cs
+++ b/src/Harmonie.Application/Features/Users/UpdateUserStatus/UpdateUserStatusEndpoint.cs
@@ -43,11 +43,11 @@ public static class UpdateUserStatusEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<UpdateUserStatusResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<UpdateUserStatusResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
         var response = await handler.HandleAsync(request, currentUserId, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Users/UploadMyAvatar/UploadMyAvatarEndpoint.cs
+++ b/src/Harmonie.Application/Features/Users/UploadMyAvatar/UploadMyAvatarEndpoint.cs
@@ -36,14 +36,14 @@ public static class UploadMyAvatarEndpoint
     {
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<UploadMyAvatarResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<UploadMyAvatarResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         if (request.File is not IFormFile file)
         {
             return ApplicationResponse<UploadMyAvatarResponse>.Fail(
                 ApplicationErrorCodes.Common.InvalidState,
                 "Request validation succeeded but file binding is missing.")
-                .ToHttpResult();
+                .ToHttpResult(httpContext);
         }
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
@@ -55,7 +55,7 @@ public static class UploadMyAvatarEndpoint
             return ApplicationResponse<UploadMyAvatarResponse>.Fail(
                 ApplicationErrorCodes.Common.InvalidState,
                 "Request validation succeeded but file metadata is invalid.")
-                .ToHttpResult();
+                .ToHttpResult(httpContext);
         }
 
         await using var stream = file.OpenReadStream();
@@ -65,6 +65,6 @@ public static class UploadMyAvatarEndpoint
             currentUserId,
             cancellationToken);
 
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Voice/HandleLiveKitWebhook/HandleLiveKitWebhookEndpoint.cs
+++ b/src/Harmonie.Application/Features/Voice/HandleLiveKitWebhook/HandleLiveKitWebhookEndpoint.cs
@@ -28,6 +28,7 @@ public static class HandleLiveKitWebhookEndpoint
         [FromHeader(Name = "Authorization")] string? authorizationHeader,
         [FromServices] IHandler<HandleLiveKitWebhookRequest, HandleLiveKitWebhookResponse> handler,
         [FromServices] IValidator<HandleLiveKitWebhookRequest> validator,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
         using var reader = new StreamReader(httpRequest.Body);
@@ -36,9 +37,9 @@ public static class HandleLiveKitWebhookEndpoint
         var request = new HandleLiveKitWebhookRequest(rawBody, authorizationHeader);
         var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
-            return ApplicationResponse<HandleLiveKitWebhookResponse>.Fail(validationError).ToHttpResult();
+            return ApplicationResponse<HandleLiveKitWebhookResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var response = await handler.HandleAsync(request, cancellationToken);
-        return response.ToHttpResult();
+        return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Harmonie.Application.csproj
+++ b/src/Harmonie.Application/Harmonie.Application.csproj
@@ -19,10 +19,10 @@
 
   <ItemGroup>
     <!-- Validation -->
-    <PackageReference Include="FluentValidation" Version="11.11.0" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageReference Include="FluentValidation" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="SixLabors.ImageSharp" />
   </ItemGroup>
 
 </Project>

--- a/src/Harmonie.Infrastructure/Harmonie.Infrastructure.csproj
+++ b/src/Harmonie.Infrastructure/Harmonie.Infrastructure.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="..\Harmonie.Domain\Harmonie.Domain.csproj" />
     <ProjectReference Include="..\Harmonie.Application\Harmonie.Application.csproj" />
   </ItemGroup>
@@ -23,12 +24,7 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
     
-    <!-- Password Hashing -->
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.9" />
-    
     <!-- Configuration -->
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Harmonie.Infrastructure/Harmonie.Infrastructure.csproj
+++ b/src/Harmonie.Infrastructure/Harmonie.Infrastructure.csproj
@@ -16,13 +16,13 @@
 
   <ItemGroup>
     <!-- Database -->
-    <PackageReference Include="Dapper" Version="2.1.66" />
-    <PackageReference Include="Livekit.Server.Sdk.Dotnet" Version="1.2.0" />
-    <PackageReference Include="Npgsql" Version="10.0.0" />
+    <PackageReference Include="Dapper" />
+    <PackageReference Include="Livekit.Server.Sdk.Dotnet" />
+    <PackageReference Include="Npgsql" />
     
     <!-- JWT -->
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     
     <!-- Configuration -->
   </ItemGroup>

--- a/tests/Harmonie.API.IntegrationTests/Harmonie.API.IntegrationTests.csproj
+++ b/tests/Harmonie.API.IntegrationTests/Harmonie.API.IntegrationTests.csproj
@@ -6,13 +6,13 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
+    <PackageReference Include="Moq" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Harmonie.API\Harmonie.API.csproj" />

--- a/tests/Harmonie.API.IntegrationTests/Middleware/TraceIdMiddlewareTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Middleware/TraceIdMiddlewareTests.cs
@@ -5,14 +5,10 @@ using System.Text.Json;
 using FluentAssertions;
 using Harmonie.API.IntegrationTests.Common;
 using Harmonie.Application.Common;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 
 namespace Harmonie.API.IntegrationTests.Middleware;
 
-/// <summary>
-/// Integration tests for TraceIdMiddleware
-/// </summary>
 public sealed class TraceIdMiddlewareTests : IClassFixture<HarmonieWebApplicationFactory>
 {
     private readonly HttpClient _client;

--- a/tests/Harmonie.API.IntegrationTests/Middleware/TraceIdMiddlewareTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Middleware/TraceIdMiddlewareTests.cs
@@ -1,0 +1,100 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Harmonie.API.IntegrationTests.Common;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Harmonie.API.IntegrationTests.Middleware;
+
+/// <summary>
+/// Integration tests for TraceIdMiddleware
+/// </summary>
+public sealed class TraceIdMiddlewareTests : IClassFixture<HarmonieWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public TraceIdMiddlewareTests(HarmonieWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task XTraceIdHeader_PresentInResponse()
+    {
+        // Act
+        var response = await _client.GetAsync("/health");
+
+        // Assert
+        response.Headers.TryGetValues("X-Trace-Id", out var traceIdValues);
+        traceIdValues.Should().NotBeNull();
+        var traceId = traceIdValues?.FirstOrDefault() ?? string.Empty;
+        traceId.Should().NotBeNullOrEmpty();
+        traceId.Length.Should().Be(32);
+        traceId.Should().BeEquivalentTo(traceId.ToLowerInvariant()); // hex lowercase
+    }
+
+    [Fact]
+    public async Task XTraceIdHeader_DifferentForEachRequest()
+    {
+        // Act
+        var response1 = await _client.GetAsync("/health");
+        var response2 = await _client.GetAsync("/health");
+
+        // Assert
+        var traceId1 = response1.Headers.GetValues("X-Trace-Id").FirstOrDefault();
+        var traceId2 = response2.Headers.GetValues("X-Trace-Id").FirstOrDefault();
+
+        traceId1.Should().NotBeNull();
+        traceId2.Should().NotBeNull();
+        traceId1.Should().NotBe(traceId2);
+    }
+
+    [Fact]
+    public async Task XTraceIdHeader_EqualsTraceParent_WhenProvided()
+    {
+        // Arrange
+        var expectedTraceId = "0123456789abcdef0123456789abcdef";
+        var request = new HttpRequestMessage(HttpMethod.Get, "/health");
+        request.Headers.Add("traceparent", $"00-{expectedTraceId}-{ActivitySpanId.CreateRandom().ToHexString()}-01");
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        var traceId = response.Headers.GetValues("X-Trace-Id").FirstOrDefault();
+        traceId.Should().Be(expectedTraceId);
+    }
+
+    [Fact]
+    public async Task XTraceIdHeader_GeneratedWhenTraceParentInvalid()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Get, "/health");
+        request.Headers.Add("traceparent", "invalid-format");
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        var traceId = response.Headers.GetValues("X-Trace-Id").FirstOrDefault();
+        traceId.Should().NotBeNull();
+        traceId!.Length.Should().Be(32);
+        traceId.Should().NotBe("invalid-format");
+    }
+
+    [Fact]
+    public async Task XTraceIdHeader_PresentOnErrorResponse()
+    {
+        // Act
+        var response = await _client.PostAsJsonAsync("/api/auth/login", new { email = "", password = "" });
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Headers.TryGetValues("X-Trace-Id", out var traceIdValues);
+        traceIdValues.Should().NotBeNull();
+        var traceId = traceIdValues?.FirstOrDefault() ?? string.Empty;
+        traceId.Should().NotBeNullOrEmpty();
+    }
+}

--- a/tests/Harmonie.API.IntegrationTests/Middleware/TraceIdMiddlewareTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Middleware/TraceIdMiddlewareTests.cs
@@ -1,8 +1,10 @@
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using FluentAssertions;
 using Harmonie.API.IntegrationTests.Common;
+using Harmonie.Application.Common;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 
@@ -96,5 +98,26 @@ public sealed class TraceIdMiddlewareTests : IClassFixture<HarmonieWebApplicatio
         traceIdValues.Should().NotBeNull();
         var traceId = traceIdValues?.FirstOrDefault() ?? string.Empty;
         traceId.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task XTraceIdHeader_MatchesTraceIdInErrorBody()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/auth/login");
+        request.Content = JsonContent.Create(new { email = "", password = "" });
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        var headerTraceId = response.Headers.GetValues("X-Trace-Id").FirstOrDefault();
+        headerTraceId.Should().NotBeNull();
+
+        var body = await response.Content.ReadAsStringAsync();
+        var error = JsonSerializer.Deserialize<ApplicationError>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        error.Should().NotBeNull();
+        error!.TraceId.Should().NotBeNull();
+        error.TraceId.Should().Be(headerTraceId);
     }
 }

--- a/tests/Harmonie.API.Tests/Harmonie.API.Tests.csproj
+++ b/tests/Harmonie.API.Tests/Harmonie.API.Tests.csproj
@@ -6,10 +6,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Harmonie.API\Harmonie.API.csproj" />

--- a/tests/Harmonie.Application.Tests/Harmonie.Application.Tests.csproj
+++ b/tests/Harmonie.Application.Tests/Harmonie.Application.Tests.csproj
@@ -6,11 +6,11 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Moq" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Harmonie.Application\Harmonie.Application.csproj" />

--- a/tests/Harmonie.Domain.Tests/Harmonie.Domain.Tests.csproj
+++ b/tests/Harmonie.Domain.Tests/Harmonie.Domain.Tests.csproj
@@ -6,10 +6,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Harmonie.Domain\Harmonie.Domain.csproj" />

--- a/tests/Harmonie.Infrastructure.Tests/Harmonie.Infrastructure.Tests.csproj
+++ b/tests/Harmonie.Infrastructure.Tests/Harmonie.Infrastructure.Tests.csproj
@@ -6,12 +6,12 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Moq" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Harmonie.Infrastructure\Harmonie.Infrastructure.csproj" />

--- a/tools/Harmonie.Migrations/Harmonie.Migrations.csproj
+++ b/tools/Harmonie.Migrations/Harmonie.Migrations.csproj
@@ -6,10 +6,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="dbup-postgresql" Version="6.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+    <PackageReference Include="dbup-postgresql" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Scripts\**\*.sql" />


### PR DESCRIPTION
## Summary

- Adds `TraceIdMiddleware` that establishes a correlation ID for every HTTP request
- Reads W3C `traceparent` header if present, otherwise generates a new TraceId
- Pushes TraceId into `LogContext` so Serilog automatically includes it in all log entries (via existing `.Enrich.FromLogContext()`)
- Adds `X-Trace-Id` response header for client-side correlation
- Stores TraceId in `HttpContext.Items` for downstream access

## Changes

| File | Description |
|---|---|
| `src/Harmonie.API/Middleware/TraceIdMiddleware.cs` | New middleware — 79 lines |
| `src/Harmonie.API/Program.cs` | Added middleware to pipeline (before `GlobalExceptionHandler`) |
| `tests/Harmonie.API.IntegrationTests/Middleware/TraceIdMiddlewareTests.cs` | 5 integration tests |

## How it works

1. Middleware runs first in the pipeline (before exception handler, auth, rate limiter)
2. Checks for `traceparent` header (W3C Trace Context format: `00-traceId-spanId-flags`)
3. If valid → uses it; if missing/invalid → generates new via `ActivityTraceId.CreateRandom()`
4. Pushes TraceId into `Serilog.Context.LogContext` → all subsequent logs automatically include it
5. Adds `X-Trace-Id` header to HTTP response

## Example log output

```json
{
  "Timestamp": "2026-04-18T10:30:00.000Z",
  "Level": "Information",
  "MessageTemplate": "LoginHandler started",
  "Properties": {
    "TraceId": "0123456789abcdef0123456789abcdef",
    "Handler": "LoginHandler",
    "SourceContext": "Harmonie.Application.Features.Auth.Login.LoginHandler"
  }
}
```

## Example response header

```
X-Trace-Id: 0123456789abcdef0123456789abcdef
```

## Testing

- 958 tests pass (0 failed)
- 5 new integration tests covering: header presence, traceparent propagation, invalid traceparent handling, error responses
- Build is warning-clean (0 warnings, 0 errors)

## Related

- Part of observability initiative — see #327 (OpenTelemetry) and #328 (docs)

Closes #326