### PR TITLE
chore(tests): migrate xUnit v2 to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         ASPNETCORE_ENVIRONMENT: Development
 
     - name: Run tests
-      run: dotnet test --no-build --verbosity normal --configuration Release --collect:"XPlat Code Coverage" --logger trx --results-directory "${{ github.workspace }}/TestResults"
+      run: dotnet test --no-build --verbosity normal --configuration Release -- --report-trx --results-directory "${{ github.workspace }}/TestResults"
       env:
         ASPNETCORE_ENVIRONMENT: Development
         ConnectionStrings__DefaultConnection: "Host=localhost;Port=5432;Database=harmonie_test;Username=harmonie_user;Password=harmonie_password"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         ASPNETCORE_ENVIRONMENT: Development
 
     - name: Run tests
-      run: dotnet test --no-build --verbosity normal --configuration Release --collect:"XPlat Code Coverage" --logger "trx;LogFileName=test-results.trx"
+      run: dotnet test --no-build --verbosity normal --configuration Release --collect:"XPlat Code Coverage" --logger trx --results-directory "${{ github.workspace }}/TestResults"
       env:
         ASPNETCORE_ENVIRONMENT: Development
         ConnectionStrings__DefaultConnection: "Host=localhost;Port=5432;Database=harmonie_test;Username=harmonie_user;Password=harmonie_password"
@@ -166,7 +166,7 @@ jobs:
       if: always()
       with:
         name: Test Results
-        path: '**/test-results.trx'
+        path: 'TestResults/*.trx'
         reporter: dotnet-trx
 
     - name: Stop containers

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,6 +51,7 @@
   <!-- Testing -->
   <ItemGroup>
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.9.1" />
     <PackageVersion Include="FluentAssertions" Version="8.9.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.6" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,9 +50,7 @@
 
   <!-- Testing -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="FluentAssertions" Version="8.9.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.6" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,7 +51,7 @@
   <!-- Testing -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="FluentAssertions" Version="8.9.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+</Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -3,4 +3,7 @@
     <OutputType>Exe</OutputType>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+  </ItemGroup>
 </Project>

--- a/tests/Harmonie.API.IntegrationTests/AsyncApiDocumentTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/AsyncApiDocumentTests.cs
@@ -22,7 +22,7 @@ public sealed class AsyncApiDocumentTests : IClassFixture<HarmonieWebApplication
         using var factory = _factory.WithWebHostBuilder(b => b.UseEnvironment("Development"));
         using var client = factory.CreateClient();
 
-        var response = await client.GetAsync("/asyncapi/v1.json");
+        var response = await client.GetAsync("/asyncapi/v1.json", TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
@@ -34,8 +34,8 @@ public sealed class AsyncApiDocumentTests : IClassFixture<HarmonieWebApplication
         using var factory = _factory.WithWebHostBuilder(b => b.UseEnvironment("Development"));
         using var client = factory.CreateClient();
 
-        var response = await client.GetAsync("/asyncapi/v1.json");
-        var body = await response.Content.ReadAsStringAsync();
+        var response = await client.GetAsync("/asyncapi/v1.json", TestContext.Current.CancellationToken);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         var document = JsonNode.Parse(body);
         document.Should().NotBeNull();
@@ -50,8 +50,8 @@ public sealed class AsyncApiDocumentTests : IClassFixture<HarmonieWebApplication
         using var factory = _factory.WithWebHostBuilder(b => b.UseEnvironment("Development"));
         using var client = factory.CreateClient();
 
-        var response = await client.GetAsync("/asyncapi/v1.json");
-        var body = await response.Content.ReadAsStringAsync();
+        var response = await client.GetAsync("/asyncapi/v1.json", TestContext.Current.CancellationToken);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var document = JsonNode.Parse(body);
 
         document!["channels"]!["Realtime"].Should().NotBeNull();
@@ -64,7 +64,7 @@ public sealed class AsyncApiDocumentTests : IClassFixture<HarmonieWebApplication
         using var factory = _factory.WithWebHostBuilder(b => b.UseEnvironment("Development"));
         using var client = factory.CreateClient();
 
-        var response = await client.GetAsync("/asyncapi/ui");
+        var response = await client.GetAsync("/asyncapi/ui", TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType?.MediaType.Should().Be("text/html");

--- a/tests/Harmonie.API.IntegrationTests/Auth/AuthEndpointsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Auth/AuthEndpointsTests.cs
@@ -35,12 +35,12 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
             Password: "Test123!@#");
 
         // Act
-        var response = await _client.PostAsJsonAsync("/api/auth/register", request);
+        var response = await _client.PostAsJsonAsync("/api/auth/register", request, TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var result = await response.Content.ReadFromJsonAsync<RegisterResponse>();
+        var result = await response.Content.ReadFromJsonAsync<RegisterResponse>(TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
 
         result!.Email.Should().Be(request.Email);
@@ -59,12 +59,12 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
             Password: "Test123!@#");
 
         // Act
-        var response = await _client.PostAsJsonAsync("/api/auth/register", request);
+        var response = await _client.PostAsJsonAsync("/api/auth/register", request, TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var result = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var result = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
 
         result!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
@@ -79,19 +79,19 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
             Username: $"testuser{Guid.NewGuid():N}"[..20],
             Password: "Test123!@#");
 
-        await _client.PostAsJsonAsync("/api/auth/register", registerRequest);
+        await _client.PostAsJsonAsync("/api/auth/register", registerRequest, TestContext.Current.CancellationToken);
 
         var loginRequest = new LoginRequest(
             EmailOrUsername: registerRequest.Email,
             Password: registerRequest.Password);
 
         // Act
-        var response = await _client.PostAsJsonAsync("/api/auth/login", loginRequest);
+        var response = await _client.PostAsJsonAsync("/api/auth/login", loginRequest, TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var result = await response.Content.ReadFromJsonAsync<LoginResponse>();
+        var result = await response.Content.ReadFromJsonAsync<LoginResponse>(TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
 
         result!.Email.Should().Be(registerRequest.Email);
@@ -107,19 +107,19 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
             Username: $"testuser{Guid.NewGuid():N}"[..20],
             Password: "Test123!@#");
 
-        await _client.PostAsJsonAsync("/api/auth/register", registerRequest);
+        await _client.PostAsJsonAsync("/api/auth/register", registerRequest, TestContext.Current.CancellationToken);
 
         var loginRequest = new LoginRequest(
             EmailOrUsername: registerRequest.Username,
             Password: registerRequest.Password);
 
         // Act
-        var response = await _client.PostAsJsonAsync("/api/auth/login", loginRequest);
+        var response = await _client.PostAsJsonAsync("/api/auth/login", loginRequest, TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var result = await response.Content.ReadFromJsonAsync<LoginResponse>();
+        var result = await response.Content.ReadFromJsonAsync<LoginResponse>(TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
 
         result!.Username.Should().Be(registerRequest.Username);
@@ -135,21 +135,21 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
             Username: $"testuser{Guid.NewGuid():N}"[..20],
             Password: "Test123!@#");
 
-        var registerResponse = await _client.PostAsJsonAsync("/api/auth/register", registerRequest);
+        var registerResponse = await _client.PostAsJsonAsync("/api/auth/register", registerRequest, TestContext.Current.CancellationToken);
         registerResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var registerPayload = await registerResponse.Content.ReadFromJsonAsync<RegisterResponse>();
+        var registerPayload = await registerResponse.Content.ReadFromJsonAsync<RegisterResponse>(TestContext.Current.CancellationToken);
         registerPayload.Should().NotBeNull();
 
         var refreshRequest = new RefreshTokenRequest(registerPayload!.RefreshToken);
 
         // Act
-        var response = await _client.PostAsJsonAsync("/api/auth/refresh", refreshRequest);
+        var response = await _client.PostAsJsonAsync("/api/auth/refresh", refreshRequest, TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var result = await response.Content.ReadFromJsonAsync<RefreshTokenResponse>();
+        var result = await response.Content.ReadFromJsonAsync<RefreshTokenResponse>(TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
 
         result!.AccessToken.Should().NotBeNullOrEmpty();
@@ -166,49 +166,54 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
             Username: $"testuser{Guid.NewGuid():N}"[..20],
             Password: "Test123!@#");
 
-        var registerResponse = await _client.PostAsJsonAsync("/api/auth/register", registerRequest);
+        var registerResponse = await _client.PostAsJsonAsync("/api/auth/register", registerRequest, TestContext.Current.CancellationToken);
         registerResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-        var registerPayload = await registerResponse.Content.ReadFromJsonAsync<RegisterResponse>();
+        var registerPayload = await registerResponse.Content.ReadFromJsonAsync<RegisterResponse>(TestContext.Current.CancellationToken);
         registerPayload.Should().NotBeNull();
 
         var loginResponse = await _client.PostAsJsonAsync(
             "/api/auth/login",
-            new LoginRequest(registerRequest.Email, registerRequest.Password));
+            new LoginRequest(registerRequest.Email, registerRequest.Password),
+            TestContext.Current.CancellationToken);
         loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        var loginPayload = await loginResponse.Content.ReadFromJsonAsync<LoginResponse>();
+        var loginPayload = await loginResponse.Content.ReadFromJsonAsync<LoginResponse>(TestContext.Current.CancellationToken);
         loginPayload.Should().NotBeNull();
 
         var firstRefreshResponse = await _client.PostAsJsonAsync(
             "/api/auth/refresh",
-            new RefreshTokenRequest(registerPayload!.RefreshToken));
+            new RefreshTokenRequest(registerPayload!.RefreshToken),
+            TestContext.Current.CancellationToken);
         firstRefreshResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        var firstRefreshPayload = await firstRefreshResponse.Content.ReadFromJsonAsync<RefreshTokenResponse>();
+        var firstRefreshPayload = await firstRefreshResponse.Content.ReadFromJsonAsync<RefreshTokenResponse>(TestContext.Current.CancellationToken);
         firstRefreshPayload.Should().NotBeNull();
 
         // Act - reuse rotated token
         var reuseResponse = await _client.PostAsJsonAsync(
             "/api/auth/refresh",
-            new RefreshTokenRequest(registerPayload.RefreshToken));
+            new RefreshTokenRequest(registerPayload.RefreshToken),
+            TestContext.Current.CancellationToken);
 
         // Assert - reuse is treated as security incident
         reuseResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
-        var reuseError = await reuseResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var reuseError = await reuseResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         reuseError.Should().NotBeNull();
         reuseError!.Code.Should().Be(ApplicationErrorCodes.Auth.RefreshTokenReuseDetected);
 
         // The associated active descendant session is revoked
         var descendantResponse = await _client.PostAsJsonAsync(
             "/api/auth/refresh",
-            new RefreshTokenRequest(firstRefreshPayload!.RefreshToken));
+            new RefreshTokenRequest(firstRefreshPayload!.RefreshToken),
+            TestContext.Current.CancellationToken);
         descendantResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
-        var descendantError = await descendantResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var descendantError = await descendantResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         descendantError.Should().NotBeNull();
         descendantError!.Code.Should().Be(ApplicationErrorCodes.Auth.RefreshTokenReuseDetected);
 
         // Unrelated active session remains valid
         var unrelatedResponse = await _client.PostAsJsonAsync(
             "/api/auth/refresh",
-            new RefreshTokenRequest(loginPayload!.RefreshToken));
+            new RefreshTokenRequest(loginPayload!.RefreshToken),
+            TestContext.Current.CancellationToken);
         unrelatedResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -221,12 +226,12 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
             Password: "WrongPassword123!@#");
 
         // Act
-        var response = await _client.PostAsJsonAsync("/api/auth/login", loginRequest);
+        var response = await _client.PostAsJsonAsync("/api/auth/login", loginRequest, TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
 
-        var result = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var result = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
 
         result!.Code.Should().Be(ApplicationErrorCodes.Auth.InvalidCredentials);
@@ -241,10 +246,10 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
             Username: $"testuser{Guid.NewGuid():N}"[..20],
             Password: "Test123!@#");
 
-        var registerResponse = await _client.PostAsJsonAsync("/api/auth/register", registerRequest);
+        var registerResponse = await _client.PostAsJsonAsync("/api/auth/register", registerRequest, TestContext.Current.CancellationToken);
         registerResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var registerPayload = await registerResponse.Content.ReadFromJsonAsync<RegisterResponse>();
+        var registerPayload = await registerResponse.Content.ReadFromJsonAsync<RegisterResponse>(TestContext.Current.CancellationToken);
         registerPayload.Should().NotBeNull();
 
         // Act - Logout current session
@@ -258,11 +263,12 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
 
         var refreshResponse = await _client.PostAsJsonAsync(
             "/api/auth/refresh",
-            new RefreshTokenRequest(registerPayload.RefreshToken));
+            new RefreshTokenRequest(registerPayload.RefreshToken),
+            TestContext.Current.CancellationToken);
 
         refreshResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
 
-        var refreshError = await refreshResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var refreshError = await refreshResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         refreshError.Should().NotBeNull();
         refreshError!.Code.Should().Be(ApplicationErrorCodes.Auth.RefreshTokenReuseDetected);
     }
@@ -281,13 +287,13 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
             Username: $"testuser{Guid.NewGuid():N}"[..20],
             Password: "Test123!@#");
 
-        var userAResponse = await _client.PostAsJsonAsync("/api/auth/register", userARequest);
-        var userBResponse = await _client.PostAsJsonAsync("/api/auth/register", userBRequest);
+        var userAResponse = await _client.PostAsJsonAsync("/api/auth/register", userARequest, TestContext.Current.CancellationToken);
+        var userBResponse = await _client.PostAsJsonAsync("/api/auth/register", userBRequest, TestContext.Current.CancellationToken);
         userAResponse.StatusCode.Should().Be(HttpStatusCode.Created);
         userBResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var userAPayload = await userAResponse.Content.ReadFromJsonAsync<RegisterResponse>();
-        var userBPayload = await userBResponse.Content.ReadFromJsonAsync<RegisterResponse>();
+        var userAPayload = await userAResponse.Content.ReadFromJsonAsync<RegisterResponse>(TestContext.Current.CancellationToken);
+        var userBPayload = await userBResponse.Content.ReadFromJsonAsync<RegisterResponse>(TestContext.Current.CancellationToken);
         userAPayload.Should().NotBeNull();
         userBPayload.Should().NotBeNull();
 
@@ -300,7 +306,7 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
         // Assert
         logoutResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
 
-        var error = await logoutResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await logoutResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Auth.InvalidRefreshToken);
     }
@@ -312,7 +318,7 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
         var request = new LogoutRequest("any_refresh_token");
 
         // Act
-        var response = await _client.PostAsJsonAsync("/api/auth/logout", request);
+        var response = await _client.PostAsJsonAsync("/api/auth/logout", request, TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
@@ -327,18 +333,19 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
             Username: $"testuser{Guid.NewGuid():N}"[..20],
             Password: "Test123!@#");
 
-        var registerResponse = await _client.PostAsJsonAsync("/api/auth/register", registerRequest);
+        var registerResponse = await _client.PostAsJsonAsync("/api/auth/register", registerRequest, TestContext.Current.CancellationToken);
         registerResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var registerPayload = await registerResponse.Content.ReadFromJsonAsync<RegisterResponse>();
+        var registerPayload = await registerResponse.Content.ReadFromJsonAsync<RegisterResponse>(TestContext.Current.CancellationToken);
         registerPayload.Should().NotBeNull();
 
         var loginResponse = await _client.PostAsJsonAsync(
             "/api/auth/login",
-            new LoginRequest(registerRequest.Email, registerRequest.Password));
+            new LoginRequest(registerRequest.Email, registerRequest.Password),
+            TestContext.Current.CancellationToken);
         loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var loginPayload = await loginResponse.Content.ReadFromJsonAsync<LoginResponse>();
+        var loginPayload = await loginResponse.Content.ReadFromJsonAsync<LoginResponse>(TestContext.Current.CancellationToken);
         loginPayload.Should().NotBeNull();
 
         // Act
@@ -351,21 +358,23 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
 
         var refreshWithRegisterTokenResponse = await _client.PostAsJsonAsync(
             "/api/auth/refresh",
-            new RefreshTokenRequest(registerPayload.RefreshToken));
+            new RefreshTokenRequest(registerPayload.RefreshToken),
+            TestContext.Current.CancellationToken);
         refreshWithRegisterTokenResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
 
         var refreshWithRegisterTokenError =
-            await refreshWithRegisterTokenResponse.Content.ReadFromJsonAsync<ApplicationError>();
+            await refreshWithRegisterTokenResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         refreshWithRegisterTokenError.Should().NotBeNull();
         refreshWithRegisterTokenError!.Code.Should().Be(ApplicationErrorCodes.Auth.RefreshTokenReuseDetected);
 
         var refreshWithLoginTokenResponse = await _client.PostAsJsonAsync(
             "/api/auth/refresh",
-            new RefreshTokenRequest(loginPayload!.RefreshToken));
+            new RefreshTokenRequest(loginPayload!.RefreshToken),
+            TestContext.Current.CancellationToken);
         refreshWithLoginTokenResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
 
         var refreshWithLoginTokenError =
-            await refreshWithLoginTokenResponse.Content.ReadFromJsonAsync<ApplicationError>();
+            await refreshWithLoginTokenResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         refreshWithLoginTokenError.Should().NotBeNull();
         refreshWithLoginTokenError!.Code.Should().Be(ApplicationErrorCodes.Auth.RefreshTokenReuseDetected);
     }
@@ -374,7 +383,7 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
     public async Task LogoutAll_WithoutAuthentication_ReturnsUnauthorized()
     {
         // Act
-        var response = await _client.PostAsync("/api/auth/logout-all", content: null);
+        var response = await _client.PostAsync("/api/auth/logout-all", content: null, TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
@@ -389,10 +398,10 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
             Username: $"testuser{Guid.NewGuid():N}"[..20],
             Password: "Test123!@#");
 
-        var registerResponse = await _client.PostAsJsonAsync("/api/auth/register", registerRequest);
+        var registerResponse = await _client.PostAsJsonAsync("/api/auth/register", registerRequest, TestContext.Current.CancellationToken);
         registerResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var registerPayload = await registerResponse.Content.ReadFromJsonAsync<RegisterResponse>();
+        var registerPayload = await registerResponse.Content.ReadFromJsonAsync<RegisterResponse>(TestContext.Current.CancellationToken);
         registerPayload.Should().NotBeNull();
 
         // Act
@@ -404,7 +413,7 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }
@@ -419,12 +428,12 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
             Password: "Test123!@#");
 
         // Act
-        var response = await _client.PostAsJsonAsync("/api/auth/register", request);
+        var response = await _client.PostAsJsonAsync("/api/auth/register", request, TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var result = await response.Content.ReadFromJsonAsync<RegisterResponse>();
+        var result = await response.Content.ReadFromJsonAsync<RegisterResponse>(TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
         result!.Avatar.Should().BeNull();
         result.Theme.Should().Be("default");
@@ -442,12 +451,12 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
             Theme: "dark");
 
         // Act
-        var response = await _client.PostAsJsonAsync("/api/auth/register", request);
+        var response = await _client.PostAsJsonAsync("/api/auth/register", request, TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var result = await response.Content.ReadFromJsonAsync<RegisterResponse>();
+        var result = await response.Content.ReadFromJsonAsync<RegisterResponse>(TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
         result!.Avatar.Should().NotBeNull();
         result.Avatar!.Color.Should().Be("#ff0000");
@@ -467,12 +476,12 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
             Avatar: new AvatarAppearanceDto("#ff0000", null, null));
 
         // Act
-        var response = await _client.PostAsJsonAsync("/api/auth/register", request);
+        var response = await _client.PostAsJsonAsync("/api/auth/register", request, TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var result = await response.Content.ReadFromJsonAsync<RegisterResponse>();
+        var result = await response.Content.ReadFromJsonAsync<RegisterResponse>(TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
         result!.Avatar.Should().NotBeNull();
         result.Avatar!.Color.Should().Be("#ff0000");

--- a/tests/Harmonie.API.IntegrationTests/Channels/AcknowledgeReadEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Channels/AcknowledgeReadEndpointTests.cs
@@ -94,7 +94,7 @@ public sealed class AcknowledgeReadEndpointTests : IClassFixture<HarmonieWebAppl
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotFound);
     }
@@ -113,7 +113,7 @@ public sealed class AcknowledgeReadEndpointTests : IClassFixture<HarmonieWebAppl
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.AccessDenied);
     }
@@ -131,7 +131,7 @@ public sealed class AcknowledgeReadEndpointTests : IClassFixture<HarmonieWebAppl
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
     }
@@ -141,7 +141,8 @@ public sealed class AcknowledgeReadEndpointTests : IClassFixture<HarmonieWebAppl
     {
         var response = await _client.PostAsJsonAsync(
             $"/api/channels/{Guid.NewGuid()}/ack",
-            new AcknowledgeReadRequest(null));
+            new AcknowledgeReadRequest(null),
+            TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -158,7 +159,7 @@ public sealed class AcknowledgeReadEndpointTests : IClassFixture<HarmonieWebAppl
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }
@@ -175,7 +176,7 @@ public sealed class AcknowledgeReadEndpointTests : IClassFixture<HarmonieWebAppl
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }

--- a/tests/Harmonie.API.IntegrationTests/Channels/AddReactionEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Channels/AddReactionEndpointTests.cs
@@ -65,7 +65,7 @@ public sealed class AddReactionEndpointTests : IClassFixture<HarmonieWebApplicat
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotFound);
     }
@@ -84,7 +84,7 @@ public sealed class AddReactionEndpointTests : IClassFixture<HarmonieWebApplicat
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.AccessDenied);
     }
@@ -101,7 +101,7 @@ public sealed class AddReactionEndpointTests : IClassFixture<HarmonieWebApplicat
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
     }
@@ -111,7 +111,8 @@ public sealed class AddReactionEndpointTests : IClassFixture<HarmonieWebApplicat
     {
         var response = await _client.PutAsync(
             $"/api/channels/{Guid.NewGuid()}/messages/{Guid.NewGuid()}/reactions/%F0%9F%91%8D",
-            null);
+            null,
+            TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -163,7 +164,7 @@ public sealed class AddReactionEndpointTests : IClassFixture<HarmonieWebApplicat
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
     }
@@ -183,7 +184,7 @@ public sealed class AddReactionEndpointTests : IClassFixture<HarmonieWebApplicat
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
     }
@@ -201,7 +202,7 @@ public sealed class AddReactionEndpointTests : IClassFixture<HarmonieWebApplicat
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
     }
@@ -211,7 +212,8 @@ public sealed class AddReactionEndpointTests : IClassFixture<HarmonieWebApplicat
     {
         var response = await _client.PutAsync(
             $"/api/conversations/{Guid.NewGuid()}/messages/{Guid.NewGuid()}/reactions/%E2%9D%A4",
-            null);
+            null,
+            TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -227,7 +229,7 @@ public sealed class AddReactionEndpointTests : IClassFixture<HarmonieWebApplicat
             accessToken);
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var payload = await response.Content.ReadFromJsonAsync<ConversationSendMessageResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<ConversationSendMessageResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         return payload!;
     }
@@ -238,6 +240,6 @@ public sealed class AddReactionEndpointTests : IClassFixture<HarmonieWebApplicat
     {
         using var request = new HttpRequestMessage(HttpMethod.Put, uri);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-        return await _client.SendAsync(request);
+        return await _client.SendAsync(request, TestContext.Current.CancellationToken);
     }
 }

--- a/tests/Harmonie.API.IntegrationTests/Channels/DeleteChannelTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Channels/DeleteChannelTests.cs
@@ -46,7 +46,7 @@ public sealed class DeleteChannelTests : IClassFixture<HarmonieWebApplicationFac
             member.AccessToken);
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
     }
@@ -63,7 +63,7 @@ public sealed class DeleteChannelTests : IClassFixture<HarmonieWebApplicationFac
             outsider.AccessToken);
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.AccessDenied);
     }
@@ -79,7 +79,7 @@ public sealed class DeleteChannelTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotFound);
     }
@@ -89,7 +89,7 @@ public sealed class DeleteChannelTests : IClassFixture<HarmonieWebApplicationFac
     {
         var nonExistentChannelId = Guid.NewGuid();
 
-        var deleteResponse = await _client.DeleteAsync($"/api/channels/{nonExistentChannelId}");
+        var deleteResponse = await _client.DeleteAsync($"/api/channels/{nonExistentChannelId}", TestContext.Current.CancellationToken);
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
@@ -104,7 +104,7 @@ public sealed class DeleteChannelTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         channelsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>();
+        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
         channelsPayload.Should().NotBeNull();
 
         var defaultChannel = channelsPayload!.Channels.First(c => c.IsDefault);
@@ -114,7 +114,7 @@ public sealed class DeleteChannelTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
 
-        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.CannotDeleteDefault);
     }

--- a/tests/Harmonie.API.IntegrationTests/Channels/DeleteMessageTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Channels/DeleteMessageTests.cs
@@ -65,7 +65,7 @@ public sealed class DeleteMessageTests : IClassFixture<HarmonieWebApplicationFac
             member.AccessToken);
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Message.DeleteForbidden);
     }
@@ -84,7 +84,7 @@ public sealed class DeleteMessageTests : IClassFixture<HarmonieWebApplicationFac
             outsider.AccessToken);
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.AccessDenied);
     }
@@ -101,7 +101,7 @@ public sealed class DeleteMessageTests : IClassFixture<HarmonieWebApplicationFac
             author.AccessToken);
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
     }
@@ -118,7 +118,7 @@ public sealed class DeleteMessageTests : IClassFixture<HarmonieWebApplicationFac
             author.AccessToken);
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotFound);
     }
@@ -130,7 +130,8 @@ public sealed class DeleteMessageTests : IClassFixture<HarmonieWebApplicationFac
         var messageId = Guid.NewGuid();
 
         var deleteResponse = await _client.DeleteAsync(
-            $"/api/channels/{channelId}/messages/{messageId}");
+            $"/api/channels/{channelId}/messages/{messageId}",
+            TestContext.Current.CancellationToken);
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 }

--- a/tests/Harmonie.API.IntegrationTests/Channels/EditMessageTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Channels/EditMessageTests.cs
@@ -31,7 +31,7 @@ public sealed class EditMessageTests : IClassFixture<HarmonieWebApplicationFacto
             author.AccessToken);
         editResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await editResponse.Content.ReadFromJsonAsync<EditMessageResponse>();
+        var payload = await editResponse.Content.ReadFromJsonAsync<EditMessageResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.MessageId.Should().Be(messageId);
         payload.Content.Should().Be("updated content");
@@ -57,7 +57,7 @@ public sealed class EditMessageTests : IClassFixture<HarmonieWebApplicationFacto
             member.AccessToken);
         editResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await editResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await editResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Message.EditForbidden);
     }
@@ -77,7 +77,7 @@ public sealed class EditMessageTests : IClassFixture<HarmonieWebApplicationFacto
             outsider.AccessToken);
         editResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await editResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await editResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.AccessDenied);
     }
@@ -95,7 +95,7 @@ public sealed class EditMessageTests : IClassFixture<HarmonieWebApplicationFacto
             author.AccessToken);
         editResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await editResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await editResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
     }
@@ -113,7 +113,7 @@ public sealed class EditMessageTests : IClassFixture<HarmonieWebApplicationFacto
             author.AccessToken);
         editResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await editResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await editResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotFound);
     }
@@ -126,7 +126,8 @@ public sealed class EditMessageTests : IClassFixture<HarmonieWebApplicationFacto
 
         var editResponse = await _client.PatchAsJsonAsync(
             $"/api/channels/{channelId}/messages/{messageId}",
-            new { content = "anon edit" });
+            new { content = "anon edit" },
+            TestContext.Current.CancellationToken);
         editResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
@@ -143,7 +144,7 @@ public sealed class EditMessageTests : IClassFixture<HarmonieWebApplicationFacto
             author.AccessToken);
         editResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await editResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await editResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }

--- a/tests/Harmonie.API.IntegrationTests/Channels/GetMessagesReactionsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Channels/GetMessagesReactionsTests.cs
@@ -36,7 +36,7 @@ public sealed class GetMessagesReactionsTests : IClassFixture<HarmonieWebApplica
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<ChannelGetMessagesResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<ChannelGetMessagesResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Items.Should().ContainSingle();
         payload.Items[0].Reactions.Should().BeEmpty();
@@ -59,7 +59,7 @@ public sealed class GetMessagesReactionsTests : IClassFixture<HarmonieWebApplica
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<ChannelGetMessagesResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<ChannelGetMessagesResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Items.Should().ContainSingle();
 
@@ -89,14 +89,14 @@ public sealed class GetMessagesReactionsTests : IClassFixture<HarmonieWebApplica
         var ownerResponse = await _client.SendAuthorizedGetAsync(
             $"/api/channels/{channelId}/messages",
             owner.AccessToken);
-        var ownerPayload = await ownerResponse.Content.ReadFromJsonAsync<ChannelGetMessagesResponse>();
+        var ownerPayload = await ownerResponse.Content.ReadFromJsonAsync<ChannelGetMessagesResponse>(TestContext.Current.CancellationToken);
         ownerPayload!.Items[0].Reactions[0].ReactedByMe.Should().BeTrue();
 
         // Member sees reactedByMe = false
         var memberResponse = await _client.SendAuthorizedGetAsync(
             $"/api/channels/{channelId}/messages",
             member.AccessToken);
-        var memberPayload = await memberResponse.Content.ReadFromJsonAsync<ChannelGetMessagesResponse>();
+        var memberPayload = await memberResponse.Content.ReadFromJsonAsync<ChannelGetMessagesResponse>(TestContext.Current.CancellationToken);
         memberPayload!.Items[0].Reactions[0].ReactedByMe.Should().BeFalse();
         memberPayload.Items[0].Reactions[0].Count.Should().Be(1);
     }
@@ -117,7 +117,7 @@ public sealed class GetMessagesReactionsTests : IClassFixture<HarmonieWebApplica
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<ConversationGetMessagesResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<ConversationGetMessagesResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Items.Should().ContainSingle();
         payload.Items[0].Reactions.Should().BeEmpty();
@@ -141,7 +141,7 @@ public sealed class GetMessagesReactionsTests : IClassFixture<HarmonieWebApplica
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<ConversationGetMessagesResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<ConversationGetMessagesResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Items.Should().ContainSingle();
 
@@ -169,14 +169,14 @@ public sealed class GetMessagesReactionsTests : IClassFixture<HarmonieWebApplica
         var callerResponse = await _client.SendAuthorizedGetAsync(
             $"/api/conversations/{conversationId}/messages",
             caller.AccessToken);
-        var callerPayload = await callerResponse.Content.ReadFromJsonAsync<ConversationGetMessagesResponse>();
+        var callerPayload = await callerResponse.Content.ReadFromJsonAsync<ConversationGetMessagesResponse>(TestContext.Current.CancellationToken);
         callerPayload!.Items[0].Reactions[0].ReactedByMe.Should().BeTrue();
 
         // Target sees reactedByMe = false
         var targetResponse = await _client.SendAuthorizedGetAsync(
             $"/api/conversations/{conversationId}/messages",
             target.AccessToken);
-        var targetPayload = await targetResponse.Content.ReadFromJsonAsync<ConversationGetMessagesResponse>();
+        var targetPayload = await targetResponse.Content.ReadFromJsonAsync<ConversationGetMessagesResponse>(TestContext.Current.CancellationToken);
         targetPayload!.Items[0].Reactions[0].ReactedByMe.Should().BeFalse();
         targetPayload.Items[0].Reactions[0].Count.Should().Be(1);
     }
@@ -194,7 +194,7 @@ public sealed class GetMessagesReactionsTests : IClassFixture<HarmonieWebApplica
             accessToken);
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var payload = await response.Content.ReadFromJsonAsync<ConversationSendMessageResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<ConversationSendMessageResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         return payload!;
     }
@@ -205,6 +205,6 @@ public sealed class GetMessagesReactionsTests : IClassFixture<HarmonieWebApplica
     {
         using var request = new HttpRequestMessage(HttpMethod.Put, uri);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-        return await _client.SendAsync(request);
+        return await _client.SendAsync(request, TestContext.Current.CancellationToken);
     }
 }

--- a/tests/Harmonie.API.IntegrationTests/Channels/JoinVoiceChannelTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Channels/JoinVoiceChannelTests.cs
@@ -31,7 +31,7 @@ public sealed class JoinVoiceChannelTests : IClassFixture<HarmonieWebApplication
             owner.AccessToken);
         joinResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await joinResponse.Content.ReadFromJsonAsync<JoinVoiceChannelResponse>();
+        var payload = await joinResponse.Content.ReadFromJsonAsync<JoinVoiceChannelResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Token.Should().NotBeNullOrWhiteSpace();
         payload.Url.Should().Be("ws://localhost:7880");
@@ -50,7 +50,7 @@ public sealed class JoinVoiceChannelTests : IClassFixture<HarmonieWebApplication
             owner.AccessToken);
         joinResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
 
-        var error = await joinResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await joinResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotVoice);
     }
@@ -68,7 +68,7 @@ public sealed class JoinVoiceChannelTests : IClassFixture<HarmonieWebApplication
             outsider.AccessToken);
         joinResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await joinResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await joinResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.AccessDenied);
     }
@@ -83,7 +83,7 @@ public sealed class JoinVoiceChannelTests : IClassFixture<HarmonieWebApplication
             user.AccessToken);
         joinResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await joinResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await joinResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotFound);
     }
@@ -93,7 +93,8 @@ public sealed class JoinVoiceChannelTests : IClassFixture<HarmonieWebApplication
     {
         var response = await _client.PostAsync(
             $"/api/channels/{Guid.NewGuid()}/voice/join",
-            content: null);
+            content: null,
+            TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -109,7 +110,7 @@ public sealed class JoinVoiceChannelTests : IClassFixture<HarmonieWebApplication
             accessToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<GetGuildChannelsResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
 
         return payload!.Channels.First(channel => channel.Type == "Voice").ChannelId;

--- a/tests/Harmonie.API.IntegrationTests/Channels/MessageAttachmentsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Channels/MessageAttachmentsTests.cs
@@ -32,7 +32,7 @@ public sealed class MessageAttachmentsTests : IClassFixture<HarmonieWebApplicati
             author.AccessToken);
         sendResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>(TestContext.Current.CancellationToken);
         sendPayload.Should().NotBeNull();
         sendPayload!.Content.Should().BeNull();
         sendPayload.Attachments.Should().ContainSingle();
@@ -43,7 +43,7 @@ public sealed class MessageAttachmentsTests : IClassFixture<HarmonieWebApplicati
             author.AccessToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var listPayload = await listResponse.Content.ReadFromJsonAsync<GetMessagesResponse>();
+        var listPayload = await listResponse.Content.ReadFromJsonAsync<GetMessagesResponse>(TestContext.Current.CancellationToken);
         listPayload.Should().NotBeNull();
         listPayload!.Items.Should().ContainSingle();
         listPayload.Items[0].Content.Should().BeNull();
@@ -78,7 +78,7 @@ public sealed class MessageAttachmentsTests : IClassFixture<HarmonieWebApplicati
             author.AccessToken);
         sendResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>(TestContext.Current.CancellationToken);
         sendPayload.Should().NotBeNull();
         sendPayload!.Attachments.Should().ContainSingle();
     }
@@ -96,7 +96,7 @@ public sealed class MessageAttachmentsTests : IClassFixture<HarmonieWebApplicati
             author.AccessToken);
         sendResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>(TestContext.Current.CancellationToken);
         sendPayload.Should().NotBeNull();
         sendPayload!.Attachments.Should().ContainSingle();
         sendPayload.Attachments[0].FileId.Should().Be(fileId);
@@ -106,7 +106,7 @@ public sealed class MessageAttachmentsTests : IClassFixture<HarmonieWebApplicati
             author.AccessToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var listPayload = await listResponse.Content.ReadFromJsonAsync<GetMessagesResponse>();
+        var listPayload = await listResponse.Content.ReadFromJsonAsync<GetMessagesResponse>(TestContext.Current.CancellationToken);
         listPayload.Should().NotBeNull();
         listPayload!.Items.Should().ContainSingle();
         listPayload.Items[0].Attachments.Should().ContainSingle();
@@ -126,7 +126,7 @@ public sealed class MessageAttachmentsTests : IClassFixture<HarmonieWebApplicati
             author.AccessToken);
         sendResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>(TestContext.Current.CancellationToken);
         sendPayload.Should().NotBeNull();
 
         var deleteResponse = await _client.SendAuthorizedDeleteAsync(
@@ -139,7 +139,7 @@ public sealed class MessageAttachmentsTests : IClassFixture<HarmonieWebApplicati
             author.AccessToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var listPayload = await listResponse.Content.ReadFromJsonAsync<GetMessagesResponse>();
+        var listPayload = await listResponse.Content.ReadFromJsonAsync<GetMessagesResponse>(TestContext.Current.CancellationToken);
         listPayload.Should().NotBeNull();
         listPayload!.Items.Should().ContainSingle();
         listPayload.Items[0].Attachments.Should().BeEmpty();
@@ -166,7 +166,7 @@ public sealed class MessageAttachmentsTests : IClassFixture<HarmonieWebApplicati
             owner.AccessToken);
         sendResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>(TestContext.Current.CancellationToken);
         sendPayload.Should().NotBeNull();
 
         var deleteResponse = await _client.SendAuthorizedDeleteAsync(
@@ -174,7 +174,7 @@ public sealed class MessageAttachmentsTests : IClassFixture<HarmonieWebApplicati
             member.AccessToken);
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Message.DeleteForbidden);
     }
@@ -192,7 +192,7 @@ public sealed class MessageAttachmentsTests : IClassFixture<HarmonieWebApplicati
             author.AccessToken);
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await deleteResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Message.AttachmentNotFound);
     }
@@ -201,7 +201,8 @@ public sealed class MessageAttachmentsTests : IClassFixture<HarmonieWebApplicati
     public async Task DeleteMessageAttachment_WhenNotAuthenticated_ShouldReturn401()
     {
         var deleteResponse = await _client.DeleteAsync(
-            $"/api/channels/{Guid.NewGuid()}/messages/{Guid.NewGuid()}/attachments/{Guid.NewGuid()}");
+            $"/api/channels/{Guid.NewGuid()}/messages/{Guid.NewGuid()}/attachments/{Guid.NewGuid()}",
+            TestContext.Current.CancellationToken);
 
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }

--- a/tests/Harmonie.API.IntegrationTests/Channels/RemoveReactionEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Channels/RemoveReactionEndpointTests.cs
@@ -65,7 +65,7 @@ public sealed class RemoveReactionEndpointTests : IClassFixture<HarmonieWebAppli
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotFound);
     }
@@ -84,7 +84,7 @@ public sealed class RemoveReactionEndpointTests : IClassFixture<HarmonieWebAppli
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.AccessDenied);
     }
@@ -101,7 +101,7 @@ public sealed class RemoveReactionEndpointTests : IClassFixture<HarmonieWebAppli
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
     }
@@ -110,7 +110,8 @@ public sealed class RemoveReactionEndpointTests : IClassFixture<HarmonieWebAppli
     public async Task RemoveChannelReaction_WithoutAuthentication_ShouldReturnUnauthorized()
     {
         var response = await _client.DeleteAsync(
-            $"/api/channels/{Guid.NewGuid()}/messages/{Guid.NewGuid()}/reactions/%F0%9F%91%8D");
+            $"/api/channels/{Guid.NewGuid()}/messages/{Guid.NewGuid()}/reactions/%F0%9F%91%8D",
+            TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -162,7 +163,7 @@ public sealed class RemoveReactionEndpointTests : IClassFixture<HarmonieWebAppli
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
     }
@@ -182,7 +183,7 @@ public sealed class RemoveReactionEndpointTests : IClassFixture<HarmonieWebAppli
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
     }
@@ -200,7 +201,7 @@ public sealed class RemoveReactionEndpointTests : IClassFixture<HarmonieWebAppli
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
     }
@@ -209,7 +210,8 @@ public sealed class RemoveReactionEndpointTests : IClassFixture<HarmonieWebAppli
     public async Task RemoveConversationReaction_WithoutAuthentication_ShouldReturnUnauthorized()
     {
         var response = await _client.DeleteAsync(
-            $"/api/conversations/{Guid.NewGuid()}/messages/{Guid.NewGuid()}/reactions/%E2%9D%A4");
+            $"/api/conversations/{Guid.NewGuid()}/messages/{Guid.NewGuid()}/reactions/%E2%9D%A4",
+            TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -227,7 +229,7 @@ public sealed class RemoveReactionEndpointTests : IClassFixture<HarmonieWebAppli
             accessToken);
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var payload = await response.Content.ReadFromJsonAsync<ConversationSendMessageResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<ConversationSendMessageResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         return payload!;
     }
@@ -238,6 +240,6 @@ public sealed class RemoveReactionEndpointTests : IClassFixture<HarmonieWebAppli
     {
         using var request = new HttpRequestMessage(HttpMethod.Put, uri);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-        return await _client.SendAsync(request);
+        return await _client.SendAsync(request, TestContext.Current.CancellationToken);
     }
 }

--- a/tests/Harmonie.API.IntegrationTests/Channels/SearchMessagesEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Channels/SearchMessagesEndpointTests.cs
@@ -32,9 +32,9 @@ public sealed class SearchMessagesEndpointTests : IClassFixture<HarmonieWebAppli
         var deploymentsChannelId = await ChannelTestHelper.CreateChannelAndGetIdAsync(_client, owner.AccessToken, "deployments", guildId, 10);
 
         await SendMessageAsync(generalChannelId, "deploy alpha", owner.AccessToken);
-        await Task.Delay(20);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
         await SendMessageAsync(generalChannelId, "random chatter", owner.AccessToken);
-        await Task.Delay(20);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
         await SendMessageAsync(deploymentsChannelId, "deploy beta", member.AccessToken);
 
         var response = await _client.SendAuthorizedGetAsync(
@@ -43,7 +43,7 @@ public sealed class SearchMessagesEndpointTests : IClassFixture<HarmonieWebAppli
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<SearchMessagesResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<SearchMessagesResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.GuildId.Should().Be(guildId);
         payload.Items.Should().HaveCount(2);
@@ -64,11 +64,11 @@ public sealed class SearchMessagesEndpointTests : IClassFixture<HarmonieWebAppli
         var deploymentsChannelId = await ChannelTestHelper.CreateChannelAndGetIdAsync(_client, owner.AccessToken, "deployments", guildId, 10);
 
         await SendMessageAsync(deploymentsChannelId, "incident one", owner.AccessToken);
-        await Task.Delay(20);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
         await SendMessageAsync(deploymentsChannelId, "incident two", member.AccessToken);
-        await Task.Delay(20);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
         await SendMessageAsync(deploymentsChannelId, "incident three", owner.AccessToken);
-        await Task.Delay(20);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
         await SendMessageAsync(deploymentsChannelId, "incident four", owner.AccessToken);
 
         var firstResponse = await _client.SendAuthorizedGetAsync(
@@ -82,7 +82,7 @@ public sealed class SearchMessagesEndpointTests : IClassFixture<HarmonieWebAppli
 
         firstResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var firstPayload = await firstResponse.Content.ReadFromJsonAsync<SearchMessagesResponse>();
+        var firstPayload = await firstResponse.Content.ReadFromJsonAsync<SearchMessagesResponse>(TestContext.Current.CancellationToken);
         firstPayload.Should().NotBeNull();
         firstPayload!.Items.Select(item => item.Content).Should().Equal("incident four", "incident three");
         firstPayload.NextCursor.Should().NotBeNullOrWhiteSpace();
@@ -99,7 +99,7 @@ public sealed class SearchMessagesEndpointTests : IClassFixture<HarmonieWebAppli
 
         secondResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var secondPayload = await secondResponse.Content.ReadFromJsonAsync<SearchMessagesResponse>();
+        var secondPayload = await secondResponse.Content.ReadFromJsonAsync<SearchMessagesResponse>(TestContext.Current.CancellationToken);
         secondPayload.Should().NotBeNull();
         secondPayload!.Items.Select(item => item.Content).Should().Equal("incident one");
         secondPayload.NextCursor.Should().BeNull();
@@ -118,7 +118,7 @@ public sealed class SearchMessagesEndpointTests : IClassFixture<HarmonieWebAppli
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
     }
@@ -130,7 +130,7 @@ public sealed class SearchMessagesEndpointTests : IClassFixture<HarmonieWebAppli
             accessToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<GetGuildChannelsResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
 
         return payload!.Channels.First(channel => channel.Type == "Text").ChannelId;

--- a/tests/Harmonie.API.IntegrationTests/Channels/SendMessageEdgeCaseTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Channels/SendMessageEdgeCaseTests.cs
@@ -31,7 +31,7 @@ public sealed class SendMessageEdgeCaseTests : IClassFixture<HarmonieWebApplicat
             user.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         var channelsResponse = await _client.SendAuthorizedGetAsync(
@@ -39,7 +39,7 @@ public sealed class SendMessageEdgeCaseTests : IClassFixture<HarmonieWebApplicat
             user.AccessToken);
         channelsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>();
+        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
         channelsPayload.Should().NotBeNull();
 
         var voiceChannel = channelsPayload!.Channels.First(channel => channel.Type == "Voice");
@@ -50,7 +50,7 @@ public sealed class SendMessageEdgeCaseTests : IClassFixture<HarmonieWebApplicat
             user.AccessToken);
         sendMessageResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
 
-        var error = await sendMessageResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await sendMessageResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
 
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotText);
@@ -67,7 +67,7 @@ public sealed class SendMessageEdgeCaseTests : IClassFixture<HarmonieWebApplicat
             user.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         var channelsResponse = await _client.SendAuthorizedGetAsync(
@@ -75,7 +75,7 @@ public sealed class SendMessageEdgeCaseTests : IClassFixture<HarmonieWebApplicat
             user.AccessToken);
         channelsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>();
+        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
         channelsPayload.Should().NotBeNull();
 
         var textChannel = channelsPayload!.Channels.First(channel => channel.Type == "Text");

--- a/tests/Harmonie.API.IntegrationTests/Channels/UpdateChannelTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Channels/UpdateChannelTests.cs
@@ -31,7 +31,7 @@ public sealed class UpdateChannelTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await updateResponse.Content.ReadFromJsonAsync<UpdateChannelResponse>();
+        var payload = await updateResponse.Content.ReadFromJsonAsync<UpdateChannelResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.ChannelId.Should().Be(channelId);
         payload.Name.Should().Be("renamed-channel");
@@ -49,7 +49,7 @@ public sealed class UpdateChannelTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await updateResponse.Content.ReadFromJsonAsync<UpdateChannelResponse>();
+        var payload = await updateResponse.Content.ReadFromJsonAsync<UpdateChannelResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Position.Should().Be(10);
     }
@@ -66,7 +66,7 @@ public sealed class UpdateChannelTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await updateResponse.Content.ReadFromJsonAsync<UpdateChannelResponse>();
+        var payload = await updateResponse.Content.ReadFromJsonAsync<UpdateChannelResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Name.Should().Be("stable-channel");
         payload.Position.Should().Be(3);
@@ -89,7 +89,7 @@ public sealed class UpdateChannelTests : IClassFixture<HarmonieWebApplicationFac
             member.AccessToken);
         updateResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await updateResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await updateResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
     }
@@ -107,7 +107,7 @@ public sealed class UpdateChannelTests : IClassFixture<HarmonieWebApplicationFac
             outsider.AccessToken);
         updateResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await updateResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await updateResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.AccessDenied);
     }
@@ -124,7 +124,7 @@ public sealed class UpdateChannelTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         updateResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await updateResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await updateResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotFound);
     }
@@ -153,7 +153,7 @@ public sealed class UpdateChannelTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         updateResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
 
-        var error = await updateResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await updateResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.NameConflict);
     }
@@ -165,7 +165,8 @@ public sealed class UpdateChannelTests : IClassFixture<HarmonieWebApplicationFac
 
         var updateResponse = await _client.PatchAsJsonAsync(
             $"/api/channels/{nonExistentChannelId}",
-            new { name = "anon-rename" });
+            new { name = "anon-rename" },
+            TestContext.Current.CancellationToken);
         updateResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
@@ -181,7 +182,7 @@ public sealed class UpdateChannelTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         updateResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await updateResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await updateResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }

--- a/tests/Harmonie.API.IntegrationTests/Conversations/AcknowledgeConversationReadEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/AcknowledgeConversationReadEndpointTests.cs
@@ -98,7 +98,7 @@ public sealed class AcknowledgeConversationReadEndpointTests : IClassFixture<Har
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
     }
@@ -118,7 +118,7 @@ public sealed class AcknowledgeConversationReadEndpointTests : IClassFixture<Har
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
     }
@@ -137,7 +137,7 @@ public sealed class AcknowledgeConversationReadEndpointTests : IClassFixture<Har
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
     }
@@ -147,7 +147,8 @@ public sealed class AcknowledgeConversationReadEndpointTests : IClassFixture<Har
     {
         var response = await _client.PostAsJsonAsync(
             $"/api/conversations/{Guid.NewGuid()}/ack",
-            new AcknowledgeReadRequest(null));
+            new AcknowledgeReadRequest(null),
+            TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -164,7 +165,7 @@ public sealed class AcknowledgeConversationReadEndpointTests : IClassFixture<Har
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }
@@ -181,7 +182,7 @@ public sealed class AcknowledgeConversationReadEndpointTests : IClassFixture<Har
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }

--- a/tests/Harmonie.API.IntegrationTests/Conversations/ConversationEndpointsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/ConversationEndpointsTests.cs
@@ -32,7 +32,7 @@ public sealed class ConversationEndpointsTests : IClassFixture<HarmonieWebApplic
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var payload = await response.Content.ReadFromJsonAsync<OpenConversationResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<OpenConversationResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Created.Should().BeTrue();
         payload.ConversationId.Should().NotBeEmpty();
@@ -54,7 +54,7 @@ public sealed class ConversationEndpointsTests : IClassFixture<HarmonieWebApplic
             caller.AccessToken);
         firstResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var firstPayload = await firstResponse.Content.ReadFromJsonAsync<OpenConversationResponse>();
+        var firstPayload = await firstResponse.Content.ReadFromJsonAsync<OpenConversationResponse>(TestContext.Current.CancellationToken);
         firstPayload.Should().NotBeNull();
 
         var secondResponse = await _client.SendAuthorizedPostAsync(
@@ -64,7 +64,7 @@ public sealed class ConversationEndpointsTests : IClassFixture<HarmonieWebApplic
 
         secondResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var secondPayload = await secondResponse.Content.ReadFromJsonAsync<OpenConversationResponse>();
+        var secondPayload = await secondResponse.Content.ReadFromJsonAsync<OpenConversationResponse>(TestContext.Current.CancellationToken);
         secondPayload.Should().NotBeNull();
         secondPayload!.Created.Should().BeFalse();
         secondPayload.ConversationId.Should().Be(firstPayload!.ConversationId);
@@ -82,7 +82,7 @@ public sealed class ConversationEndpointsTests : IClassFixture<HarmonieWebApplic
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.User.NotFound);
     }
@@ -99,7 +99,7 @@ public sealed class ConversationEndpointsTests : IClassFixture<HarmonieWebApplic
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.CannotOpenSelf);
     }
@@ -109,7 +109,8 @@ public sealed class ConversationEndpointsTests : IClassFixture<HarmonieWebApplic
     {
         var response = await _client.PostAsJsonAsync(
             "/api/conversations",
-            new OpenConversationRequest(Guid.NewGuid()));
+            new OpenConversationRequest(Guid.NewGuid()),
+            TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -137,7 +138,7 @@ public sealed class ConversationEndpointsTests : IClassFixture<HarmonieWebApplic
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<ListConversationsResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<ListConversationsResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Conversations.Should().HaveCount(2);
         payload.Conversations.Should().Contain(x =>
@@ -156,7 +157,7 @@ public sealed class ConversationEndpointsTests : IClassFixture<HarmonieWebApplic
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<ListConversationsResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<ListConversationsResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Conversations.Should().BeEmpty();
     }
@@ -164,7 +165,7 @@ public sealed class ConversationEndpointsTests : IClassFixture<HarmonieWebApplic
     [Fact]
     public async Task ListConversations_WithoutAuthentication_ShouldReturnUnauthorized()
     {
-        var response = await _client.GetAsync("/api/conversations");
+        var response = await _client.GetAsync("/api/conversations", TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }

--- a/tests/Harmonie.API.IntegrationTests/Conversations/ConversationMessageAttachmentsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/ConversationMessageAttachmentsTests.cs
@@ -35,7 +35,7 @@ public sealed class ConversationMessageAttachmentsTests : IClassFixture<Harmonie
             caller.AccessToken);
         sendResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>(TestContext.Current.CancellationToken);
         sendPayload.Should().NotBeNull();
 
         var deleteResponse = await _client.SendAuthorizedDeleteAsync(
@@ -48,7 +48,7 @@ public sealed class ConversationMessageAttachmentsTests : IClassFixture<Harmonie
             caller.AccessToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var listPayload = await listResponse.Content.ReadFromJsonAsync<GetMessagesResponse>();
+        var listPayload = await listResponse.Content.ReadFromJsonAsync<GetMessagesResponse>(TestContext.Current.CancellationToken);
         listPayload.Should().NotBeNull();
         listPayload!.Items.Should().ContainSingle();
         listPayload.Items[0].Attachments.Should().BeEmpty();
@@ -68,7 +68,7 @@ public sealed class ConversationMessageAttachmentsTests : IClassFixture<Harmonie
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
     }
@@ -88,7 +88,7 @@ public sealed class ConversationMessageAttachmentsTests : IClassFixture<Harmonie
             participantOne.AccessToken);
         sendResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>(TestContext.Current.CancellationToken);
         sendPayload.Should().NotBeNull();
 
         var response = await _client.SendAuthorizedDeleteAsync(
@@ -97,7 +97,7 @@ public sealed class ConversationMessageAttachmentsTests : IClassFixture<Harmonie
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
     }
@@ -116,7 +116,7 @@ public sealed class ConversationMessageAttachmentsTests : IClassFixture<Harmonie
             participantOne.AccessToken);
         sendResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>(TestContext.Current.CancellationToken);
         sendPayload.Should().NotBeNull();
 
         var response = await _client.SendAuthorizedDeleteAsync(
@@ -125,7 +125,7 @@ public sealed class ConversationMessageAttachmentsTests : IClassFixture<Harmonie
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Message.DeleteForbidden);
     }
@@ -145,7 +145,7 @@ public sealed class ConversationMessageAttachmentsTests : IClassFixture<Harmonie
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Message.AttachmentNotFound);
     }
@@ -154,7 +154,8 @@ public sealed class ConversationMessageAttachmentsTests : IClassFixture<Harmonie
     public async Task DeleteConversationMessageAttachment_WithoutAuthentication_ShouldReturnUnauthorized()
     {
         var response = await _client.DeleteAsync(
-            $"/api/conversations/{Guid.NewGuid()}/messages/{Guid.NewGuid()}/attachments/{Guid.NewGuid()}");
+            $"/api/conversations/{Guid.NewGuid()}/messages/{Guid.NewGuid()}/attachments/{Guid.NewGuid()}",
+            TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -179,7 +180,7 @@ public sealed class ConversationMessageAttachmentsTests : IClassFixture<Harmonie
         var response = await _client.SendAsync(request);
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var payload = await response.Content.ReadFromJsonAsync<UploadFileResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<UploadFileResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         return payload!;
     }

--- a/tests/Harmonie.API.IntegrationTests/Conversations/DeleteConversationMessageTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/DeleteConversationMessageTests.cs
@@ -44,7 +44,7 @@ public sealed class DeleteConversationMessageTests : IClassFixture<HarmonieWebAp
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
     }
@@ -64,7 +64,7 @@ public sealed class DeleteConversationMessageTests : IClassFixture<HarmonieWebAp
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
     }
@@ -83,7 +83,7 @@ public sealed class DeleteConversationMessageTests : IClassFixture<HarmonieWebAp
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Message.DeleteForbidden);
     }
@@ -101,7 +101,7 @@ public sealed class DeleteConversationMessageTests : IClassFixture<HarmonieWebAp
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
     }
@@ -113,7 +113,7 @@ public sealed class DeleteConversationMessageTests : IClassFixture<HarmonieWebAp
         var target = await AuthTestHelper.RegisterAsync(_client);
         var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, target.UserId);
         var visibleMessage = await ConversationTestHelper.SendConversationMessageAsync(_client, conversationId, "keep me", target.AccessToken);
-        await Task.Delay(20);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
         var deletedMessage = await ConversationTestHelper.SendConversationMessageAsync(_client, conversationId, "delete me", caller.AccessToken);
 
         var deleteResponse = await _client.SendAuthorizedDeleteAsync(
@@ -126,7 +126,7 @@ public sealed class DeleteConversationMessageTests : IClassFixture<HarmonieWebAp
             caller.AccessToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await listResponse.Content.ReadFromJsonAsync<GetMessagesResponse>();
+        var payload = await listResponse.Content.ReadFromJsonAsync<GetMessagesResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Items.Should().ContainSingle();
         payload.Items[0].MessageId.Should().Be(visibleMessage.MessageId);
@@ -136,7 +136,8 @@ public sealed class DeleteConversationMessageTests : IClassFixture<HarmonieWebAp
     public async Task DeleteConversationMessage_WithoutAuthentication_ShouldReturnUnauthorized()
     {
         var response = await _client.DeleteAsync(
-            $"/api/conversations/{Guid.NewGuid()}/messages/{Guid.NewGuid()}");
+            $"/api/conversations/{Guid.NewGuid()}/messages/{Guid.NewGuid()}",
+            TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }

--- a/tests/Harmonie.API.IntegrationTests/Conversations/DeleteConversationTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/DeleteConversationTests.cs
@@ -41,7 +41,7 @@ public sealed class DeleteConversationTests : IClassFixture<HarmonieWebApplicati
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
     }
@@ -60,7 +60,7 @@ public sealed class DeleteConversationTests : IClassFixture<HarmonieWebApplicati
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
     }
@@ -68,7 +68,7 @@ public sealed class DeleteConversationTests : IClassFixture<HarmonieWebApplicati
     [Fact]
     public async Task DeleteConversation_WithoutAuthentication_ShouldReturnUnauthorized()
     {
-        var response = await _client.DeleteAsync($"/api/conversations/{Guid.NewGuid()}");
+        var response = await _client.DeleteAsync($"/api/conversations/{Guid.NewGuid()}", TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }

--- a/tests/Harmonie.API.IntegrationTests/Conversations/EditConversationMessageTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/EditConversationMessageTests.cs
@@ -33,7 +33,7 @@ public sealed class EditConversationMessageTests : IClassFixture<HarmonieWebAppl
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<EditMessageResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<EditMessageResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.MessageId.Should().Be(message.MessageId);
         payload.ConversationId.Should().Be(conversationId);
@@ -54,7 +54,7 @@ public sealed class EditConversationMessageTests : IClassFixture<HarmonieWebAppl
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
     }
@@ -75,7 +75,7 @@ public sealed class EditConversationMessageTests : IClassFixture<HarmonieWebAppl
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
     }
@@ -95,7 +95,7 @@ public sealed class EditConversationMessageTests : IClassFixture<HarmonieWebAppl
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Message.EditForbidden);
     }
@@ -114,7 +114,7 @@ public sealed class EditConversationMessageTests : IClassFixture<HarmonieWebAppl
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
     }
@@ -124,7 +124,8 @@ public sealed class EditConversationMessageTests : IClassFixture<HarmonieWebAppl
     {
         var response = await _client.PatchAsJsonAsync(
             $"/api/conversations/{Guid.NewGuid()}/messages/{Guid.NewGuid()}",
-            new EditMessageRequest("updated direct"));
+            new EditMessageRequest("updated direct"),
+            TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }

--- a/tests/Harmonie.API.IntegrationTests/Conversations/GetConversationMessagesTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/GetConversationMessagesTests.cs
@@ -30,7 +30,7 @@ public sealed class GetConversationMessagesTests : IClassFixture<HarmonieWebAppl
         var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, target.UserId);
 
         await ConversationTestHelper.SendConversationMessageAsync(_client, conversationId, "first direct", caller.AccessToken);
-        await Task.Delay(20);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
         await ConversationTestHelper.SendConversationMessageAsync(_client, conversationId, "second direct", target.AccessToken);
 
         var response = await _client.SendAuthorizedGetAsync(
@@ -39,7 +39,7 @@ public sealed class GetConversationMessagesTests : IClassFixture<HarmonieWebAppl
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<GetMessagesResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<GetMessagesResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.ConversationId.Should().Be(conversationId);
         payload.Items.Select(x => x.Content).Should().Equal("first direct", "second direct");
@@ -56,7 +56,7 @@ public sealed class GetConversationMessagesTests : IClassFixture<HarmonieWebAppl
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
     }
@@ -75,7 +75,7 @@ public sealed class GetConversationMessagesTests : IClassFixture<HarmonieWebAppl
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
     }
@@ -88,9 +88,9 @@ public sealed class GetConversationMessagesTests : IClassFixture<HarmonieWebAppl
         var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, target.UserId);
 
         await ConversationTestHelper.SendConversationMessageAsync(_client, conversationId, "first page item", caller.AccessToken);
-        await Task.Delay(20);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
         await ConversationTestHelper.SendConversationMessageAsync(_client, conversationId, "second page item", target.AccessToken);
-        await Task.Delay(20);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
         await ConversationTestHelper.SendConversationMessageAsync(_client, conversationId, "third page item", caller.AccessToken);
 
         var firstResponse = await _client.SendAuthorizedGetAsync(
@@ -99,7 +99,7 @@ public sealed class GetConversationMessagesTests : IClassFixture<HarmonieWebAppl
 
         firstResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var firstPayload = await firstResponse.Content.ReadFromJsonAsync<GetMessagesResponse>();
+        var firstPayload = await firstResponse.Content.ReadFromJsonAsync<GetMessagesResponse>(TestContext.Current.CancellationToken);
         firstPayload.Should().NotBeNull();
         firstPayload!.Items.Select(x => x.Content).Should().Equal("second page item", "third page item");
         firstPayload.NextCursor.Should().NotBeNullOrWhiteSpace();
@@ -110,7 +110,7 @@ public sealed class GetConversationMessagesTests : IClassFixture<HarmonieWebAppl
 
         secondResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var secondPayload = await secondResponse.Content.ReadFromJsonAsync<GetMessagesResponse>();
+        var secondPayload = await secondResponse.Content.ReadFromJsonAsync<GetMessagesResponse>(TestContext.Current.CancellationToken);
         secondPayload.Should().NotBeNull();
         secondPayload!.Items.Select(x => x.Content).Should().Equal("first page item");
         secondPayload.NextCursor.Should().BeNull();
@@ -124,7 +124,7 @@ public sealed class GetConversationMessagesTests : IClassFixture<HarmonieWebAppl
         var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, target.UserId);
 
         var visibleMessage = await ConversationTestHelper.SendConversationMessageAsync(_client, conversationId, "visible direct", caller.AccessToken);
-        await Task.Delay(20);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
         var deletedMessage = await ConversationTestHelper.SendConversationMessageAsync(_client, conversationId, "deleted direct", target.AccessToken);
 
         await SoftDeleteConversationMessageAsync(deletedMessage.MessageId);
@@ -135,7 +135,7 @@ public sealed class GetConversationMessagesTests : IClassFixture<HarmonieWebAppl
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<GetMessagesResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<GetMessagesResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Items.Should().ContainSingle();
         payload.Items[0].MessageId.Should().Be(visibleMessage.MessageId);
@@ -146,7 +146,8 @@ public sealed class GetConversationMessagesTests : IClassFixture<HarmonieWebAppl
     public async Task GetConversationMessages_WithoutAuthentication_ShouldReturnUnauthorized()
     {
         var response = await _client.GetAsync(
-            $"/api/conversations/{Guid.NewGuid()}/messages");
+            $"/api/conversations/{Guid.NewGuid()}/messages",
+            TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }

--- a/tests/Harmonie.API.IntegrationTests/Conversations/GroupConversationEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/GroupConversationEndpointTests.cs
@@ -37,7 +37,7 @@ public sealed class GroupConversationEndpointTests : IClassFixture<HarmonieWebAp
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var payload = await response.Content.ReadFromJsonAsync<CreateGroupConversationResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<CreateGroupConversationResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Type.Should().Be("group");
         payload.Name.Should().Be("Dev Team");
@@ -65,7 +65,7 @@ public sealed class GroupConversationEndpointTests : IClassFixture<HarmonieWebAp
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
     }
@@ -85,7 +85,7 @@ public sealed class GroupConversationEndpointTests : IClassFixture<HarmonieWebAp
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.User.NotFound);
     }
@@ -105,7 +105,7 @@ public sealed class GroupConversationEndpointTests : IClassFixture<HarmonieWebAp
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }
@@ -178,7 +178,7 @@ public sealed class GroupConversationEndpointTests : IClassFixture<HarmonieWebAp
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<ListConversationsResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<ListConversationsResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Conversations.Should().Contain(x =>
             x.ConversationId == group.ConversationId

--- a/tests/Harmonie.API.IntegrationTests/Conversations/SearchConversationMessagesEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/SearchConversationMessagesEndpointTests.cs
@@ -28,9 +28,9 @@ public sealed class SearchConversationMessagesEndpointTests : IClassFixture<Harm
         var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, target.UserId);
 
         await SendConversationMessageAsync(conversationId, "deploy alpha", caller.AccessToken);
-        await Task.Delay(20);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
         await SendConversationMessageAsync(conversationId, "random chatter", caller.AccessToken);
-        await Task.Delay(20);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
         await SendConversationMessageAsync(conversationId, "deploy beta", target.AccessToken);
 
         var response = await _client.SendAuthorizedGetAsync(
@@ -39,7 +39,7 @@ public sealed class SearchConversationMessagesEndpointTests : IClassFixture<Harm
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<SearchConversationMessagesResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<SearchConversationMessagesResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.ConversationId.Should().Be(conversationId);
         payload.Items.Select(item => item.Content).Should().Equal("deploy beta", "deploy alpha");
@@ -55,9 +55,9 @@ public sealed class SearchConversationMessagesEndpointTests : IClassFixture<Harm
         var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, target.UserId);
 
         await SendConversationMessageAsync(conversationId, "incident one", caller.AccessToken);
-        await Task.Delay(20);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
         await SendConversationMessageAsync(conversationId, "incident two", target.AccessToken);
-        await Task.Delay(20);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
         await SendConversationMessageAsync(conversationId, "incident three", caller.AccessToken);
 
         var firstResponse = await _client.SendAuthorizedGetAsync(
@@ -66,7 +66,7 @@ public sealed class SearchConversationMessagesEndpointTests : IClassFixture<Harm
 
         firstResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var firstPayload = await firstResponse.Content.ReadFromJsonAsync<SearchConversationMessagesResponse>();
+        var firstPayload = await firstResponse.Content.ReadFromJsonAsync<SearchConversationMessagesResponse>(TestContext.Current.CancellationToken);
         firstPayload.Should().NotBeNull();
         firstPayload!.Items.Select(item => item.Content).Should().Equal("incident three", "incident two");
         firstPayload.NextCursor.Should().NotBeNullOrWhiteSpace();
@@ -77,7 +77,7 @@ public sealed class SearchConversationMessagesEndpointTests : IClassFixture<Harm
 
         secondResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var secondPayload = await secondResponse.Content.ReadFromJsonAsync<SearchConversationMessagesResponse>();
+        var secondPayload = await secondResponse.Content.ReadFromJsonAsync<SearchConversationMessagesResponse>(TestContext.Current.CancellationToken);
         secondPayload.Should().NotBeNull();
         secondPayload!.Items.Select(item => item.Content).Should().Equal("incident one");
         secondPayload.NextCursor.Should().BeNull();
@@ -97,7 +97,7 @@ public sealed class SearchConversationMessagesEndpointTests : IClassFixture<Harm
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
     }
@@ -106,7 +106,8 @@ public sealed class SearchConversationMessagesEndpointTests : IClassFixture<Harm
     public async Task SearchConversationMessages_WithoutAuthentication_ShouldReturnUnauthorized()
     {
         var response = await _client.GetAsync(
-            $"/api/conversations/{Guid.NewGuid()}/messages/search?q=incident");
+            $"/api/conversations/{Guid.NewGuid()}/messages/search?q=incident",
+            TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }

--- a/tests/Harmonie.API.IntegrationTests/Conversations/SendConversationMessageTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/SendConversationMessageTests.cs
@@ -33,7 +33,7 @@ public sealed class SendConversationMessageTests : IClassFixture<HarmonieWebAppl
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var payload = await response.Content.ReadFromJsonAsync<SendMessageResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<SendMessageResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.ConversationId.Should().Be(conversationId);
         payload.AuthorUserId.Should().Be(caller.UserId);
@@ -54,7 +54,7 @@ public sealed class SendConversationMessageTests : IClassFixture<HarmonieWebAppl
             caller.AccessToken);
         sendResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>(TestContext.Current.CancellationToken);
         sendPayload.Should().NotBeNull();
         sendPayload!.Attachments.Should().ContainSingle();
         sendPayload.Attachments[0].FileId.Should().Be(uploadedFileId);
@@ -64,7 +64,7 @@ public sealed class SendConversationMessageTests : IClassFixture<HarmonieWebAppl
             caller.AccessToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var listPayload = await listResponse.Content.ReadFromJsonAsync<GetMessagesResponse>();
+        var listPayload = await listResponse.Content.ReadFromJsonAsync<GetMessagesResponse>(TestContext.Current.CancellationToken);
         listPayload.Should().NotBeNull();
         listPayload!.Items.Should().ContainSingle();
         listPayload.Items[0].Attachments.Should().ContainSingle();
@@ -83,7 +83,7 @@ public sealed class SendConversationMessageTests : IClassFixture<HarmonieWebAppl
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
     }
@@ -103,7 +103,7 @@ public sealed class SendConversationMessageTests : IClassFixture<HarmonieWebAppl
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
     }
@@ -113,7 +113,8 @@ public sealed class SendConversationMessageTests : IClassFixture<HarmonieWebAppl
     {
         var response = await _client.PostAsJsonAsync(
             $"/api/conversations/{Guid.NewGuid()}/messages",
-            new SendMessageRequest("hello direct"));
+            new SendMessageRequest("hello direct"),
+            TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }

--- a/tests/Harmonie.API.IntegrationTests/CorsPolicyTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/CorsPolicyTests.cs
@@ -21,7 +21,7 @@ public sealed class CorsPolicyTests : IClassFixture<HarmonieWebApplicationFactor
         request.Headers.Add("Origin", "http://localhost:3000");
         request.Headers.Add("Access-Control-Request-Method", "GET");
 
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
 
         response.Headers.TryGetValues("Access-Control-Allow-Origin", out var origins).Should().BeTrue();
         origins.Should().Contain("http://localhost:3000");

--- a/tests/Harmonie.API.IntegrationTests/Files/UploadsEndpointsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Files/UploadsEndpointsTests.cs
@@ -47,7 +47,7 @@ public sealed class UploadsEndpointsTests : IClassFixture<HarmonieWebApplication
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var payload = await response.Content.ReadFromJsonAsync<UploadFileResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<UploadFileResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Filename.Should().Be("avatar.png");
         payload.ContentType.Should().Be("image/png");
@@ -78,7 +78,7 @@ public sealed class UploadsEndpointsTests : IClassFixture<HarmonieWebApplication
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
         fakeStorage.UploadedObjects.Should().BeEmpty();
@@ -107,7 +107,7 @@ public sealed class UploadsEndpointsTests : IClassFixture<HarmonieWebApplication
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var payload = await response.Content.ReadFromJsonAsync<UploadFileResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<UploadFileResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Filename.Should().Be("icon.png");
         fakeStorage.UploadedObjects.Should().ContainSingle();
@@ -136,7 +136,7 @@ public sealed class UploadsEndpointsTests : IClassFixture<HarmonieWebApplication
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
         fakeStorage.UploadedObjects.Should().BeEmpty();
@@ -165,7 +165,7 @@ public sealed class UploadsEndpointsTests : IClassFixture<HarmonieWebApplication
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
         fakeStorage.UploadedObjects.Should().BeEmpty();
@@ -176,7 +176,7 @@ public sealed class UploadsEndpointsTests : IClassFixture<HarmonieWebApplication
     {
         using var content = CreateMultipartContent("avatar.png", "image/png", [1, 2, 3, 4]);
 
-        var response = await _client.PostAsync("/api/files/uploads", content);
+        var response = await _client.PostAsync("/api/files/uploads", content, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -213,7 +213,7 @@ public sealed class UploadsEndpointsTests : IClassFixture<HarmonieWebApplication
 
         var request = new HttpRequestMessage(HttpMethod.Delete, $"/api/files/{fileId}");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", user.AccessToken);
-        var response = await client.SendAsync(request);
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
         fakeStorage.UploadedObjects.Should().BeEmpty();
@@ -227,7 +227,7 @@ public sealed class UploadsEndpointsTests : IClassFixture<HarmonieWebApplication
 
         var request = new HttpRequestMessage(HttpMethod.Delete, $"/api/files/{unknownId}");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", user.AccessToken);
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
@@ -253,7 +253,7 @@ public sealed class UploadsEndpointsTests : IClassFixture<HarmonieWebApplication
 
         var request = new HttpRequestMessage(HttpMethod.Delete, $"/api/files/{fileId}");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", otherUser.AccessToken);
-        var response = await client.SendAsync(request);
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
         fakeStorage.UploadedObjects.Should().ContainSingle();
@@ -262,7 +262,7 @@ public sealed class UploadsEndpointsTests : IClassFixture<HarmonieWebApplication
     [Fact]
     public async Task DeleteFile_WithoutAuthentication_ShouldReturnUnauthorized()
     {
-        var response = await _client.DeleteAsync($"/api/files/{Guid.NewGuid()}");
+        var response = await _client.DeleteAsync($"/api/files/{Guid.NewGuid()}", TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }

--- a/tests/Harmonie.API.IntegrationTests/Files/UploadsLocalFileSystemE2ETests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Files/UploadsLocalFileSystemE2ETests.cs
@@ -41,7 +41,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
-        var payload = await response.Content.ReadFromJsonAsync<UploadFileResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<UploadFileResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(payload);
         Assert.Equal("hello.txt", payload!.Filename);
         Assert.Equal("text/plain", payload.ContentType);
@@ -51,7 +51,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
         var downloadResponse = await client.SendAuthorizedGetAsync($"/api/files/{payload.FileId}", user.AccessToken);
         Assert.Equal(HttpStatusCode.OK, downloadResponse.StatusCode);
 
-        var diskContent = await downloadResponse.Content.ReadAsStringAsync();
+        var diskContent = await downloadResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.Equal("hello from filesystem", diskContent);
     }
 
@@ -67,7 +67,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
         var uploadResponse = await SendAuthorizedMultipartAsync(client, "/api/files/uploads", multipart, user.AccessToken);
         Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
 
-        var payload = await uploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>();
+        var payload = await uploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(payload);
 
         var fileResponse = await client.SendAuthorizedGetAsync($"/api/files/{payload!.FileId}", user.AccessToken);
@@ -75,7 +75,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
         Assert.Equal(HttpStatusCode.OK, fileResponse.StatusCode);
         Assert.Equal("image/png", fileResponse.Content.Headers.ContentType?.MediaType);
 
-        var fileContent = await fileResponse.Content.ReadAsStringAsync();
+        var fileContent = await fileResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.Equal("fake-png-content", fileContent);
     }
 
@@ -91,10 +91,10 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
         var uploadResponse = await SendAuthorizedMultipartAsync(client, "/api/files/uploads", multipart, user.AccessToken);
         Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
 
-        var payload = await uploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>();
+        var payload = await uploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(payload);
 
-        var fileResponse = await client.GetAsync($"/api/files/{payload!.FileId}");
+        var fileResponse = await client.GetAsync($"/api/files/{payload!.FileId}", TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.Unauthorized, fileResponse.StatusCode);
     }
@@ -110,7 +110,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
         using var multipart = CreateMultipartContent("doc.txt", "text/plain", "test content");
 
         var response = await SendAuthorizedMultipartAsync(client, "/api/files/uploads", multipart, user.AccessToken);
-        var payload = await response.Content.ReadFromJsonAsync<UploadFileResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<UploadFileResponse>(TestContext.Current.CancellationToken);
 
         Assert.NotNull(payload);
         Assert.NotEqual(Guid.Empty, payload!.FileId);
@@ -131,7 +131,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
         var uploadResponse = await SendAuthorizedMultipartAsync(client, "/api/files/uploads", multipart, user.AccessToken);
         Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
 
-        var uploadPayload = await uploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>();
+        var uploadPayload = await uploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(uploadPayload);
 
         var createGuildResponse = await client.SendAuthorizedPostAsync(
@@ -140,7 +140,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
             user.AccessToken);
         Assert.Equal(HttpStatusCode.Created, createGuildResponse.StatusCode);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(createGuildPayload);
 
         var setIconResponse = await client.SendAuthorizedPatchAsync(
@@ -175,8 +175,8 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
         var replacementUploadResponse = await SendAuthorizedMultipartAsync(client, "/api/files/uploads", replacementMultipart, user.AccessToken);
         Assert.Equal(HttpStatusCode.Created, replacementUploadResponse.StatusCode);
 
-        var initialUploadPayload = await initialUploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>();
-        var replacementUploadPayload = await replacementUploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>();
+        var initialUploadPayload = await initialUploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>(TestContext.Current.CancellationToken);
+        var replacementUploadPayload = await replacementUploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(initialUploadPayload);
         Assert.NotNull(replacementUploadPayload);
 
@@ -186,7 +186,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
             user.AccessToken);
         Assert.Equal(HttpStatusCode.Created, createGuildResponse.StatusCode);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(guild);
 
         var setInitialIconResponse = await client.SendAuthorizedPatchAsync(
@@ -207,7 +207,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
         var newFileResponse = await client.SendAuthorizedGetAsync($"/api/files/{replacementUploadPayload.FileId}", user.AccessToken);
         Assert.Equal(HttpStatusCode.OK, newFileResponse.StatusCode);
 
-        var newFileContent = await newFileResponse.Content.ReadAsStringAsync();
+        var newFileContent = await newFileResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.Equal("replacement guild icon", newFileContent);
     }
 
@@ -223,7 +223,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
         var uploadResponse = await SendAuthorizedMultipartAsync(client, "/api/files/uploads", multipart, user.AccessToken);
         Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
 
-        var uploadPayload = await uploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>();
+        var uploadPayload = await uploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(uploadPayload);
 
         var createGuildResponse = await client.SendAuthorizedPostAsync(
@@ -236,7 +236,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
             user.AccessToken);
         Assert.Equal(HttpStatusCode.Created, createGuildResponse.StatusCode);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(createGuildPayload);
 
         var deleteGuildResponse = await client.SendAuthorizedDeleteAsync(
@@ -260,7 +260,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
         var uploadResponse = await SendAuthorizedMultipartAsync(client, "/api/files/uploads", multipart, user.AccessToken);
         Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
 
-        var uploadPayload = await uploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>();
+        var uploadPayload = await uploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(uploadPayload);
 
         var setAvatarResponse = await client.SendAuthorizedPatchAsync(
@@ -292,7 +292,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
         var uploadResponse = await SendAuthorizedMultipartAsync(client, "/api/files/uploads", multipart, user.AccessToken);
         Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
 
-        var uploadPayload = await uploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>();
+        var uploadPayload = await uploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(uploadPayload);
 
         var sendMessageResponse = await client.SendAuthorizedPostAsync(
@@ -301,7 +301,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
             user.AccessToken);
         Assert.Equal(HttpStatusCode.Created, sendMessageResponse.StatusCode);
 
-        var sendMessagePayload = await sendMessageResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        var sendMessagePayload = await sendMessageResponse.Content.ReadFromJsonAsync<SendMessageResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(sendMessagePayload);
 
         var deleteAttachmentResponse = await client.SendAuthorizedDeleteAsync(
@@ -327,7 +327,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
         var uploadResponse = await SendAuthorizedMultipartAsync(client, "/api/files/uploads", multipart, caller.AccessToken);
         Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
 
-        var uploadPayload = await uploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>();
+        var uploadPayload = await uploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(uploadPayload);
 
         var sendMessageResponse = await client.SendAuthorizedPostAsync(
@@ -336,7 +336,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
             caller.AccessToken);
         Assert.Equal(HttpStatusCode.Created, sendMessageResponse.StatusCode);
 
-        var sendMessagePayload = await sendMessageResponse.Content.ReadFromJsonAsync<ConversationSendMessageResponse>();
+        var sendMessagePayload = await sendMessageResponse.Content.ReadFromJsonAsync<ConversationSendMessageResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(sendMessagePayload);
 
         var deleteAttachmentResponse = await client.SendAuthorizedDeleteAsync(
@@ -360,7 +360,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
         var uploadResponse = await SendAuthorizedMultipartAsync(client, "/api/files/uploads", multipart, user.AccessToken);
         Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
 
-        var uploadPayload = await uploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>();
+        var uploadPayload = await uploadResponse.Content.ReadFromJsonAsync<UploadFileResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(uploadPayload);
 
         var createGuildResponse = await client.SendAuthorizedPostAsync(
@@ -369,7 +369,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
             user.AccessToken);
         Assert.Equal(HttpStatusCode.Created, createGuildResponse.StatusCode);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(guild);
 
         var setIconResponse = await client.SendAuthorizedPatchAsync(
@@ -418,7 +418,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
             accessToken);
         Assert.True(response.StatusCode is HttpStatusCode.Created or HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<OpenConversationResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<OpenConversationResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(payload);
         return payload!.ConversationId;
     }
@@ -434,7 +434,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
             accessToken);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
-        var payload = await response.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(payload);
         return payload!.GuildId;
     }
@@ -451,7 +451,7 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
             accessToken);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
-        var payload = await response.Content.ReadFromJsonAsync<CreateChannelResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<CreateChannelResponse>(TestContext.Current.CancellationToken);
         Assert.NotNull(payload);
         return payload!.ChannelId;
     }
@@ -476,6 +476,6 @@ public sealed class UploadsLocalFileSystemE2ETests : IClassFixture<HarmonieWebAp
     {
         using var request = new HttpRequestMessage(HttpMethod.Post, uri) { Content = content };
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-        return await client.SendAsync(request);
+        return await client.SendAsync(request, TestContext.Current.CancellationToken);
     }
 }

--- a/tests/Harmonie.API.IntegrationTests/Guilds/BanMemberEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/BanMemberEndpointTests.cs
@@ -39,7 +39,7 @@ public sealed class BanMemberEndpointTests : IClassFixture<HarmonieWebApplicatio
             owner.AccessToken);
         banResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var banPayload = await banResponse.Content.ReadFromJsonAsync<BanMemberResponse>();
+        var banPayload = await banResponse.Content.ReadFromJsonAsync<BanMemberResponse>(TestContext.Current.CancellationToken);
         banPayload.Should().NotBeNull();
         banPayload!.GuildId.Should().Be(guild.GuildId);
         banPayload.UserId.Should().Be(member.UserId);
@@ -52,7 +52,7 @@ public sealed class BanMemberEndpointTests : IClassFixture<HarmonieWebApplicatio
             owner.AccessToken);
         membersResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var membersPayload = await membersResponse.Content.ReadFromJsonAsync<GetGuildMembersResponse>();
+        var membersPayload = await membersResponse.Content.ReadFromJsonAsync<GetGuildMembersResponse>(TestContext.Current.CancellationToken);
         membersPayload.Should().NotBeNull();
         membersPayload!.Members.Should().NotContain(m => m.UserId == member.UserId);
     }
@@ -84,7 +84,7 @@ public sealed class BanMemberEndpointTests : IClassFixture<HarmonieWebApplicatio
             banned.AccessToken);
         acceptResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await acceptResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await acceptResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.UserBanned);
     }
@@ -108,7 +108,7 @@ public sealed class BanMemberEndpointTests : IClassFixture<HarmonieWebApplicatio
             member.AccessToken);
         banResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await banResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await banResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
     }
@@ -138,7 +138,7 @@ public sealed class BanMemberEndpointTests : IClassFixture<HarmonieWebApplicatio
             admin.AccessToken);
         banResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
 
-        var error = await banResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await banResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.OwnerCannotBeBanned);
     }
@@ -166,7 +166,7 @@ public sealed class BanMemberEndpointTests : IClassFixture<HarmonieWebApplicatio
             owner.AccessToken);
         secondBan.StatusCode.Should().Be(HttpStatusCode.Conflict);
 
-        var error = await secondBan.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await secondBan.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.AlreadyBanned);
     }
@@ -186,7 +186,7 @@ public sealed class BanMemberEndpointTests : IClassFixture<HarmonieWebApplicatio
         var channelsResponse = await _client.SendAuthorizedGetAsync(
             $"/api/guilds/{guild.GuildId}/channels",
             owner.AccessToken);
-        var channels = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>();
+        var channels = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
         var textChannel = channels!.Channels.First(c => c.Type == "Text");
 
         // Member sends a message
@@ -209,7 +209,7 @@ public sealed class BanMemberEndpointTests : IClassFixture<HarmonieWebApplicatio
             owner.AccessToken);
         messagesResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var messages = await messagesResponse.Content.ReadFromJsonAsync<GetMessagesResponse>();
+        var messages = await messagesResponse.Content.ReadFromJsonAsync<GetMessagesResponse>(TestContext.Current.CancellationToken);
         messages.Should().NotBeNull();
         messages!.Items.Should().NotContain(m => m.AuthorUserId == member.UserId);
     }
@@ -221,7 +221,8 @@ public sealed class BanMemberEndpointTests : IClassFixture<HarmonieWebApplicatio
 
         var banResponse = await _client.PostAsJsonAsync(
             $"/api/guilds/{nonExistentGuildId}/bans",
-            new BanMemberRequest(Guid.NewGuid()));
+            new BanMemberRequest(Guid.NewGuid()),
+            TestContext.Current.CancellationToken);
         banResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 }

--- a/tests/Harmonie.API.IntegrationTests/Guilds/CreateChannelTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/CreateChannelTests.cs
@@ -30,7 +30,7 @@ public sealed class CreateChannelTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         createResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await createResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await createResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }
@@ -52,7 +52,7 @@ public sealed class CreateChannelTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         createResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
 
-        var error = await createResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await createResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Channel.NameConflict);
     }

--- a/tests/Harmonie.API.IntegrationTests/Guilds/CreateGuildInviteEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/CreateGuildInviteEndpointTests.cs
@@ -30,7 +30,7 @@ public sealed class CreateGuildInviteEndpointTests : IClassFixture<HarmonieWebAp
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         guild.Should().NotBeNull();
 
         var inviteResponse = await _client.SendAuthorizedPostAsync(
@@ -39,7 +39,7 @@ public sealed class CreateGuildInviteEndpointTests : IClassFixture<HarmonieWebAp
             owner.AccessToken);
         inviteResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var invite = await inviteResponse.Content.ReadFromJsonAsync<CreateGuildInviteResponse>();
+        var invite = await inviteResponse.Content.ReadFromJsonAsync<CreateGuildInviteResponse>(TestContext.Current.CancellationToken);
         invite.Should().NotBeNull();
         invite!.GuildId.Should().Be(guild.GuildId);
         invite.CreatorId.Should().Be(owner.UserId);
@@ -61,7 +61,7 @@ public sealed class CreateGuildInviteEndpointTests : IClassFixture<HarmonieWebAp
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
 
         var inviteResponse = await _client.SendAuthorizedPostAsync(
             $"/api/guilds/{guild!.GuildId}/invites",
@@ -69,7 +69,7 @@ public sealed class CreateGuildInviteEndpointTests : IClassFixture<HarmonieWebAp
             owner.AccessToken);
         inviteResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var invite = await inviteResponse.Content.ReadFromJsonAsync<CreateGuildInviteResponse>();
+        var invite = await inviteResponse.Content.ReadFromJsonAsync<CreateGuildInviteResponse>(TestContext.Current.CancellationToken);
         invite.Should().NotBeNull();
         invite!.MaxUses.Should().BeNull();
         invite.ExpiresAtUtc.Should().BeNull();
@@ -87,7 +87,7 @@ public sealed class CreateGuildInviteEndpointTests : IClassFixture<HarmonieWebAp
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
 
         await GuildTestHelper.InviteMemberAsync(_client, guild!.GuildId, owner.AccessToken, member.AccessToken);
 
@@ -97,7 +97,7 @@ public sealed class CreateGuildInviteEndpointTests : IClassFixture<HarmonieWebAp
             member.AccessToken);
         inviteResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await inviteResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await inviteResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.InviteForbidden);
     }
@@ -114,7 +114,7 @@ public sealed class CreateGuildInviteEndpointTests : IClassFixture<HarmonieWebAp
             user.AccessToken);
         inviteResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await inviteResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await inviteResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.NotFound);
     }
@@ -126,7 +126,8 @@ public sealed class CreateGuildInviteEndpointTests : IClassFixture<HarmonieWebAp
 
         var inviteResponse = await _client.PostAsJsonAsync(
             $"/api/guilds/{nonExistentGuildId}/invites",
-            new CreateGuildInviteRequest());
+            new CreateGuildInviteRequest(),
+            TestContext.Current.CancellationToken);
         inviteResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
@@ -141,7 +142,7 @@ public sealed class CreateGuildInviteEndpointTests : IClassFixture<HarmonieWebAp
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
 
         var inviteResponse = await _client.SendAuthorizedPostAsync(
             $"/api/guilds/{guild!.GuildId}/invites",
@@ -149,7 +150,7 @@ public sealed class CreateGuildInviteEndpointTests : IClassFixture<HarmonieWebAp
             owner.AccessToken);
         inviteResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await inviteResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await inviteResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }
@@ -165,7 +166,7 @@ public sealed class CreateGuildInviteEndpointTests : IClassFixture<HarmonieWebAp
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
 
         var inviteResponse = await _client.SendAuthorizedPostAsync(
             $"/api/guilds/{guild!.GuildId}/invites",
@@ -173,7 +174,7 @@ public sealed class CreateGuildInviteEndpointTests : IClassFixture<HarmonieWebAp
             owner.AccessToken);
         inviteResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await inviteResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await inviteResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }
@@ -189,7 +190,7 @@ public sealed class CreateGuildInviteEndpointTests : IClassFixture<HarmonieWebAp
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
 
         var inviteResponse = await _client.SendAuthorizedPostAsync(
             $"/api/guilds/{guild!.GuildId}/invites",

--- a/tests/Harmonie.API.IntegrationTests/Guilds/CreateGuildTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/CreateGuildTests.cs
@@ -33,7 +33,7 @@ public sealed class CreateGuildTests : IClassFixture<HarmonieWebApplicationFacto
             userA.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
         createGuildPayload!.IconFileId.Should().BeNull();
         createGuildPayload.Icon.Should().BeNull();
@@ -45,7 +45,7 @@ public sealed class CreateGuildTests : IClassFixture<HarmonieWebApplicationFacto
             userB.AccessToken);
         channelsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>();
+        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
         channelsPayload.Should().NotBeNull();
 
         channelsPayload!.Channels.Should().HaveCount(2);
@@ -60,7 +60,7 @@ public sealed class CreateGuildTests : IClassFixture<HarmonieWebApplicationFacto
             userA.AccessToken);
         sendMessageResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var sendMessagePayload = await sendMessageResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        var sendMessagePayload = await sendMessageResponse.Content.ReadFromJsonAsync<SendMessageResponse>(TestContext.Current.CancellationToken);
         sendMessagePayload.Should().NotBeNull();
 
         sendMessagePayload!.Content.Should().Be("Hello team");
@@ -70,7 +70,7 @@ public sealed class CreateGuildTests : IClassFixture<HarmonieWebApplicationFacto
             userB.AccessToken);
         getMessagesResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var getMessagesPayload = await getMessagesResponse.Content.ReadFromJsonAsync<GetMessagesResponse>();
+        var getMessagesPayload = await getMessagesResponse.Content.ReadFromJsonAsync<GetMessagesResponse>(TestContext.Current.CancellationToken);
         getMessagesPayload.Should().NotBeNull();
 
         getMessagesPayload!.Items.Should().Contain(item => item.MessageId == sendMessagePayload.MessageId);
@@ -89,7 +89,7 @@ public sealed class CreateGuildTests : IClassFixture<HarmonieWebApplicationFacto
             owner.AccessToken);
         ownerGuildOneResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var ownerGuildOne = await ownerGuildOneResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var ownerGuildOne = await ownerGuildOneResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         ownerGuildOne.Should().NotBeNull();
 
         var ownerGuildTwoResponse = await _client.SendAuthorizedPostAsync(
@@ -98,7 +98,7 @@ public sealed class CreateGuildTests : IClassFixture<HarmonieWebApplicationFacto
             owner.AccessToken);
         ownerGuildTwoResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var ownerGuildTwo = await ownerGuildTwoResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var ownerGuildTwo = await ownerGuildTwoResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         ownerGuildTwo.Should().NotBeNull();
 
         var inviterGuildResponse = await _client.SendAuthorizedPostAsync(
@@ -107,7 +107,7 @@ public sealed class CreateGuildTests : IClassFixture<HarmonieWebApplicationFacto
             inviter.AccessToken);
         inviterGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var inviterGuild = await inviterGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var inviterGuild = await inviterGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         inviterGuild.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, inviterGuild!.GuildId, inviter.AccessToken, owner.AccessToken);
@@ -115,7 +115,7 @@ public sealed class CreateGuildTests : IClassFixture<HarmonieWebApplicationFacto
         var listResponse = await _client.SendAuthorizedGetAsync("/api/guilds", owner.AccessToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var listPayload = await listResponse.Content.ReadFromJsonAsync<ListUserGuildsResponse>();
+        var listPayload = await listResponse.Content.ReadFromJsonAsync<ListUserGuildsResponse>(TestContext.Current.CancellationToken);
         listPayload.Should().NotBeNull();
 
         listPayload!.Guilds.Should().HaveCount(3);
@@ -142,7 +142,7 @@ public sealed class CreateGuildTests : IClassFixture<HarmonieWebApplicationFacto
             owner.AccessToken);
         createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createPayload = await createResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createPayload = await createResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createPayload.Should().NotBeNull();
         createPayload!.IconFileId.Should().Be(iconFileId);
         createPayload.Icon.Should().NotBeNull();
@@ -153,7 +153,7 @@ public sealed class CreateGuildTests : IClassFixture<HarmonieWebApplicationFacto
         var listResponse = await _client.SendAuthorizedGetAsync("/api/guilds", owner.AccessToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var listPayload = await listResponse.Content.ReadFromJsonAsync<ListUserGuildsResponse>();
+        var listPayload = await listResponse.Content.ReadFromJsonAsync<ListUserGuildsResponse>(TestContext.Current.CancellationToken);
         listPayload.Should().NotBeNull();
         listPayload!.Guilds.Should().Contain(guild =>
             guild.GuildId == createPayload.GuildId
@@ -179,7 +179,7 @@ public sealed class CreateGuildTests : IClassFixture<HarmonieWebApplicationFacto
             owner.AccessToken);
         createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createPayload = await createResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createPayload = await createResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createPayload.Should().NotBeNull();
         createPayload!.IconFileId.Should().BeNull();
         createPayload.Icon.Should().NotBeNull();

--- a/tests/Harmonie.API.IntegrationTests/Guilds/DeleteGuildEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/DeleteGuildEndpointTests.cs
@@ -33,7 +33,7 @@ public sealed class DeleteGuildEndpointTests : IClassFixture<HarmonieWebApplicat
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -43,7 +43,7 @@ public sealed class DeleteGuildEndpointTests : IClassFixture<HarmonieWebApplicat
             owner.AccessToken);
         channelsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>();
+        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
         channelsPayload.Should().NotBeNull();
 
         var textChannel = channelsPayload!.Channels.First(channel => channel.Type == "Text");
@@ -72,14 +72,14 @@ public sealed class DeleteGuildEndpointTests : IClassFixture<HarmonieWebApplicat
         var ownerGuildsResponse = await _client.SendAuthorizedGetAsync("/api/guilds", owner.AccessToken);
         ownerGuildsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var ownerGuildsPayload = await ownerGuildsResponse.Content.ReadFromJsonAsync<ListUserGuildsResponse>();
+        var ownerGuildsPayload = await ownerGuildsResponse.Content.ReadFromJsonAsync<ListUserGuildsResponse>(TestContext.Current.CancellationToken);
         ownerGuildsPayload.Should().NotBeNull();
         ownerGuildsPayload!.Guilds.Should().NotContain(guild => guild.GuildId == createGuildPayload.GuildId);
 
         var memberGuildsResponse = await _client.SendAuthorizedGetAsync("/api/guilds", member.AccessToken);
         memberGuildsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var memberGuildsPayload = await memberGuildsResponse.Content.ReadFromJsonAsync<ListUserGuildsResponse>();
+        var memberGuildsPayload = await memberGuildsResponse.Content.ReadFromJsonAsync<ListUserGuildsResponse>(TestContext.Current.CancellationToken);
         memberGuildsPayload.Should().NotBeNull();
         memberGuildsPayload!.Guilds.Should().NotContain(guild => guild.GuildId == createGuildPayload.GuildId);
     }
@@ -96,7 +96,7 @@ public sealed class DeleteGuildEndpointTests : IClassFixture<HarmonieWebApplicat
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -106,7 +106,7 @@ public sealed class DeleteGuildEndpointTests : IClassFixture<HarmonieWebApplicat
             member.AccessToken);
         deleteGuildResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await deleteGuildResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await deleteGuildResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
     }
@@ -121,7 +121,7 @@ public sealed class DeleteGuildEndpointTests : IClassFixture<HarmonieWebApplicat
             user.AccessToken);
         deleteGuildResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await deleteGuildResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await deleteGuildResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.NotFound);
     }
@@ -129,7 +129,7 @@ public sealed class DeleteGuildEndpointTests : IClassFixture<HarmonieWebApplicat
     [Fact]
     public async Task DeleteGuild_WhenNotAuthenticated_ShouldReturn401()
     {
-        var createGuildResponse = await _client.DeleteAsync($"/api/guilds/{Guid.NewGuid()}");
+        var createGuildResponse = await _client.DeleteAsync($"/api/guilds/{Guid.NewGuid()}", TestContext.Current.CancellationToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 }

--- a/tests/Harmonie.API.IntegrationTests/Guilds/GuildChannelsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/GuildChannelsTests.cs
@@ -31,7 +31,7 @@ public sealed class GuildChannelsTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         var createChannelResponse = await _client.SendAuthorizedPostAsync(
@@ -40,7 +40,7 @@ public sealed class GuildChannelsTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         createChannelResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var payload = await createChannelResponse.Content.ReadFromJsonAsync<CreateChannelResponse>();
+        var payload = await createChannelResponse.Content.ReadFromJsonAsync<CreateChannelResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.GuildId.Should().Be(createGuildPayload.GuildId);
         payload.Name.Should().Be("announcements");
@@ -61,7 +61,7 @@ public sealed class GuildChannelsTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         var createChannelResponse = await _client.SendAuthorizedPostAsync(
@@ -70,7 +70,7 @@ public sealed class GuildChannelsTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         createChannelResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var payload = await createChannelResponse.Content.ReadFromJsonAsync<CreateChannelResponse>();
+        var payload = await createChannelResponse.Content.ReadFromJsonAsync<CreateChannelResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Type.Should().Be("Voice");
         payload.Name.Should().Be("Gaming");
@@ -88,7 +88,7 @@ public sealed class GuildChannelsTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -99,7 +99,7 @@ public sealed class GuildChannelsTests : IClassFixture<HarmonieWebApplicationFac
             member.AccessToken);
         createChannelResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await createChannelResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await createChannelResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
     }
@@ -116,7 +116,7 @@ public sealed class GuildChannelsTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         var createChannelResponse = await _client.SendAuthorizedPostAsync(
@@ -125,7 +125,7 @@ public sealed class GuildChannelsTests : IClassFixture<HarmonieWebApplicationFac
             outsider.AccessToken);
         createChannelResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await createChannelResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await createChannelResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
     }
@@ -142,7 +142,7 @@ public sealed class GuildChannelsTests : IClassFixture<HarmonieWebApplicationFac
             user.AccessToken);
         createChannelResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await createChannelResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await createChannelResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.NotFound);
     }
@@ -154,7 +154,8 @@ public sealed class GuildChannelsTests : IClassFixture<HarmonieWebApplicationFac
 
         var createChannelResponse = await _client.PostAsJsonAsync(
             $"/api/guilds/{nonExistentGuildId}/channels",
-            new CreateChannelRequest("anon-channel", ChannelTypeInput.Text, 0));
+            new CreateChannelRequest("anon-channel", ChannelTypeInput.Text, 0),
+            TestContext.Current.CancellationToken);
         createChannelResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
@@ -169,7 +170,7 @@ public sealed class GuildChannelsTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         var createChannelResponse = await SendAuthorizedPostRawAsync(
@@ -178,7 +179,7 @@ public sealed class GuildChannelsTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         createChannelResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await createChannelResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await createChannelResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
         error.Errors.Should().ContainKey("type");
@@ -196,7 +197,7 @@ public sealed class GuildChannelsTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         var createChannelResponse = await _client.SendAuthorizedPostAsync(
@@ -205,7 +206,7 @@ public sealed class GuildChannelsTests : IClassFixture<HarmonieWebApplicationFac
             owner.AccessToken);
         createChannelResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await createChannelResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await createChannelResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.DomainRuleViolation);
     }
@@ -220,6 +221,6 @@ public sealed class GuildChannelsTests : IClassFixture<HarmonieWebApplicationFac
             Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
         };
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-        return await _client.SendAsync(request);
+        return await _client.SendAsync(request, TestContext.Current.CancellationToken);
     }
 }

--- a/tests/Harmonie.API.IntegrationTests/Guilds/GuildInvitesTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/GuildInvitesTests.cs
@@ -30,7 +30,7 @@ public sealed class GuildInvitesTests : IClassFixture<HarmonieWebApplicationFact
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -40,7 +40,7 @@ public sealed class GuildInvitesTests : IClassFixture<HarmonieWebApplicationFact
             member.AccessToken);
         membersResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var membersPayload = await membersResponse.Content.ReadFromJsonAsync<GetGuildMembersResponse>();
+        var membersPayload = await membersResponse.Content.ReadFromJsonAsync<GetGuildMembersResponse>(TestContext.Current.CancellationToken);
         membersPayload.Should().NotBeNull();
 
         membersPayload!.GuildId.Should().Be(createGuildPayload.GuildId);

--- a/tests/Harmonie.API.IntegrationTests/Guilds/GuildVoiceParticipantsEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/GuildVoiceParticipantsEndpointTests.cs
@@ -40,7 +40,7 @@ public sealed class GuildVoiceParticipantsEndpointTests : IClassFixture<Harmonie
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -50,7 +50,7 @@ public sealed class GuildVoiceParticipantsEndpointTests : IClassFixture<Harmonie
             member.AccessToken);
         channelsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>();
+        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
         channelsPayload.Should().NotBeNull();
 
         var voiceChannels = channelsPayload!.Channels
@@ -84,7 +84,7 @@ public sealed class GuildVoiceParticipantsEndpointTests : IClassFixture<Harmonie
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<GetGuildVoiceParticipantsResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<GetGuildVoiceParticipantsResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Channels.Should().HaveCount(1);
         payload.Channels.Should().Contain(channel =>
@@ -106,7 +106,7 @@ public sealed class GuildVoiceParticipantsEndpointTests : IClassFixture<Harmonie
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         var response = await _client.SendAuthorizedGetAsync(
@@ -115,7 +115,7 @@ public sealed class GuildVoiceParticipantsEndpointTests : IClassFixture<Harmonie
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
     }

--- a/tests/Harmonie.API.IntegrationTests/Guilds/LeaveGuildTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/LeaveGuildTests.cs
@@ -30,7 +30,7 @@ public sealed class LeaveGuildTests : IClassFixture<HarmonieWebApplicationFactor
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -52,7 +52,7 @@ public sealed class LeaveGuildTests : IClassFixture<HarmonieWebApplicationFactor
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         var leaveResponse = await _client.SendAuthorizedPostNoBodyAsync(
@@ -60,7 +60,7 @@ public sealed class LeaveGuildTests : IClassFixture<HarmonieWebApplicationFactor
             owner.AccessToken);
         leaveResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
 
-        var error = await leaveResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await leaveResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.OwnerCannotLeave);
     }
@@ -77,7 +77,7 @@ public sealed class LeaveGuildTests : IClassFixture<HarmonieWebApplicationFactor
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         var leaveResponse = await _client.SendAuthorizedPostNoBodyAsync(
@@ -85,7 +85,7 @@ public sealed class LeaveGuildTests : IClassFixture<HarmonieWebApplicationFactor
             outsider.AccessToken);
         leaveResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await leaveResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await leaveResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
     }
@@ -101,12 +101,13 @@ public sealed class LeaveGuildTests : IClassFixture<HarmonieWebApplicationFactor
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         var leaveResponse = await _client.PostAsync(
             $"/api/guilds/{createGuildPayload!.GuildId}/leave",
-            null);
+            null,
+            TestContext.Current.CancellationToken);
         leaveResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
@@ -121,7 +122,7 @@ public sealed class LeaveGuildTests : IClassFixture<HarmonieWebApplicationFactor
             user.AccessToken);
         leaveResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await leaveResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await leaveResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.NotFound);
     }

--- a/tests/Harmonie.API.IntegrationTests/Guilds/ListBansEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/ListBansEndpointTests.cs
@@ -32,7 +32,7 @@ public sealed class ListBansEndpointTests : IClassFixture<HarmonieWebApplication
             owner.AccessToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<ListBansResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<ListBansResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.GuildId.Should().Be(guild.GuildId);
         payload.Bans.Should().BeEmpty();
@@ -62,7 +62,7 @@ public sealed class ListBansEndpointTests : IClassFixture<HarmonieWebApplication
             owner.AccessToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<ListBansResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<ListBansResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.GuildId.Should().Be(guild.GuildId);
         payload.Bans.Should().HaveCount(1);
@@ -90,7 +90,7 @@ public sealed class ListBansEndpointTests : IClassFixture<HarmonieWebApplication
             member.AccessToken);
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
     }
@@ -106,7 +106,7 @@ public sealed class ListBansEndpointTests : IClassFixture<HarmonieWebApplication
             owner.AccessToken);
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.NotFound);
     }
@@ -115,7 +115,8 @@ public sealed class ListBansEndpointTests : IClassFixture<HarmonieWebApplication
     public async Task ListBans_WhenNotAuthenticated_ShouldReturn401()
     {
         var response = await _client.GetAsync(
-            $"/api/guilds/{Guid.NewGuid()}/bans");
+            $"/api/guilds/{Guid.NewGuid()}/bans",
+            TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
@@ -149,7 +150,7 @@ public sealed class ListBansEndpointTests : IClassFixture<HarmonieWebApplication
             owner.AccessToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<ListBansResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<ListBansResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Bans.Should().BeEmpty();
     }

--- a/tests/Harmonie.API.IntegrationTests/Guilds/ListGuildInvitesEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/ListGuildInvitesEndpointTests.cs
@@ -31,7 +31,7 @@ public sealed class ListGuildInvitesEndpointTests : IClassFixture<HarmonieWebApp
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         guild.Should().NotBeNull();
 
         var listResponse = await _client.SendAuthorizedGetAsync(
@@ -39,7 +39,7 @@ public sealed class ListGuildInvitesEndpointTests : IClassFixture<HarmonieWebApp
             owner.AccessToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var result = await listResponse.Content.ReadFromJsonAsync<ListGuildInvitesResponse>();
+        var result = await listResponse.Content.ReadFromJsonAsync<ListGuildInvitesResponse>(TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
         result!.GuildId.Should().Be(guild.GuildId);
         result.Invites.Should().BeEmpty();
@@ -56,7 +56,7 @@ public sealed class ListGuildInvitesEndpointTests : IClassFixture<HarmonieWebApp
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         guild.Should().NotBeNull();
 
         var invite1Response = await _client.SendAuthorizedPostAsync(
@@ -76,7 +76,7 @@ public sealed class ListGuildInvitesEndpointTests : IClassFixture<HarmonieWebApp
             owner.AccessToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var result = await listResponse.Content.ReadFromJsonAsync<ListGuildInvitesResponse>();
+        var result = await listResponse.Content.ReadFromJsonAsync<ListGuildInvitesResponse>(TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
         result!.GuildId.Should().Be(guild.GuildId);
         result.Invites.Should().HaveCount(2);
@@ -100,7 +100,7 @@ public sealed class ListGuildInvitesEndpointTests : IClassFixture<HarmonieWebApp
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         guild.Should().NotBeNull();
 
         // Valid invite (no limits)
@@ -115,7 +115,7 @@ public sealed class ListGuildInvitesEndpointTests : IClassFixture<HarmonieWebApp
             owner.AccessToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var result = await listResponse.Content.ReadFromJsonAsync<ListGuildInvitesResponse>();
+        var result = await listResponse.Content.ReadFromJsonAsync<ListGuildInvitesResponse>(TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
         result!.Invites.Should().ContainSingle();
         result.Invites[0].IsExpired.Should().BeFalse();
@@ -135,7 +135,7 @@ public sealed class ListGuildInvitesEndpointTests : IClassFixture<HarmonieWebApp
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         guild.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, guild!.GuildId, owner.AccessToken, member.AccessToken);
@@ -145,7 +145,7 @@ public sealed class ListGuildInvitesEndpointTests : IClassFixture<HarmonieWebApp
             member.AccessToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await listResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await listResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.InviteForbidden);
     }
@@ -161,7 +161,7 @@ public sealed class ListGuildInvitesEndpointTests : IClassFixture<HarmonieWebApp
             user.AccessToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await listResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await listResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.NotFound);
     }
@@ -171,7 +171,7 @@ public sealed class ListGuildInvitesEndpointTests : IClassFixture<HarmonieWebApp
     {
         var nonExistentGuildId = Guid.NewGuid();
 
-        var listResponse = await _client.GetAsync($"/api/guilds/{nonExistentGuildId}/invites");
+        var listResponse = await _client.GetAsync($"/api/guilds/{nonExistentGuildId}/invites", TestContext.Current.CancellationToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
@@ -185,7 +185,7 @@ public sealed class ListGuildInvitesEndpointTests : IClassFixture<HarmonieWebApp
             user.AccessToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await listResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await listResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }
@@ -201,7 +201,7 @@ public sealed class ListGuildInvitesEndpointTests : IClassFixture<HarmonieWebApp
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         guild.Should().NotBeNull();
 
         var first = await _client.SendAuthorizedPostAsync(
@@ -209,21 +209,21 @@ public sealed class ListGuildInvitesEndpointTests : IClassFixture<HarmonieWebApp
             new CreateGuildInviteRequest(MaxUses: 1),
             owner.AccessToken);
         first.StatusCode.Should().Be(HttpStatusCode.Created);
-        var firstInvite = await first.Content.ReadFromJsonAsync<CreateGuildInviteResponse>();
+        var firstInvite = await first.Content.ReadFromJsonAsync<CreateGuildInviteResponse>(TestContext.Current.CancellationToken);
 
         var second = await _client.SendAuthorizedPostAsync(
             $"/api/guilds/{guild.GuildId}/invites",
             new CreateGuildInviteRequest(MaxUses: 2),
             owner.AccessToken);
         second.StatusCode.Should().Be(HttpStatusCode.Created);
-        var secondInvite = await second.Content.ReadFromJsonAsync<CreateGuildInviteResponse>();
+        var secondInvite = await second.Content.ReadFromJsonAsync<CreateGuildInviteResponse>(TestContext.Current.CancellationToken);
 
         var listResponse = await _client.SendAuthorizedGetAsync(
             $"/api/guilds/{guild.GuildId}/invites",
             owner.AccessToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var result = await listResponse.Content.ReadFromJsonAsync<ListGuildInvitesResponse>();
+        var result = await listResponse.Content.ReadFromJsonAsync<ListGuildInvitesResponse>(TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
         result!.Invites.Should().HaveCount(2);
         // Most recent first

--- a/tests/Harmonie.API.IntegrationTests/Guilds/RemoveMemberTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/RemoveMemberTests.cs
@@ -30,7 +30,7 @@ public sealed class RemoveMemberTests : IClassFixture<HarmonieWebApplicationFact
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -54,7 +54,7 @@ public sealed class RemoveMemberTests : IClassFixture<HarmonieWebApplicationFact
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -66,7 +66,7 @@ public sealed class RemoveMemberTests : IClassFixture<HarmonieWebApplicationFact
             member.AccessToken);
         removeResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await removeResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await removeResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
     }
@@ -83,11 +83,12 @@ public sealed class RemoveMemberTests : IClassFixture<HarmonieWebApplicationFact
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         var removeResponse = await _client.DeleteAsync(
-            $"/api/guilds/{createGuildPayload!.GuildId}/members/{member.UserId}");
+            $"/api/guilds/{createGuildPayload!.GuildId}/members/{member.UserId}",
+            TestContext.Current.CancellationToken);
         removeResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
@@ -105,7 +106,7 @@ public sealed class RemoveMemberTests : IClassFixture<HarmonieWebApplicationFact
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         var removeResponse = await _client.SendAuthorizedDeleteAsync(
@@ -113,7 +114,7 @@ public sealed class RemoveMemberTests : IClassFixture<HarmonieWebApplicationFact
             owner.AccessToken);
         removeResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
 
-        var error = await removeResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await removeResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.OwnerCannotBeRemoved);
     }
@@ -130,7 +131,7 @@ public sealed class RemoveMemberTests : IClassFixture<HarmonieWebApplicationFact
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         var removeResponse = await _client.SendAuthorizedDeleteAsync(
@@ -138,7 +139,7 @@ public sealed class RemoveMemberTests : IClassFixture<HarmonieWebApplicationFact
             owner.AccessToken);
         removeResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await removeResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await removeResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.MemberNotFound);
     }

--- a/tests/Harmonie.API.IntegrationTests/Guilds/ReorderChannelsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/ReorderChannelsTests.cs
@@ -36,7 +36,7 @@ public sealed class ReorderChannelsTests : IClassFixture<HarmonieWebApplicationF
             owner.AccessToken);
         reorderResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await reorderResponse.Content.ReadFromJsonAsync<ReorderChannelsResponse>();
+        var payload = await reorderResponse.Content.ReadFromJsonAsync<ReorderChannelsResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.GuildId.Should().Be(guildId);
 
@@ -68,7 +68,7 @@ public sealed class ReorderChannelsTests : IClassFixture<HarmonieWebApplicationF
             owner.AccessToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var channels = await getResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>();
+        var channels = await getResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
         channels.Should().NotBeNull();
 
         var getCh1 = channels!.Channels.First(c => c.ChannelId == ch1);
@@ -131,7 +131,8 @@ public sealed class ReorderChannelsTests : IClassFixture<HarmonieWebApplicationF
             $"/api/guilds/{Guid.NewGuid()}/channels/reorder",
             JsonContent.Create(new ReorderChannelsRequest([
                 new ReorderChannelsItemRequest(Guid.NewGuid(), 0)
-            ])));
+            ])),
+            TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }

--- a/tests/Harmonie.API.IntegrationTests/Guilds/RevokeInviteEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/RevokeInviteEndpointTests.cs
@@ -49,7 +49,7 @@ public sealed class RevokeInviteEndpointTests : IClassFixture<HarmonieWebApplica
             owner.AccessToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var result = await listResponse.Content.ReadFromJsonAsync<ListGuildInvitesResponse>();
+        var result = await listResponse.Content.ReadFromJsonAsync<ListGuildInvitesResponse>(TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
         result!.Invites.Should().ContainSingle();
         result.Invites[0].Code.Should().Be(invite.Code);
@@ -69,7 +69,7 @@ public sealed class RevokeInviteEndpointTests : IClassFixture<HarmonieWebApplica
             new CreateGuildRequest($"Revoke Creator Guild {Guid.NewGuid():N}"[..40]),
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         guild.Should().NotBeNull();
 
         // Add second user as admin
@@ -86,7 +86,7 @@ public sealed class RevokeInviteEndpointTests : IClassFixture<HarmonieWebApplica
             new CreateGuildInviteRequest(),
             owner.AccessToken);
         inviteResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-        var invite = await inviteResponse.Content.ReadFromJsonAsync<CreateGuildInviteResponse>();
+        var invite = await inviteResponse.Content.ReadFromJsonAsync<CreateGuildInviteResponse>(TestContext.Current.CancellationToken);
         invite.Should().NotBeNull();
 
         // Second admin (not the creator) can also revoke because they are an admin
@@ -108,7 +108,7 @@ public sealed class RevokeInviteEndpointTests : IClassFixture<HarmonieWebApplica
             new CreateGuildRequest($"Revoke Forbidden Guild {Guid.NewGuid():N}"[..40]),
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         guild.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, guild!.GuildId, owner.AccessToken, member.AccessToken);
@@ -119,7 +119,7 @@ public sealed class RevokeInviteEndpointTests : IClassFixture<HarmonieWebApplica
             new CreateGuildInviteRequest(),
             owner.AccessToken);
         inviteResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-        var invite = await inviteResponse.Content.ReadFromJsonAsync<CreateGuildInviteResponse>();
+        var invite = await inviteResponse.Content.ReadFromJsonAsync<CreateGuildInviteResponse>(TestContext.Current.CancellationToken);
         invite.Should().NotBeNull();
 
         // Member (not admin, not creator) tries to revoke
@@ -129,7 +129,7 @@ public sealed class RevokeInviteEndpointTests : IClassFixture<HarmonieWebApplica
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Invite.RevokeForbidden);
     }
@@ -143,7 +143,7 @@ public sealed class RevokeInviteEndpointTests : IClassFixture<HarmonieWebApplica
             new CreateGuildRequest($"Revoke NotFound Guild {Guid.NewGuid():N}"[..40]),
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         guild.Should().NotBeNull();
 
         var response = await _client.SendAuthorizedDeleteAsync(
@@ -152,7 +152,7 @@ public sealed class RevokeInviteEndpointTests : IClassFixture<HarmonieWebApplica
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Invite.NotFound);
     }
@@ -160,7 +160,7 @@ public sealed class RevokeInviteEndpointTests : IClassFixture<HarmonieWebApplica
     [Fact]
     public async Task RevokeInvite_WhenNotAuthenticated_ShouldReturn401()
     {
-        var response = await _client.DeleteAsync($"/api/guilds/{Guid.NewGuid()}/invites/ABCD1234");
+        var response = await _client.DeleteAsync($"/api/guilds/{Guid.NewGuid()}/invites/ABCD1234", TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
@@ -175,7 +175,7 @@ public sealed class RevokeInviteEndpointTests : IClassFixture<HarmonieWebApplica
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }
@@ -191,7 +191,7 @@ public sealed class RevokeInviteEndpointTests : IClassFixture<HarmonieWebApplica
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }
@@ -206,21 +206,21 @@ public sealed class RevokeInviteEndpointTests : IClassFixture<HarmonieWebApplica
             new CreateGuildRequest($"Revoke Other Guild 1 {Guid.NewGuid():N}"[..40]),
             owner.AccessToken);
         guild1Response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var guild1 = await guild1Response.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild1 = await guild1Response.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
 
         var guild2Response = await _client.SendAuthorizedPostAsync(
             "/api/guilds",
             new CreateGuildRequest($"Revoke Other Guild 2 {Guid.NewGuid():N}"[..40]),
             owner.AccessToken);
         guild2Response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var guild2 = await guild2Response.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild2 = await guild2Response.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
 
         var inviteResponse = await _client.SendAuthorizedPostAsync(
             $"/api/guilds/{guild1!.GuildId}/invites",
             new CreateGuildInviteRequest(),
             owner.AccessToken);
         inviteResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-        var invite = await inviteResponse.Content.ReadFromJsonAsync<CreateGuildInviteResponse>();
+        var invite = await inviteResponse.Content.ReadFromJsonAsync<CreateGuildInviteResponse>(TestContext.Current.CancellationToken);
         invite.Should().NotBeNull();
 
         // Try to revoke guild1's invite via guild2's route
@@ -238,7 +238,7 @@ public sealed class RevokeInviteEndpointTests : IClassFixture<HarmonieWebApplica
             new CreateGuildRequest($"Revoke Test Guild {Guid.NewGuid():N}"[..40]),
             accessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         guild.Should().NotBeNull();
 
         var inviteResponse = await _client.SendAuthorizedPostAsync(
@@ -246,7 +246,7 @@ public sealed class RevokeInviteEndpointTests : IClassFixture<HarmonieWebApplica
             new CreateGuildInviteRequest(),
             accessToken);
         inviteResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-        var invite = await inviteResponse.Content.ReadFromJsonAsync<CreateGuildInviteResponse>();
+        var invite = await inviteResponse.Content.ReadFromJsonAsync<CreateGuildInviteResponse>(TestContext.Current.CancellationToken);
         invite.Should().NotBeNull();
 
         return (guild, invite!);

--- a/tests/Harmonie.API.IntegrationTests/Guilds/TransferOwnershipTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/TransferOwnershipTests.cs
@@ -31,7 +31,7 @@ public sealed class TransferOwnershipTests : IClassFixture<HarmonieWebApplicatio
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -56,7 +56,7 @@ public sealed class TransferOwnershipTests : IClassFixture<HarmonieWebApplicatio
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -69,7 +69,7 @@ public sealed class TransferOwnershipTests : IClassFixture<HarmonieWebApplicatio
             member.AccessToken);
         transferResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await transferResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await transferResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
     }
@@ -85,7 +85,7 @@ public sealed class TransferOwnershipTests : IClassFixture<HarmonieWebApplicatio
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         var transferResponse = await _client.SendAuthorizedPostAsync(
@@ -94,7 +94,7 @@ public sealed class TransferOwnershipTests : IClassFixture<HarmonieWebApplicatio
             owner.AccessToken);
         transferResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
 
-        var error = await transferResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await transferResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.OwnerTransferToSelf);
     }
@@ -111,7 +111,7 @@ public sealed class TransferOwnershipTests : IClassFixture<HarmonieWebApplicatio
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         var transferResponse = await _client.SendAuthorizedPostAsync(
@@ -120,7 +120,7 @@ public sealed class TransferOwnershipTests : IClassFixture<HarmonieWebApplicatio
             owner.AccessToken);
         transferResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await transferResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await transferResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.MemberNotFound);
     }
@@ -138,7 +138,7 @@ public sealed class TransferOwnershipTests : IClassFixture<HarmonieWebApplicatio
             user.AccessToken);
         transferResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await transferResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await transferResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.NotFound);
     }
@@ -151,7 +151,8 @@ public sealed class TransferOwnershipTests : IClassFixture<HarmonieWebApplicatio
 
         var transferResponse = await _client.PostAsJsonAsync(
             $"/api/guilds/{nonExistentGuildId}/owner/transfer",
-            new TransferOwnershipRequest(target.UserId));
+            new TransferOwnershipRequest(target.UserId),
+            TestContext.Current.CancellationToken);
         transferResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 }

--- a/tests/Harmonie.API.IntegrationTests/Guilds/UnbanMemberEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/UnbanMemberEndpointTests.cs
@@ -89,7 +89,7 @@ public sealed class UnbanMemberEndpointTests : IClassFixture<HarmonieWebApplicat
             owner.AccessToken);
         unbanResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await unbanResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await unbanResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.NotBanned);
     }
@@ -120,7 +120,7 @@ public sealed class UnbanMemberEndpointTests : IClassFixture<HarmonieWebApplicat
             member.AccessToken);
         unbanResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await unbanResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await unbanResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
     }
@@ -132,7 +132,8 @@ public sealed class UnbanMemberEndpointTests : IClassFixture<HarmonieWebApplicat
         var nonExistentUserId = Guid.NewGuid();
 
         var response = await _client.DeleteAsync(
-            $"/api/guilds/{nonExistentGuildId}/bans/{nonExistentUserId}");
+            $"/api/guilds/{nonExistentGuildId}/bans/{nonExistentUserId}",
+            TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 }

--- a/tests/Harmonie.API.IntegrationTests/Guilds/UpdateGuildTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/UpdateGuildTests.cs
@@ -32,7 +32,7 @@ public sealed class UpdateGuildTests : IClassFixture<HarmonieWebApplicationFacto
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
         var iconFileId = await UploadTestHelper.UploadFileAsync(_client, owner.AccessToken, "guild-icon.png", "image/png", "guild icon");
 
@@ -57,7 +57,7 @@ public sealed class UpdateGuildTests : IClassFixture<HarmonieWebApplicationFacto
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<UpdateGuildResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<UpdateGuildResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.GuildId.Should().Be(createGuildPayload.GuildId);
         payload.Name.Should().Be("Renamed Guild");
@@ -70,7 +70,7 @@ public sealed class UpdateGuildTests : IClassFixture<HarmonieWebApplicationFacto
         var listResponse = await _client.SendAuthorizedGetAsync("/api/guilds", owner.AccessToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var listPayload = await listResponse.Content.ReadFromJsonAsync<ListUserGuildsResponse>();
+        var listPayload = await listResponse.Content.ReadFromJsonAsync<ListUserGuildsResponse>(TestContext.Current.CancellationToken);
         listPayload.Should().NotBeNull();
         listPayload!.Guilds.Should().Contain(guild =>
             guild.GuildId == createGuildPayload.GuildId
@@ -94,7 +94,7 @@ public sealed class UpdateGuildTests : IClassFixture<HarmonieWebApplicationFacto
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
         var iconFileId = await UploadTestHelper.UploadFileAsync(_client, owner.AccessToken, "admin-guild.png", "image/png", "admin guild icon");
 
@@ -127,7 +127,7 @@ public sealed class UpdateGuildTests : IClassFixture<HarmonieWebApplicationFacto
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<UpdateGuildResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<UpdateGuildResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.IconFileId.Should().BeNull();
         payload.Icon.Should().BeNull();
@@ -145,7 +145,7 @@ public sealed class UpdateGuildTests : IClassFixture<HarmonieWebApplicationFacto
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         guild.Should().NotBeNull();
 
         var seedResponse = await _client.SendAuthorizedPatchAsync(
@@ -163,7 +163,7 @@ public sealed class UpdateGuildTests : IClassFixture<HarmonieWebApplicationFacto
         var listResponse = await _client.SendAuthorizedGetAsync("/api/guilds", owner.AccessToken);
         listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var listPayload = await listResponse.Content.ReadFromJsonAsync<ListUserGuildsResponse>();
+        var listPayload = await listResponse.Content.ReadFromJsonAsync<ListUserGuildsResponse>(TestContext.Current.CancellationToken);
         listPayload.Should().NotBeNull();
         listPayload!.Guilds.Should().Contain(item =>
             item.GuildId == guild.GuildId &&
@@ -181,7 +181,7 @@ public sealed class UpdateGuildTests : IClassFixture<HarmonieWebApplicationFacto
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         guild.Should().NotBeNull();
 
         var response = await _client.SendAuthorizedDeleteAsync(
@@ -190,7 +190,7 @@ public sealed class UpdateGuildTests : IClassFixture<HarmonieWebApplicationFacto
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Upload.NotFound);
     }
@@ -208,7 +208,7 @@ public sealed class UpdateGuildTests : IClassFixture<HarmonieWebApplicationFacto
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         guild.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, guild!.GuildId, owner.AccessToken, member.AccessToken);
@@ -225,7 +225,7 @@ public sealed class UpdateGuildTests : IClassFixture<HarmonieWebApplicationFacto
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
     }
@@ -242,7 +242,7 @@ public sealed class UpdateGuildTests : IClassFixture<HarmonieWebApplicationFacto
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -254,7 +254,7 @@ public sealed class UpdateGuildTests : IClassFixture<HarmonieWebApplicationFacto
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
     }

--- a/tests/Harmonie.API.IntegrationTests/Guilds/UpdateMemberRoleTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/UpdateMemberRoleTests.cs
@@ -32,7 +32,7 @@ public sealed class UpdateMemberRoleTests : IClassFixture<HarmonieWebApplication
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -56,7 +56,7 @@ public sealed class UpdateMemberRoleTests : IClassFixture<HarmonieWebApplication
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, otherAdmin.AccessToken);
@@ -86,7 +86,7 @@ public sealed class UpdateMemberRoleTests : IClassFixture<HarmonieWebApplication
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -99,7 +99,7 @@ public sealed class UpdateMemberRoleTests : IClassFixture<HarmonieWebApplication
             member.AccessToken);
         updateRoleResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await updateRoleResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await updateRoleResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
     }
@@ -115,7 +115,7 @@ public sealed class UpdateMemberRoleTests : IClassFixture<HarmonieWebApplication
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         var updateRoleResponse = await _client.SendAuthorizedPutAsync(
@@ -124,7 +124,7 @@ public sealed class UpdateMemberRoleTests : IClassFixture<HarmonieWebApplication
             owner.AccessToken);
         updateRoleResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
 
-        var error = await updateRoleResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await updateRoleResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.OwnerRoleCannotBeChanged);
     }
@@ -142,7 +142,7 @@ public sealed class UpdateMemberRoleTests : IClassFixture<HarmonieWebApplication
             user.AccessToken);
         updateRoleResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await updateRoleResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await updateRoleResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.NotFound);
     }
@@ -155,7 +155,8 @@ public sealed class UpdateMemberRoleTests : IClassFixture<HarmonieWebApplication
 
         var updateRoleResponse = await _client.PutAsJsonAsync(
             $"/api/guilds/{nonExistentGuildId}/members/{targetId}/role",
-            new UpdateMemberRoleRequest(GuildRoleInput.Admin));
+            new UpdateMemberRoleRequest(GuildRoleInput.Admin),
+            TestContext.Current.CancellationToken);
         updateRoleResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
@@ -171,7 +172,7 @@ public sealed class UpdateMemberRoleTests : IClassFixture<HarmonieWebApplication
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -182,7 +183,7 @@ public sealed class UpdateMemberRoleTests : IClassFixture<HarmonieWebApplication
             owner.AccessToken);
         updateRoleResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await updateRoleResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await updateRoleResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
         error.Errors.Should().ContainKey("role");
@@ -199,6 +200,6 @@ public sealed class UpdateMemberRoleTests : IClassFixture<HarmonieWebApplication
             Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
         };
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-        return await _client.SendAsync(request);
+        return await _client.SendAsync(request, TestContext.Current.CancellationToken);
     }
 }

--- a/tests/Harmonie.API.IntegrationTests/Harmonie.API.IntegrationTests.csproj
+++ b/tests/Harmonie.API.IntegrationTests/Harmonie.API.IntegrationTests.csproj
@@ -6,9 +6,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />

--- a/tests/Harmonie.API.IntegrationTests/Harmonie.API.IntegrationTests.csproj
+++ b/tests/Harmonie.API.IntegrationTests/Harmonie.API.IntegrationTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />

--- a/tests/Harmonie.API.IntegrationTests/Invites/AcceptInviteEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Invites/AcceptInviteEndpointTests.cs
@@ -33,7 +33,7 @@ public sealed class AcceptInviteEndpointTests : IClassFixture<HarmonieWebApplica
             joiner.AccessToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var result = await response.Content.ReadFromJsonAsync<AcceptInviteResponse>();
+        var result = await response.Content.ReadFromJsonAsync<AcceptInviteResponse>(TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
         result!.GuildId.Should().Be(guild.GuildId);
         result.Role.Should().Be("Member");
@@ -54,7 +54,7 @@ public sealed class AcceptInviteEndpointTests : IClassFixture<HarmonieWebApplica
             owner.AccessToken);
         response.StatusCode.Should().Be(HttpStatusCode.Conflict);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.MemberAlreadyExists);
     }
@@ -70,7 +70,7 @@ public sealed class AcceptInviteEndpointTests : IClassFixture<HarmonieWebApplica
             user.AccessToken);
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Invite.NotFound);
     }
@@ -78,7 +78,7 @@ public sealed class AcceptInviteEndpointTests : IClassFixture<HarmonieWebApplica
     [Fact]
     public async Task AcceptInvite_WhenUnauthenticated_ShouldReturn401()
     {
-        var response = await _client.PostAsync("/api/invites/ABCD1234/accept", null);
+        var response = await _client.PostAsync("/api/invites/ABCD1234/accept", null, TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
@@ -93,7 +93,7 @@ public sealed class AcceptInviteEndpointTests : IClassFixture<HarmonieWebApplica
             user.AccessToken);
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }
@@ -121,7 +121,7 @@ public sealed class AcceptInviteEndpointTests : IClassFixture<HarmonieWebApplica
             joiner2.AccessToken);
         response2.StatusCode.Should().Be(HttpStatusCode.Gone);
 
-        var error = await response2.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response2.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Invite.Exhausted);
     }

--- a/tests/Harmonie.API.IntegrationTests/Invites/PreviewInviteEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Invites/PreviewInviteEndpointTests.cs
@@ -31,7 +31,7 @@ public sealed class PreviewInviteEndpointTests : IClassFixture<HarmonieWebApplic
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
 
         var createInviteResponse = await _client.SendAuthorizedPostAsync(
             $"/api/guilds/{guild!.GuildId}/invites",
@@ -39,12 +39,12 @@ public sealed class PreviewInviteEndpointTests : IClassFixture<HarmonieWebApplic
             owner.AccessToken);
         createInviteResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var invite = await createInviteResponse.Content.ReadFromJsonAsync<CreateGuildInviteResponse>();
+        var invite = await createInviteResponse.Content.ReadFromJsonAsync<CreateGuildInviteResponse>(TestContext.Current.CancellationToken);
 
-        var previewResponse = await _client.GetAsync($"/api/invites/{invite!.Code}");
+        var previewResponse = await _client.GetAsync($"/api/invites/{invite!.Code}", TestContext.Current.CancellationToken);
         previewResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var preview = await previewResponse.Content.ReadFromJsonAsync<PreviewInviteResponse>();
+        var preview = await previewResponse.Content.ReadFromJsonAsync<PreviewInviteResponse>(TestContext.Current.CancellationToken);
         preview.Should().NotBeNull();
         preview!.GuildName.Should().Be("Preview Invite Guild");
         preview.MemberCount.Should().BeGreaterThanOrEqualTo(1);
@@ -64,7 +64,7 @@ public sealed class PreviewInviteEndpointTests : IClassFixture<HarmonieWebApplic
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
 
         var createInviteResponse = await _client.SendAuthorizedPostAsync(
             $"/api/guilds/{guild!.GuildId}/invites",
@@ -72,12 +72,12 @@ public sealed class PreviewInviteEndpointTests : IClassFixture<HarmonieWebApplic
             owner.AccessToken);
         createInviteResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var invite = await createInviteResponse.Content.ReadFromJsonAsync<CreateGuildInviteResponse>();
+        var invite = await createInviteResponse.Content.ReadFromJsonAsync<CreateGuildInviteResponse>(TestContext.Current.CancellationToken);
 
-        var previewResponse = await _client.GetAsync($"/api/invites/{invite!.Code}");
+        var previewResponse = await _client.GetAsync($"/api/invites/{invite!.Code}", TestContext.Current.CancellationToken);
         previewResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var preview = await previewResponse.Content.ReadFromJsonAsync<PreviewInviteResponse>();
+        var preview = await previewResponse.Content.ReadFromJsonAsync<PreviewInviteResponse>(TestContext.Current.CancellationToken);
         preview.Should().NotBeNull();
         preview!.MaxUses.Should().BeNull();
         preview.ExpiresAtUtc.Should().BeNull();
@@ -94,7 +94,7 @@ public sealed class PreviewInviteEndpointTests : IClassFixture<HarmonieWebApplic
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var guild = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
 
         var createInviteResponse = await _client.SendAuthorizedPostAsync(
             $"/api/guilds/{guild!.GuildId}/invites",
@@ -102,20 +102,20 @@ public sealed class PreviewInviteEndpointTests : IClassFixture<HarmonieWebApplic
             owner.AccessToken);
         createInviteResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var invite = await createInviteResponse.Content.ReadFromJsonAsync<CreateGuildInviteResponse>();
+        var invite = await createInviteResponse.Content.ReadFromJsonAsync<CreateGuildInviteResponse>(TestContext.Current.CancellationToken);
 
         // Use a raw HttpClient with no auth header
-        var previewResponse = await _client.GetAsync($"/api/invites/{invite!.Code}");
+        var previewResponse = await _client.GetAsync($"/api/invites/{invite!.Code}", TestContext.Current.CancellationToken);
         previewResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [Fact]
     public async Task PreviewInvite_WhenInviteNotFound_ShouldReturn404()
     {
-        var previewResponse = await _client.GetAsync("/api/invites/ZZZZZZZZ");
+        var previewResponse = await _client.GetAsync("/api/invites/ZZZZZZZZ", TestContext.Current.CancellationToken);
         previewResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await previewResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await previewResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Invite.NotFound);
     }
@@ -123,10 +123,10 @@ public sealed class PreviewInviteEndpointTests : IClassFixture<HarmonieWebApplic
     [Fact]
     public async Task PreviewInvite_WhenInvalidCodeFormat_ShouldReturn400()
     {
-        var previewResponse = await _client.GetAsync("/api/invites/abc");
+        var previewResponse = await _client.GetAsync("/api/invites/abc", TestContext.Current.CancellationToken);
         previewResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await previewResponse.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await previewResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }
@@ -134,7 +134,7 @@ public sealed class PreviewInviteEndpointTests : IClassFixture<HarmonieWebApplic
     [Fact]
     public async Task PreviewInvite_WhenCodeContainsSpecialChars_ShouldReturn400()
     {
-        var previewResponse = await _client.GetAsync("/api/invites/abc!@#$%");
+        var previewResponse = await _client.GetAsync("/api/invites/abc!@#$%", TestContext.Current.CancellationToken);
         previewResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 }

--- a/tests/Harmonie.API.IntegrationTests/Middleware/TraceIdMiddlewareTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Middleware/TraceIdMiddlewareTests.cs
@@ -22,7 +22,7 @@ public sealed class TraceIdMiddlewareTests : IClassFixture<HarmonieWebApplicatio
     public async Task XTraceIdHeader_PresentInResponse()
     {
         // Act
-        var response = await _client.GetAsync("/health");
+        var response = await _client.GetAsync("/health", TestContext.Current.CancellationToken);
 
         // Assert
         response.Headers.TryGetValues("X-Trace-Id", out var traceIdValues);
@@ -37,8 +37,8 @@ public sealed class TraceIdMiddlewareTests : IClassFixture<HarmonieWebApplicatio
     public async Task XTraceIdHeader_DifferentForEachRequest()
     {
         // Act
-        var response1 = await _client.GetAsync("/health");
-        var response2 = await _client.GetAsync("/health");
+        var response1 = await _client.GetAsync("/health", TestContext.Current.CancellationToken);
+        var response2 = await _client.GetAsync("/health", TestContext.Current.CancellationToken);
 
         // Assert
         var traceId1 = response1.Headers.GetValues("X-Trace-Id").FirstOrDefault();
@@ -58,7 +58,7 @@ public sealed class TraceIdMiddlewareTests : IClassFixture<HarmonieWebApplicatio
         request.Headers.Add("traceparent", $"00-{expectedTraceId}-{ActivitySpanId.CreateRandom().ToHexString()}-01");
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         var traceId = response.Headers.GetValues("X-Trace-Id").FirstOrDefault();
@@ -73,7 +73,7 @@ public sealed class TraceIdMiddlewareTests : IClassFixture<HarmonieWebApplicatio
         request.Headers.Add("traceparent", "invalid-format");
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         var traceId = response.Headers.GetValues("X-Trace-Id").FirstOrDefault();
@@ -86,7 +86,7 @@ public sealed class TraceIdMiddlewareTests : IClassFixture<HarmonieWebApplicatio
     public async Task XTraceIdHeader_PresentOnErrorResponse()
     {
         // Act
-        var response = await _client.PostAsJsonAsync("/api/auth/login", new { email = "", password = "" });
+        var response = await _client.PostAsJsonAsync("/api/auth/login", new { email = "", password = "" }, TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -104,13 +104,13 @@ public sealed class TraceIdMiddlewareTests : IClassFixture<HarmonieWebApplicatio
         request.Content = JsonContent.Create(new { email = "", password = "" });
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         var headerTraceId = response.Headers.GetValues("X-Trace-Id").FirstOrDefault();
         headerTraceId.Should().NotBeNull();
 
-        var body = await response.Content.ReadAsStringAsync();
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var error = JsonSerializer.Deserialize<ApplicationError>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
         error.Should().NotBeNull();
         error!.TraceId.Should().NotBeNull();

--- a/tests/Harmonie.API.IntegrationTests/OpenApiDocumentTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/OpenApiDocumentTests.cs
@@ -24,11 +24,11 @@ public sealed class OpenApiDocumentTests : IClassFixture<HarmonieWebApplicationF
         using var factory = _factory.WithWebHostBuilder(builder => builder.UseEnvironment("Development"));
         using var client = factory.CreateClient();
 
-        var response = await client.GetAsync("/openapi/v1.json");
+        var response = await client.GetAsync("/openapi/v1.json", TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var document = JsonNode.Parse(await response.Content.ReadAsStringAsync());
+        var document = JsonNode.Parse(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
         document.Should().NotBeNull();
 
         var getGuildChannels = document!["paths"]?["/api/guilds/{guildId}/channels"]?["get"]?["responses"];
@@ -71,11 +71,11 @@ public sealed class OpenApiDocumentTests : IClassFixture<HarmonieWebApplicationF
         using var factory = _factory.WithWebHostBuilder(builder => builder.UseEnvironment("Development"));
         using var client = factory.CreateClient();
 
-        var response = await client.GetAsync("/openapi/v1.json");
+        var response = await client.GetAsync("/openapi/v1.json", TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var document = JsonNode.Parse(await response.Content.ReadAsStringAsync());
+        var document = JsonNode.Parse(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
         document.Should().NotBeNull();
 
         var registerConflict = document!["paths"]?["/api/auth/register"]?["post"]?["responses"]?["409"];
@@ -99,11 +99,11 @@ public sealed class OpenApiDocumentTests : IClassFixture<HarmonieWebApplicationF
         using var factory = _factory.WithWebHostBuilder(builder => builder.UseEnvironment("Development"));
         using var client = factory.CreateClient();
 
-        var response = await client.GetAsync("/openapi/v1.json");
+        var response = await client.GetAsync("/openapi/v1.json", TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var document = JsonNode.Parse(await response.Content.ReadAsStringAsync());
+        var document = JsonNode.Parse(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
         document.Should().NotBeNull();
 
         if (document is null)
@@ -171,11 +171,11 @@ public sealed class OpenApiDocumentTests : IClassFixture<HarmonieWebApplicationF
         using var factory = _factory.WithWebHostBuilder(builder => builder.UseEnvironment("Development"));
         using var client = factory.CreateClient();
 
-        var response = await client.GetAsync("/openapi/v1.json");
+        var response = await client.GetAsync("/openapi/v1.json", TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var document = JsonNode.Parse(await response.Content.ReadAsStringAsync());
+        var document = JsonNode.Parse(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
         document.Should().NotBeNull();
 
         var requestBody = document!["paths"]?["/api/files/uploads"]?["post"]?["requestBody"];

--- a/tests/Harmonie.API.IntegrationTests/RealTime/ConnectionTrackerTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/ConnectionTrackerTests.cs
@@ -63,7 +63,7 @@ public sealed class ConnectionTrackerTests : IDisposable
             .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<UserGuildMembership>());
 
-        await _tracker.HandleConnectedAsync(userId, "conn-1");
+        await _tracker.HandleConnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);
 
         _tracker.IsOnline(userId).Should().BeTrue();
     }
@@ -87,7 +87,7 @@ public sealed class ConnectionTrackerTests : IDisposable
                 new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow)
             });
 
-        await _tracker.HandleConnectedAsync(userId, "conn-1");
+        await _tracker.HandleConnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);
 
         _presenceNotifierMock.Verify(
             x => x.NotifyStatusChangedAsync(
@@ -114,8 +114,8 @@ public sealed class ConnectionTrackerTests : IDisposable
             .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<UserGuildMembership>());
 
-        await _tracker.HandleConnectedAsync(userId, "conn-1");
-        await _tracker.HandleConnectedAsync(userId, "conn-2");
+        await _tracker.HandleConnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);
+        await _tracker.HandleConnectedAsync(userId, "conn-2", TestContext.Current.CancellationToken);
 
         _tracker.IsOnline(userId).Should().BeTrue();
 
@@ -138,9 +138,9 @@ public sealed class ConnectionTrackerTests : IDisposable
             .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<UserGuildMembership>());
 
-        await _tracker.HandleConnectedAsync(userId, "conn-1");
-        await _tracker.HandleConnectedAsync(userId, "conn-2");
-        await _tracker.HandleDisconnectedAsync(userId, "conn-1");
+        await _tracker.HandleConnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);
+        await _tracker.HandleConnectedAsync(userId, "conn-2", TestContext.Current.CancellationToken);
+        await _tracker.HandleDisconnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);
 
         _tracker.IsOnline(userId).Should().BeTrue();
     }
@@ -164,10 +164,10 @@ public sealed class ConnectionTrackerTests : IDisposable
                 new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow)
             });
 
-        await _tracker.HandleConnectedAsync(userId, "conn-1");
+        await _tracker.HandleConnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);
         _presenceNotifierMock.Invocations.Clear();
 
-        await _tracker.HandleDisconnectedAsync(userId, "conn-1");
+        await _tracker.HandleDisconnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);
 
         // Should not broadcast immediately
         _presenceNotifierMock.Verify(
@@ -177,7 +177,7 @@ public sealed class ConnectionTrackerTests : IDisposable
             Times.Never);
 
         // Wait for grace period to expire
-        await Task.Delay(TestGracePeriod + TimeSpan.FromMilliseconds(200));
+        await Task.Delay(TestGracePeriod + TimeSpan.FromMilliseconds(200), TestContext.Current.CancellationToken);
 
         _presenceNotifierMock.Verify(
             x => x.NotifyStatusChangedAsync(
@@ -207,17 +207,17 @@ public sealed class ConnectionTrackerTests : IDisposable
                 new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow)
             });
 
-        await _tracker.HandleConnectedAsync(userId, "conn-1");
+        await _tracker.HandleConnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);
         _presenceNotifierMock.Invocations.Clear();
 
-        await _tracker.HandleDisconnectedAsync(userId, "conn-1");
+        await _tracker.HandleDisconnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);
 
         // Reconnect before grace period expires
-        await Task.Delay(TestGracePeriod / 2);
-        await _tracker.HandleConnectedAsync(userId, "conn-2");
+        await Task.Delay(TestGracePeriod / 2, TestContext.Current.CancellationToken);
+        await _tracker.HandleConnectedAsync(userId, "conn-2", TestContext.Current.CancellationToken);
 
         // Wait for grace period to fully expire
-        await Task.Delay(TestGracePeriod + TimeSpan.FromMilliseconds(200));
+        await Task.Delay(TestGracePeriod + TimeSpan.FromMilliseconds(200), TestContext.Current.CancellationToken);
 
         // Should have broadcast online on reconnect, not offline
         _presenceNotifierMock.Verify(
@@ -254,7 +254,7 @@ public sealed class ConnectionTrackerTests : IDisposable
                 new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow)
             });
 
-        await _tracker.HandleConnectedAsync(userId, "conn-1");
+        await _tracker.HandleConnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);
 
         _presenceNotifierMock.Verify(
             x => x.NotifyStatusChangedAsync(
@@ -276,7 +276,7 @@ public sealed class ConnectionTrackerTests : IDisposable
     public async Task HandleDisconnectedAsync_UnknownUser_ShouldNotThrow()
     {
         var userId = UserId.New();
-        await _tracker.HandleDisconnectedAsync(userId, "conn-1");
+        await _tracker.HandleDisconnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -293,7 +293,7 @@ public sealed class ConnectionTrackerTests : IDisposable
             .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<UserGuildMembership>());
 
-        await _tracker.HandleConnectedAsync(userId, "conn-1");
+        await _tracker.HandleConnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);
 
         _presenceNotifierMock.Verify(
             x => x.NotifyStatusChangedAsync(
@@ -323,8 +323,8 @@ public sealed class ConnectionTrackerTests : IDisposable
             .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<UserGuildMembership>());
 
-        await _tracker.HandleConnectedAsync(userId, "conn-1");
-        await _tracker.HandleConnectedAsync(userId, "conn-2");
+        await _tracker.HandleConnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);
+        await _tracker.HandleConnectedAsync(userId, "conn-2", TestContext.Current.CancellationToken);
 
         var connectionIds = _tracker.GetConnectionIds(userId);
         connectionIds.Should().HaveCount(2);
@@ -346,9 +346,9 @@ public sealed class ConnectionTrackerTests : IDisposable
             .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<UserGuildMembership>());
 
-        await _tracker.HandleConnectedAsync(userId, "conn-1");
-        await _tracker.HandleConnectedAsync(userId, "conn-2");
-        await _tracker.HandleDisconnectedAsync(userId, "conn-1");
+        await _tracker.HandleConnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);
+        await _tracker.HandleConnectedAsync(userId, "conn-2", TestContext.Current.CancellationToken);
+        await _tracker.HandleDisconnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);
 
         var connectionIds = _tracker.GetConnectionIds(userId);
         connectionIds.Should().HaveCount(1);

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRConversationCreatedHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRConversationCreatedHubTests.cs
@@ -35,8 +35,8 @@ public sealed class SignalRConversationCreatedHubTests : IClassFixture<HarmonieW
             eventReceived.TrySetResult(payload);
         });
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
         var group = await ConversationTestHelper.CreateGroupConversationAsync(
             _client, creator.AccessToken, "Integration Test Group",

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRConversationMessagesHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRConversationMessagesHubTests.cs
@@ -42,8 +42,8 @@ public sealed class SignalRConversationMessagesHubTests : IClassFixture<Harmonie
             messageReceived.TrySetResult(payload);
         });
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
         var sendResponse = await _client.SendAuthorizedPostAsync(
             $"/api/conversations/{conversationId}/messages",
@@ -51,7 +51,7 @@ public sealed class SignalRConversationMessagesHubTests : IClassFixture<Harmonie
             sender.AccessToken);
         sendResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>(TestContext.Current.CancellationToken);
         sendPayload.Should().NotBeNull();
 
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -78,7 +78,7 @@ public sealed class SignalRConversationMessagesHubTests : IClassFixture<Harmonie
             sender.AccessToken);
         sendResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>(TestContext.Current.CancellationToken);
         sendPayload.Should().NotBeNull();
 
         await using var connection = CreateHubConnection(receiver.AccessToken);
@@ -92,8 +92,8 @@ public sealed class SignalRConversationMessagesHubTests : IClassFixture<Harmonie
             messageReceived.TrySetResult(payload);
         });
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
         var editResponse = await _client.SendAuthorizedPatchAsync(
             $"/api/conversations/{conversationId}/messages/{sendPayload!.MessageId}",
@@ -125,7 +125,7 @@ public sealed class SignalRConversationMessagesHubTests : IClassFixture<Harmonie
             sender.AccessToken);
         sendResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<SendMessageResponse>(TestContext.Current.CancellationToken);
         sendPayload.Should().NotBeNull();
 
         await using var connection = CreateHubConnection(receiver.AccessToken);
@@ -139,8 +139,8 @@ public sealed class SignalRConversationMessagesHubTests : IClassFixture<Harmonie
             messageReceived.TrySetResult(payload);
         });
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
         var deleteResponse = await _client.SendAuthorizedDeleteAsync(
             $"/api/conversations/{conversationId}/messages/{sendPayload!.MessageId}",

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRGuildHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRGuildHubTests.cs
@@ -36,7 +36,7 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -52,8 +52,8 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             eventReceived.TrySetResult(payload);
         });
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var deleteGuildResponse = await _client.SendAuthorizedDeleteAsync(
             $"/api/guilds/{createGuildPayload.GuildId}",
@@ -82,7 +82,7 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -105,8 +105,8 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             eventReceived.TrySetResult(payload);
         });
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var updateResponse = await _client.SendAuthorizedPatchAsync(
             $"/api/channels/{channelId}",
@@ -138,7 +138,7 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -161,8 +161,8 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             eventReceived.TrySetResult(payload);
         });
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var deleteResponse = await _client.SendAuthorizedDeleteAsync(
             $"/api/channels/{channelId}",
@@ -192,7 +192,7 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -222,8 +222,8 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             eventReceived.TrySetResult(payload);
         });
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var reorderResponse = await _client.SendAuthorizedPatchAsync(
             $"/api/guilds/{createGuildPayload.GuildId}/channels/reorder",
@@ -260,7 +260,7 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, existingMember.AccessToken);
@@ -276,8 +276,8 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             eventReceived.TrySetResult(payload);
         });
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload.GuildId, owner.AccessToken, joiningMember.AccessToken);
 
@@ -305,7 +305,7 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, remainingMember.AccessToken);
@@ -322,8 +322,8 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             eventReceived.TrySetResult(payload);
         });
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var leaveResponse = await _client.SendAuthorizedPostAsync(
             $"/api/guilds/{createGuildPayload.GuildId}/leave",
@@ -355,7 +355,7 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, remainingMember.AccessToken);
@@ -372,8 +372,8 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             eventReceived.TrySetResult(payload);
         });
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var banResponse = await _client.SendAuthorizedPostAsync(
             $"/api/guilds/{createGuildPayload.GuildId}/bans",
@@ -450,7 +450,7 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, remainingMember.AccessToken);
@@ -467,8 +467,8 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             eventReceived.TrySetResult(payload);
         });
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var removeResponse = await _client.SendAuthorizedDeleteAsync(
             $"/api/guilds/{createGuildPayload.GuildId}/members/{targetMember.UserId}",
@@ -499,7 +499,7 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, remainingMember.AccessToken);
@@ -516,8 +516,8 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             eventReceived.TrySetResult(payload);
         });
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var updateRoleResponse = await _client.SendAuthorizedPutAsync(
             $"/api/guilds/{createGuildPayload.GuildId}/members/{targetMember.UserId}/role",
@@ -549,7 +549,7 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -565,8 +565,8 @@ public sealed class SignalRGuildHubTests : IClassFixture<HarmonieWebApplicationF
             eventReceived.TrySetResult(payload);
         });
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var updateResponse = await _client.SendAuthorizedPatchAsync(
             $"/api/guilds/{createGuildPayload.GuildId}",

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRRealtimeGroupManagerTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRRealtimeGroupManagerTests.cs
@@ -63,7 +63,7 @@ public sealed class SignalRRealtimeGroupManagerTests
                 new[] { channelId },
                 new[] { conversationId }));
 
-        await _manager.SubscribeConnectionAsync(userId, connectionId);
+        await _manager.SubscribeConnectionAsync(userId, connectionId, TestContext.Current.CancellationToken);
 
         _groupManagerMock.Verify(
             x => x.AddToGroupAsync(connectionId, $"guild-voice:{guildId}", It.IsAny<CancellationToken>()),
@@ -88,7 +88,7 @@ public sealed class SignalRRealtimeGroupManagerTests
                 Array.Empty<GuildChannelId>(),
                 Array.Empty<ConversationId>()));
 
-        await _manager.SubscribeConnectionAsync(userId, "conn-1");
+        await _manager.SubscribeConnectionAsync(userId, "conn-1", TestContext.Current.CancellationToken);
 
         _groupManagerMock.Verify(
             x => x.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
@@ -115,7 +115,7 @@ public sealed class SignalRRealtimeGroupManagerTests
                 CreateChannel(voiceChannelId, guildId, GuildChannelType.Voice)
             });
 
-        await _manager.AddUserToGuildGroupsAsync(userId, guildId);
+        await _manager.AddUserToGuildGroupsAsync(userId, guildId, TestContext.Current.CancellationToken);
 
         _groupManagerMock.Verify(
             x => x.AddToGroupAsync("conn-1", $"guild-voice:{guildId}", It.IsAny<CancellationToken>()),
@@ -138,7 +138,7 @@ public sealed class SignalRRealtimeGroupManagerTests
             .Setup(x => x.GetConnectionIds(userId))
             .Returns(Array.Empty<string>());
 
-        await _manager.AddUserToGuildGroupsAsync(userId, guildId);
+        await _manager.AddUserToGuildGroupsAsync(userId, guildId, TestContext.Current.CancellationToken);
 
         _guildChannelRepositoryMock.Verify(
             x => x.GetByGuildIdAsync(It.IsAny<GuildId>(), It.IsAny<CancellationToken>()),
@@ -166,7 +166,7 @@ public sealed class SignalRRealtimeGroupManagerTests
                 CreateChannel(textChannelId, guildId, GuildChannelType.Text)
             });
 
-        await _manager.RemoveUserFromGuildGroupsAsync(userId, guildId);
+        await _manager.RemoveUserFromGuildGroupsAsync(userId, guildId, TestContext.Current.CancellationToken);
 
         _groupManagerMock.Verify(
             x => x.RemoveFromGroupAsync("conn-1", $"guild-voice:{guildId}", It.IsAny<CancellationToken>()),
@@ -186,7 +186,7 @@ public sealed class SignalRRealtimeGroupManagerTests
             .Setup(x => x.GetConnectionIds(userId))
             .Returns(Array.Empty<string>());
 
-        await _manager.RemoveUserFromGuildGroupsAsync(userId, guildId);
+        await _manager.RemoveUserFromGuildGroupsAsync(userId, guildId, TestContext.Current.CancellationToken);
 
         _groupManagerMock.Verify(
             x => x.RemoveFromGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
@@ -203,7 +203,7 @@ public sealed class SignalRRealtimeGroupManagerTests
             .Setup(x => x.GetConnectionIds(userId))
             .Returns(new[] { "conn-1", "conn-2" });
 
-        await _manager.AddUserToChannelGroupAsync(userId, channelId);
+        await _manager.AddUserToChannelGroupAsync(userId, channelId, TestContext.Current.CancellationToken);
 
         _groupManagerMock.Verify(
             x => x.AddToGroupAsync("conn-1", $"channel:{channelId}", It.IsAny<CancellationToken>()),
@@ -236,7 +236,7 @@ public sealed class SignalRRealtimeGroupManagerTests
             .Setup(x => x.GetConnectionIds(offlineUserId))
             .Returns(Array.Empty<string>());
 
-        await _manager.AddAllGuildMembersToChannelGroupAsync(guildId, channelId);
+        await _manager.AddAllGuildMembersToChannelGroupAsync(guildId, channelId, TestContext.Current.CancellationToken);
 
         _groupManagerMock.Verify(
             x => x.AddToGroupAsync("conn-1", $"channel:{channelId}", It.IsAny<CancellationToken>()),
@@ -256,7 +256,7 @@ public sealed class SignalRRealtimeGroupManagerTests
             .Setup(x => x.GetConnectionIds(userId))
             .Returns(new[] { "conn-1" });
 
-        await _manager.AddUserToConversationGroupAsync(userId, conversationId);
+        await _manager.AddUserToConversationGroupAsync(userId, conversationId, TestContext.Current.CancellationToken);
 
         _groupManagerMock.Verify(
             x => x.AddToGroupAsync("conn-1", $"conversation:{conversationId}", It.IsAny<CancellationToken>()),
@@ -273,7 +273,7 @@ public sealed class SignalRRealtimeGroupManagerTests
             .Setup(x => x.GetConnectionIds(userId))
             .Returns(Array.Empty<string>());
 
-        await _manager.AddUserToConversationGroupAsync(userId, conversationId);
+        await _manager.AddUserToConversationGroupAsync(userId, conversationId, TestContext.Current.CancellationToken);
 
         _groupManagerMock.Verify(
             x => x.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
@@ -298,7 +298,7 @@ public sealed class SignalRRealtimeGroupManagerTests
                 CreateChannel(channelId, guildId, GuildChannelType.Text)
             });
 
-        await _manager.AddUserToGuildGroupsAsync(userId, guildId);
+        await _manager.AddUserToGuildGroupsAsync(userId, guildId, TestContext.Current.CancellationToken);
 
         // 2 connections x (1 guild + 1 channel) = 4 calls
         _groupManagerMock.Verify(

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRTextChannelsHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRTextChannelsHubTests.cs
@@ -37,7 +37,7 @@ public sealed class SignalRTextChannelsHubTests : IClassFixture<HarmonieWebAppli
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -47,7 +47,7 @@ public sealed class SignalRTextChannelsHubTests : IClassFixture<HarmonieWebAppli
             member.AccessToken);
         channelsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>();
+        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
         channelsPayload.Should().NotBeNull();
 
         var textChannel = channelsPayload!.Channels.First(channel => channel.Type == "Text");
@@ -65,8 +65,8 @@ public sealed class SignalRTextChannelsHubTests : IClassFixture<HarmonieWebAppli
         var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         connection.On("Ready", () => ready.TrySetResult());
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var sendMessageResponse = await _client.SendAuthorizedPostAsync(
             $"/api/channels/{textChannel.ChannelId}/messages",
@@ -74,7 +74,7 @@ public sealed class SignalRTextChannelsHubTests : IClassFixture<HarmonieWebAppli
             owner.AccessToken);
         sendMessageResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var sendMessagePayload = await sendMessageResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        var sendMessagePayload = await sendMessageResponse.Content.ReadFromJsonAsync<SendMessageResponse>(TestContext.Current.CancellationToken);
         sendMessagePayload.Should().NotBeNull();
 
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -100,7 +100,7 @@ public sealed class SignalRTextChannelsHubTests : IClassFixture<HarmonieWebAppli
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -110,7 +110,7 @@ public sealed class SignalRTextChannelsHubTests : IClassFixture<HarmonieWebAppli
             member.AccessToken);
         channelsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>();
+        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
         channelsPayload.Should().NotBeNull();
 
         var textChannel = channelsPayload!.Channels.First(channel => channel.Type == "Text");
@@ -121,7 +121,7 @@ public sealed class SignalRTextChannelsHubTests : IClassFixture<HarmonieWebAppli
             owner.AccessToken);
         sendMessageResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var sendMessagePayload = await sendMessageResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        var sendMessagePayload = await sendMessageResponse.Content.ReadFromJsonAsync<SendMessageResponse>(TestContext.Current.CancellationToken);
         sendMessagePayload.Should().NotBeNull();
 
         await using var connection = CreateHubConnection(member.AccessToken);
@@ -136,8 +136,8 @@ public sealed class SignalRTextChannelsHubTests : IClassFixture<HarmonieWebAppli
         var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         connection.On("Ready", () => ready.TrySetResult());
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var editResponse = await _client.SendAuthorizedPatchAsync(
             $"/api/channels/{textChannel.ChannelId}/messages/{sendMessagePayload!.MessageId}",
@@ -168,7 +168,7 @@ public sealed class SignalRTextChannelsHubTests : IClassFixture<HarmonieWebAppli
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -178,7 +178,7 @@ public sealed class SignalRTextChannelsHubTests : IClassFixture<HarmonieWebAppli
             member.AccessToken);
         channelsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>();
+        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
         channelsPayload.Should().NotBeNull();
 
         var textChannel = channelsPayload!.Channels.First(channel => channel.Type == "Text");
@@ -189,7 +189,7 @@ public sealed class SignalRTextChannelsHubTests : IClassFixture<HarmonieWebAppli
             owner.AccessToken);
         sendMessageResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var sendMessagePayload = await sendMessageResponse.Content.ReadFromJsonAsync<SendMessageResponse>();
+        var sendMessagePayload = await sendMessageResponse.Content.ReadFromJsonAsync<SendMessageResponse>(TestContext.Current.CancellationToken);
         sendMessagePayload.Should().NotBeNull();
 
         await using var connection = CreateHubConnection(member.AccessToken);
@@ -204,8 +204,8 @@ public sealed class SignalRTextChannelsHubTests : IClassFixture<HarmonieWebAppli
         var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         connection.On("Ready", () => ready.TrySetResult());
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var deleteResponse = await _client.SendAuthorizedDeleteAsync(
             $"/api/channels/{textChannel.ChannelId}/messages/{sendMessagePayload!.MessageId}",

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRTypingIndicatorHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRTypingIndicatorHubTests.cs
@@ -40,7 +40,7 @@ public sealed class SignalRTypingIndicatorHubTests : IClassFixture<HarmonieWebAp
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         var channelsResponse = await _client.SendAuthorizedGetAsync(
@@ -48,7 +48,7 @@ public sealed class SignalRTypingIndicatorHubTests : IClassFixture<HarmonieWebAp
             owner.AccessToken);
         channelsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>();
+        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
         channelsPayload.Should().NotBeNull();
 
         var textChannel = channelsPayload!.Channels.First(channel => channel.Type == "Text");
@@ -76,7 +76,7 @@ public sealed class SignalRTypingIndicatorHubTests : IClassFixture<HarmonieWebAp
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -86,7 +86,7 @@ public sealed class SignalRTypingIndicatorHubTests : IClassFixture<HarmonieWebAp
             member.AccessToken);
         channelsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>();
+        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
         channelsPayload.Should().NotBeNull();
 
         var textChannel = channelsPayload!.Channels.First(channel => channel.Type == "Text");
@@ -106,7 +106,7 @@ public sealed class SignalRTypingIndicatorHubTests : IClassFixture<HarmonieWebAp
 
         await using var senderConnection = CreateHubConnection(owner.AccessToken);
         await StartAndWaitReadyAsync(senderConnection);
-        await senderConnection.InvokeAsync("StartTypingChannel", textChannelId);
+        await senderConnection.InvokeAsync("StartTypingChannel", textChannelId, TestContext.Current.CancellationToken);
 
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var completedTask = await Task.WhenAny(typingReceived.Task, Task.Delay(Timeout.InfiniteTimeSpan, timeout.Token));
@@ -130,7 +130,7 @@ public sealed class SignalRTypingIndicatorHubTests : IClassFixture<HarmonieWebAp
             owner.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, owner.AccessToken, member.AccessToken);
@@ -140,7 +140,7 @@ public sealed class SignalRTypingIndicatorHubTests : IClassFixture<HarmonieWebAp
             member.AccessToken);
         channelsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>();
+        var channelsPayload = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
         channelsPayload.Should().NotBeNull();
 
         var textChannel = channelsPayload!.Channels.First(channel => channel.Type == "Text");
@@ -159,11 +159,11 @@ public sealed class SignalRTypingIndicatorHubTests : IClassFixture<HarmonieWebAp
         await using var senderConnection = CreateHubConnection(owner.AccessToken);
         await StartAndWaitReadyAsync(senderConnection);
 
-        await senderConnection.InvokeAsync("StartTypingChannel", textChannelId);
-        await senderConnection.InvokeAsync("StartTypingChannel", textChannelId);
-        await senderConnection.InvokeAsync("StartTypingChannel", textChannelId);
+        await senderConnection.InvokeAsync("StartTypingChannel", textChannelId, TestContext.Current.CancellationToken);
+        await senderConnection.InvokeAsync("StartTypingChannel", textChannelId, TestContext.Current.CancellationToken);
+        await senderConnection.InvokeAsync("StartTypingChannel", textChannelId, TestContext.Current.CancellationToken);
 
-        await Task.Delay(TimeSpan.FromSeconds(1));
+        await Task.Delay(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
         eventsReceived.Should().Be(1);
     }
@@ -207,7 +207,7 @@ public sealed class SignalRTypingIndicatorHubTests : IClassFixture<HarmonieWebAp
 
         await using var senderConnection = CreateHubConnection(sender.AccessToken);
         await StartAndWaitReadyAsync(senderConnection);
-        await senderConnection.InvokeAsync("StartTypingConversation", conversationId);
+        await senderConnection.InvokeAsync("StartTypingConversation", conversationId, TestContext.Current.CancellationToken);
 
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var completedTask = await Task.WhenAny(typingReceived.Task, Task.Delay(Timeout.InfiniteTimeSpan, timeout.Token));
@@ -238,11 +238,11 @@ public sealed class SignalRTypingIndicatorHubTests : IClassFixture<HarmonieWebAp
         await using var senderConnection = CreateHubConnection(sender.AccessToken);
         await StartAndWaitReadyAsync(senderConnection);
 
-        await senderConnection.InvokeAsync("StartTypingConversation", conversationId);
-        await senderConnection.InvokeAsync("StartTypingConversation", conversationId);
-        await senderConnection.InvokeAsync("StartTypingConversation", conversationId);
+        await senderConnection.InvokeAsync("StartTypingConversation", conversationId, TestContext.Current.CancellationToken);
+        await senderConnection.InvokeAsync("StartTypingConversation", conversationId, TestContext.Current.CancellationToken);
+        await senderConnection.InvokeAsync("StartTypingConversation", conversationId, TestContext.Current.CancellationToken);
 
-        await Task.Delay(TimeSpan.FromSeconds(1));
+        await Task.Delay(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
         eventsReceived.Should().Be(1);
     }

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRUserProfileHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRUserProfileHubTests.cs
@@ -36,7 +36,7 @@ public sealed class SignalRUserProfileHubTests : IClassFixture<HarmonieWebApplic
             updatingUser.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, updatingUser.AccessToken, observer.AccessToken);
@@ -53,8 +53,8 @@ public sealed class SignalRUserProfileHubTests : IClassFixture<HarmonieWebApplic
                 eventReceived.TrySetResult(payload);
         });
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var updateResponse = await _client.SendAuthorizedPatchAsync(
             "/api/users/me",
@@ -85,7 +85,7 @@ public sealed class SignalRUserProfileHubTests : IClassFixture<HarmonieWebApplic
             updatingUser.AccessToken);
         createGuildResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>();
+        var createGuildPayload = await createGuildResponse.Content.ReadFromJsonAsync<CreateGuildResponse>(TestContext.Current.CancellationToken);
         createGuildPayload.Should().NotBeNull();
 
         await GuildTestHelper.InviteMemberAsync(_client, createGuildPayload!.GuildId, updatingUser.AccessToken, observer.AccessToken);
@@ -102,8 +102,8 @@ public sealed class SignalRUserProfileHubTests : IClassFixture<HarmonieWebApplic
                 eventReceived.TrySetResult(payload);
         });
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var updateResponse = await _client.SendAuthorizedPatchAsync(
             "/api/users/me",

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRVoicePresenceHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRVoicePresenceHubTests.cs
@@ -52,8 +52,8 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
         var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         connection.On("Ready", () => ready.TrySetResult());
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var webhookResponse = await SendLiveKitWebhookAsync(
             CreateParticipantWebhookBody("participant_joined", voiceChannelId.ToString(), member.UserId.ToString(), member.Username));
@@ -97,8 +97,8 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
         var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         connection.On("Ready", () => ready.TrySetResult());
 
-        await connection.StartAsync();
-        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var webhookResponse = await SendLiveKitWebhookAsync(
             CreateParticipantWebhookBody("participant_left", voiceChannelId.ToString(), member.UserId.ToString(), member.Username));

--- a/tests/Harmonie.API.IntegrationTests/Users/SearchUsersEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Users/SearchUsersEndpointTests.cs
@@ -41,7 +41,7 @@ public sealed class SearchUsersEndpointTests : IClassFixture<HarmonieWebApplicat
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<SearchUsersResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<SearchUsersResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Users.Should().Contain(user => user.Username == alpha.Username);
         payload.Users.Should().Contain(user => user.Username == beta.Username);
@@ -68,7 +68,7 @@ public sealed class SearchUsersEndpointTests : IClassFixture<HarmonieWebApplicat
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<SearchUsersResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<SearchUsersResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Users.Should().ContainSingle(user => user.UserId == guildMember.UserId);
         payload.Users.Should().NotContain(user => user.UserId == outsider.UserId);
@@ -87,7 +87,7 @@ public sealed class SearchUsersEndpointTests : IClassFixture<HarmonieWebApplicat
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
     }
@@ -110,7 +110,7 @@ public sealed class SearchUsersEndpointTests : IClassFixture<HarmonieWebApplicat
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<SearchUsersResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<SearchUsersResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Users.Should().Contain(user => user.UserId == activeUser.UserId);
         payload.Users.Should().NotContain(user => user.UserId == inactiveUser.UserId);
@@ -134,7 +134,7 @@ public sealed class SearchUsersEndpointTests : IClassFixture<HarmonieWebApplicat
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<SearchUsersResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<SearchUsersResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         var user = payload!.Users.Should().ContainSingle(u => u.UserId == target.UserId).Subject;
         user.Avatar.Should().NotBeNull();
@@ -146,11 +146,11 @@ public sealed class SearchUsersEndpointTests : IClassFixture<HarmonieWebApplicat
     [Fact]
     public async Task SearchUsers_WithoutAuthentication_ShouldReturnUnauthorized()
     {
-        var response = await _client.GetAsync("/api/users/search?q=al");
+        var response = await _client.GetAsync("/api/users/search?q=al", TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Auth.InvalidCredentials);
     }

--- a/tests/Harmonie.API.IntegrationTests/Users/UserProfileTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Users/UserProfileTests.cs
@@ -36,7 +36,7 @@ public sealed class UserProfileTests : IClassFixture<HarmonieWebApplicationFacto
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<GetMyProfileResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<GetMyProfileResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
 
         payload!.UserId.Should().Be(user.UserId);
@@ -52,12 +52,12 @@ public sealed class UserProfileTests : IClassFixture<HarmonieWebApplicationFacto
     [Fact]
     public async Task GetMyProfile_WithoutAuthentication_ShouldReturnUnauthorized()
     {
-        var response = await _client.GetAsync("/api/users/me");
+        var response = await _client.GetAsync("/api/users/me", TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
 
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Auth.InvalidCredentials);
         error.Status.Should().Be((int)HttpStatusCode.Unauthorized);
@@ -73,7 +73,7 @@ public sealed class UserProfileTests : IClassFixture<HarmonieWebApplicationFacto
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.User.NotFound);
     }
@@ -102,7 +102,7 @@ public sealed class UserProfileTests : IClassFixture<HarmonieWebApplicationFacto
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<UpdateMyProfileResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<UpdateMyProfileResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.UserId.Should().Be(user.UserId);
         payload.Username.Should().Be(user.Username);
@@ -112,7 +112,7 @@ public sealed class UserProfileTests : IClassFixture<HarmonieWebApplicationFacto
 
         var getResponse = await _client.SendAuthorizedGetAsync("/api/users/me", user.AccessToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        var profile = await getResponse.Content.ReadFromJsonAsync<GetMyProfileResponse>();
+        var profile = await getResponse.Content.ReadFromJsonAsync<GetMyProfileResponse>(TestContext.Current.CancellationToken);
         profile.Should().NotBeNull();
         profile!.DisplayName.Should().Be("Updated Name");
         profile.Bio.Should().Be("Initial bio");
@@ -147,7 +147,7 @@ public sealed class UserProfileTests : IClassFixture<HarmonieWebApplicationFacto
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<UpdateMyProfileResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<UpdateMyProfileResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.DisplayName.Should().Be("Alice");
         payload.Bio.Should().BeNull();
@@ -166,7 +166,7 @@ public sealed class UserProfileTests : IClassFixture<HarmonieWebApplicationFacto
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
         error.Status.Should().Be((int)HttpStatusCode.BadRequest);
@@ -189,7 +189,7 @@ public sealed class UserProfileTests : IClassFixture<HarmonieWebApplicationFacto
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }
@@ -199,7 +199,8 @@ public sealed class UserProfileTests : IClassFixture<HarmonieWebApplicationFacto
     {
         var response = await _client.PatchAsJsonAsync(
             "/api/users/me",
-            new { displayName = "NoAuth" });
+            new { displayName = "NoAuth" },
+            TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -216,13 +217,13 @@ public sealed class UserProfileTests : IClassFixture<HarmonieWebApplicationFacto
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<UpdateMyProfileResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<UpdateMyProfileResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Theme.Should().Be("dark");
         payload.Language.Should().Be("fr");
 
         var getResponse = await _client.SendAuthorizedGetAsync("/api/users/me", user.AccessToken);
-        var profile = await getResponse.Content.ReadFromJsonAsync<GetMyProfileResponse>();
+        var profile = await getResponse.Content.ReadFromJsonAsync<GetMyProfileResponse>(TestContext.Current.CancellationToken);
         profile.Should().NotBeNull();
         profile!.Theme.Should().Be("dark");
         profile.Language.Should().Be("fr");
@@ -240,7 +241,7 @@ public sealed class UserProfileTests : IClassFixture<HarmonieWebApplicationFacto
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<UpdateMyProfileResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<UpdateMyProfileResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Avatar.Should().NotBeNull();
         payload.Avatar!.Color.Should().Be("#FFF4D6");
@@ -248,7 +249,7 @@ public sealed class UserProfileTests : IClassFixture<HarmonieWebApplicationFacto
         payload.Avatar.Bg.Should().Be("#1F2937");
 
         var getResponse = await _client.SendAuthorizedGetAsync("/api/users/me", user.AccessToken);
-        var profile = await getResponse.Content.ReadFromJsonAsync<GetMyProfileResponse>();
+        var profile = await getResponse.Content.ReadFromJsonAsync<GetMyProfileResponse>(TestContext.Current.CancellationToken);
         profile.Should().NotBeNull();
         profile!.Avatar.Should().NotBeNull();
         profile.Avatar!.Color.Should().Be("#FFF4D6");
@@ -271,7 +272,7 @@ public sealed class UserProfileTests : IClassFixture<HarmonieWebApplicationFacto
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<UpdateMyProfileResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<UpdateMyProfileResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Avatar.Should().NotBeNull();
         payload.Avatar!.Color.Should().Be("#UPDATED");
@@ -296,7 +297,7 @@ public sealed class UserProfileTests : IClassFixture<HarmonieWebApplicationFacto
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<UpdateMyProfileResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<UpdateMyProfileResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Avatar.Should().BeNull();
     }
@@ -318,7 +319,7 @@ public sealed class UserProfileTests : IClassFixture<HarmonieWebApplicationFacto
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<UpdateMyProfileResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<UpdateMyProfileResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Language.Should().BeNull();
     }
@@ -342,7 +343,7 @@ public sealed class UserProfileTests : IClassFixture<HarmonieWebApplicationFacto
         var profileResponse = await _client.SendAuthorizedGetAsync("/api/users/me", user.AccessToken);
         profileResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var profile = await profileResponse.Content.ReadFromJsonAsync<GetMyProfileResponse>();
+        var profile = await profileResponse.Content.ReadFromJsonAsync<GetMyProfileResponse>(TestContext.Current.CancellationToken);
         profile.Should().NotBeNull();
         profile!.AvatarFileId.Should().BeNull();
 
@@ -359,7 +360,7 @@ public sealed class UserProfileTests : IClassFixture<HarmonieWebApplicationFacto
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Upload.NotFound);
     }
@@ -367,7 +368,7 @@ public sealed class UserProfileTests : IClassFixture<HarmonieWebApplicationFacto
     [Fact]
     public async Task DeleteMyAvatar_WithoutAuthentication_ShouldReturnUnauthorized()
     {
-        var response = await _client.DeleteAsync("/api/users/me/avatar");
+        var response = await _client.DeleteAsync("/api/users/me/avatar", TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }

--- a/tests/Harmonie.API.IntegrationTests/Users/UserStatusTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Users/UserStatusTests.cs
@@ -31,13 +31,13 @@ public sealed class UserStatusTests : IClassFixture<HarmonieWebApplicationFactor
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<UpdateUserStatusResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<UpdateUserStatusResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.UserId.Should().Be(user.UserId);
         payload.Status.Should().Be("dnd");
 
         var profileResponse = await _client.SendAuthorizedGetAsync("/api/users/me", user.AccessToken);
-        var profile = await profileResponse.Content.ReadFromJsonAsync<GetMyProfileResponse>();
+        var profile = await profileResponse.Content.ReadFromJsonAsync<GetMyProfileResponse>(TestContext.Current.CancellationToken);
         profile.Should().NotBeNull();
         profile!.Status.Should().Be("dnd");
     }
@@ -54,13 +54,13 @@ public sealed class UserStatusTests : IClassFixture<HarmonieWebApplicationFactor
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var payload = await response.Content.ReadFromJsonAsync<UpdateUserStatusResponse>();
+        var payload = await response.Content.ReadFromJsonAsync<UpdateUserStatusResponse>(TestContext.Current.CancellationToken);
         payload.Should().NotBeNull();
         payload!.Status.Should().Be("invisible");
 
         // Verify persistence via GET profile
         var profileResponse = await _client.SendAuthorizedGetAsync("/api/users/me", user.AccessToken);
-        var profile = await profileResponse.Content.ReadFromJsonAsync<GetMyProfileResponse>();
+        var profile = await profileResponse.Content.ReadFromJsonAsync<GetMyProfileResponse>(TestContext.Current.CancellationToken);
         profile.Should().NotBeNull();
         profile!.Status.Should().Be("invisible");
     }
@@ -77,7 +77,7 @@ public sealed class UserStatusTests : IClassFixture<HarmonieWebApplicationFactor
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }
@@ -94,7 +94,7 @@ public sealed class UserStatusTests : IClassFixture<HarmonieWebApplicationFactor
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var error = await response.Content.ReadFromJsonAsync<ApplicationError>();
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }
@@ -104,7 +104,8 @@ public sealed class UserStatusTests : IClassFixture<HarmonieWebApplicationFactor
     {
         var response = await _client.PutAsJsonAsync(
             "/api/users/me/status",
-            new { status = "online" });
+            new { status = "online" },
+            TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -123,7 +124,7 @@ public sealed class UserStatusTests : IClassFixture<HarmonieWebApplicationFactor
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-            var payload = await response.Content.ReadFromJsonAsync<UpdateUserStatusResponse>();
+            var payload = await response.Content.ReadFromJsonAsync<UpdateUserStatusResponse>(TestContext.Current.CancellationToken);
             payload.Should().NotBeNull();
             payload!.Status.Should().Be(status);
         }
@@ -137,7 +138,7 @@ public sealed class UserStatusTests : IClassFixture<HarmonieWebApplicationFactor
         var response = await _client.SendAuthorizedGetAsync("/api/users/me", user.AccessToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var profile = await response.Content.ReadFromJsonAsync<GetMyProfileResponse>();
+        var profile = await response.Content.ReadFromJsonAsync<GetMyProfileResponse>(TestContext.Current.CancellationToken);
         profile.Should().NotBeNull();
         profile!.Status.Should().Be("online");
     }

--- a/tests/Harmonie.API.Tests/Harmonie.API.Tests.csproj
+++ b/tests/Harmonie.API.Tests/Harmonie.API.Tests.csproj
@@ -6,9 +6,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Harmonie.API.Tests/Harmonie.API.Tests.csproj
+++ b/tests/Harmonie.API.Tests/Harmonie.API.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />
   </ItemGroup>

--- a/tests/Harmonie.Application.Tests/Auth/LoginHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Auth/LoginHandlerTests.cs
@@ -80,7 +80,7 @@ public sealed class LoginHandlerTests
             .Returns(DateTime.UtcNow.AddDays(30));
 
         // Act
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         response.Should().NotBeNull();
@@ -137,7 +137,7 @@ public sealed class LoginHandlerTests
             .Returns(DateTime.UtcNow.AddDays(30));
 
         // Act
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeTrue();
@@ -157,7 +157,7 @@ public sealed class LoginHandlerTests
             .ReturnsAsync((User?)null);
 
         // Act
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeFalse();
@@ -180,7 +180,7 @@ public sealed class LoginHandlerTests
             .ReturnsAsync(user);
 
         // Act
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeFalse();
@@ -207,7 +207,7 @@ public sealed class LoginHandlerTests
             .Returns(false);
 
         // Act
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeFalse();
@@ -262,7 +262,7 @@ public sealed class LoginHandlerTests
             .ThrowsAsync(new InvalidOperationException("Simulated write failure"));
 
         // Act
-        var act = async () => await _handler.HandleAsync(request);
+        var act = async () => await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         await act.Should().ThrowAsync<InvalidOperationException>();

--- a/tests/Harmonie.Application.Tests/Auth/LogoutAllHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Auth/LogoutAllHandlerTests.cs
@@ -39,7 +39,7 @@ public sealed class LogoutAllHandlerTests
             .Returns(Task.CompletedTask);
 
         // Act
-        var response = await _handler.HandleAsync(Unit.Value, currentUserId);
+        var response = await _handler.HandleAsync(Unit.Value, currentUserId, TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeTrue();

--- a/tests/Harmonie.Application.Tests/Auth/LogoutHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Auth/LogoutHandlerTests.cs
@@ -49,7 +49,7 @@ public sealed class LogoutHandlerTests
             .ReturnsAsync(true);
 
         // Act
-        var response = await _handler.HandleAsync(request, currentUserId);
+        var response = await _handler.HandleAsync(request, currentUserId, TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeTrue();
@@ -87,7 +87,7 @@ public sealed class LogoutHandlerTests
             .ReturnsAsync(false);
 
         // Act
-        var response = await _handler.HandleAsync(request, currentUserId);
+        var response = await _handler.HandleAsync(request, currentUserId, TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeFalse();

--- a/tests/Harmonie.Application.Tests/Auth/RefreshTokenHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Auth/RefreshTokenHandlerTests.cs
@@ -88,7 +88,7 @@ public sealed class RefreshTokenHandlerTests
         var request = new RefreshTokenRequest("old_refresh_token");
 
         // Act
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeTrue();
@@ -129,7 +129,7 @@ public sealed class RefreshTokenHandlerTests
         var request = new RefreshTokenRequest("unknown_refresh_token");
 
         // Act
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeFalse();
@@ -162,7 +162,7 @@ public sealed class RefreshTokenHandlerTests
         var request = new RefreshTokenRequest("expired_refresh_token");
 
         // Act
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeFalse();
@@ -201,7 +201,7 @@ public sealed class RefreshTokenHandlerTests
             .Returns(Task.CompletedTask);
 
         // Act
-        var response = await _handler.HandleAsync(new RefreshTokenRequest("reused_refresh_token"));
+        var response = await _handler.HandleAsync(new RefreshTokenRequest("reused_refresh_token"), TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeFalse();
@@ -293,7 +293,7 @@ public sealed class RefreshTokenHandlerTests
             .Returns(Task.CompletedTask);
 
         // Act
-        var response = await _handler.HandleAsync(new RefreshTokenRequest("race_refresh_token"));
+        var response = await _handler.HandleAsync(new RefreshTokenRequest("race_refresh_token"), TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeFalse();
@@ -354,7 +354,7 @@ public sealed class RefreshTokenHandlerTests
             .Returns(Task.CompletedTask);
 
         // Act
-        var response = await _handler.HandleAsync(new RefreshTokenRequest("legacy_reused_refresh_token"));
+        var response = await _handler.HandleAsync(new RefreshTokenRequest("legacy_reused_refresh_token"), TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeFalse();
@@ -407,7 +407,7 @@ public sealed class RefreshTokenHandlerTests
             .Returns(Task.CompletedTask);
 
         // Act
-        var response = await _handler.HandleAsync(new RefreshTokenRequest("already_reuse_detected_token"));
+        var response = await _handler.HandleAsync(new RefreshTokenRequest("already_reuse_detected_token"), TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeFalse();

--- a/tests/Harmonie.Application.Tests/Auth/RegisterHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Auth/RegisterHandlerTests.cs
@@ -83,7 +83,7 @@ public sealed class RegisterHandlerTests
             .Returns(DateTime.UtcNow.AddDays(30));
 
         // Act
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         response.Should().NotBeNull();
@@ -166,7 +166,7 @@ public sealed class RegisterHandlerTests
             .ThrowsAsync(new InvalidOperationException("Simulated write failure"));
 
         // Act
-        var act = async () => await _handler.HandleAsync(request);
+        var act = async () => await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         await act.Should().ThrowAsync<InvalidOperationException>();
@@ -210,7 +210,7 @@ public sealed class RegisterHandlerTests
             .ReturnsAsync(new UserDuplicateCheck(true, false));
 
         // Act
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeFalse();
@@ -233,7 +233,7 @@ public sealed class RegisterHandlerTests
             .ReturnsAsync(new UserDuplicateCheck(false, true));
 
         // Act
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeFalse();
@@ -258,7 +258,7 @@ public sealed class RegisterHandlerTests
             .ReturnsAsync(new UserDuplicateCheck(false, false));
 
         // Act
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeTrue();
@@ -284,7 +284,7 @@ public sealed class RegisterHandlerTests
             .ReturnsAsync(new UserDuplicateCheck(false, false));
 
         // Act
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeTrue();
@@ -312,7 +312,7 @@ public sealed class RegisterHandlerTests
             .ReturnsAsync(new UserDuplicateCheck(false, false));
 
         // Act
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         response.Success.Should().BeTrue();

--- a/tests/Harmonie.Application.Tests/Channels/AcknowledgeChannelReadHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Channels/AcknowledgeChannelReadHandlerTests.cs
@@ -52,7 +52,7 @@ public sealed class AcknowledgeChannelReadHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channelId, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((ChannelAccessContext?)null);
 
-        var response = await _handler.HandleAsync(new AcknowledgeChannelReadInput(channelId, null), callerId);
+        var response = await _handler.HandleAsync(new AcknowledgeChannelReadInput(channelId, null), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotFound);
@@ -69,7 +69,7 @@ public sealed class AcknowledgeChannelReadHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
 
-        var response = await _handler.HandleAsync(new AcknowledgeChannelReadInput(channel.Id, null), callerId);
+        var response = await _handler.HandleAsync(new AcknowledgeChannelReadInput(channel.Id, null), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotText);
@@ -86,7 +86,7 @@ public sealed class AcknowledgeChannelReadHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelAccessContext(channel, CallerRole: null));
 
-        var response = await _handler.HandleAsync(new AcknowledgeChannelReadInput(channel.Id, null), callerId);
+        var response = await _handler.HandleAsync(new AcknowledgeChannelReadInput(channel.Id, null), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Channel.AccessDenied);
@@ -108,7 +108,7 @@ public sealed class AcknowledgeChannelReadHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Message?)null);
 
-        var response = await _handler.HandleAsync(new AcknowledgeChannelReadInput(channel.Id, messageId), callerId);
+        var response = await _handler.HandleAsync(new AcknowledgeChannelReadInput(channel.Id, messageId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
@@ -131,7 +131,7 @@ public sealed class AcknowledgeChannelReadHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(messageFromOtherChannel);
 
-        var response = await _handler.HandleAsync(new AcknowledgeChannelReadInput(channel.Id, messageId), callerId);
+        var response = await _handler.HandleAsync(new AcknowledgeChannelReadInput(channel.Id, messageId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
@@ -154,7 +154,7 @@ public sealed class AcknowledgeChannelReadHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new AcknowledgeChannelReadInput(channel.Id, messageId), callerId);
+        var response = await _handler.HandleAsync(new AcknowledgeChannelReadInput(channel.Id, messageId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 
@@ -182,7 +182,7 @@ public sealed class AcknowledgeChannelReadHandlerTests
             .Setup(x => x.GetLatestChannelMessageIdAsync(channel.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(latestMessageId);
 
-        var response = await _handler.HandleAsync(new AcknowledgeChannelReadInput(channel.Id, null), callerId);
+        var response = await _handler.HandleAsync(new AcknowledgeChannelReadInput(channel.Id, null), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 
@@ -209,7 +209,7 @@ public sealed class AcknowledgeChannelReadHandlerTests
             .Setup(x => x.GetLatestChannelMessageIdAsync(channel.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync((MessageId?)null);
 
-        var response = await _handler.HandleAsync(new AcknowledgeChannelReadInput(channel.Id, null), callerId);
+        var response = await _handler.HandleAsync(new AcknowledgeChannelReadInput(channel.Id, null), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 

--- a/tests/Harmonie.Application.Tests/Channels/CreateChannelHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Channels/CreateChannelHandlerTests.cs
@@ -60,7 +60,7 @@ public sealed class CreateChannelHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guildId, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GuildAccessContext?)null);
 
-        var response = await _handler.HandleAsync(new CreateChannelInput(guildId, "general", GuildChannelType.Text, 0), callerId);
+        var response = await _handler.HandleAsync(new CreateChannelInput(guildId, "general", GuildChannelType.Text, 0), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -77,7 +77,7 @@ public sealed class CreateChannelHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, null));
 
-        var response = await _handler.HandleAsync(new CreateChannelInput(guild.Id, "general", GuildChannelType.Text, 0), callerId);
+        var response = await _handler.HandleAsync(new CreateChannelInput(guild.Id, "general", GuildChannelType.Text, 0), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -94,7 +94,7 @@ public sealed class CreateChannelHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
 
-        var response = await _handler.HandleAsync(new CreateChannelInput(guild.Id, "general", GuildChannelType.Text, 0), callerId);
+        var response = await _handler.HandleAsync(new CreateChannelInput(guild.Id, "general", GuildChannelType.Text, 0), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -119,7 +119,7 @@ public sealed class CreateChannelHandlerTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        var response = await _handler.HandleAsync(new CreateChannelInput(guild.Id, "announcements", GuildChannelType.Text, 2), adminId);
+        var response = await _handler.HandleAsync(new CreateChannelInput(guild.Id, "announcements", GuildChannelType.Text, 2), adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -136,7 +136,7 @@ public sealed class CreateChannelHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, adminId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Admin));
 
-        var response = await _handler.HandleAsync(new CreateChannelInput(guild.Id, "announcements", GuildChannelType.Text, 2), adminId);
+        var response = await _handler.HandleAsync(new CreateChannelInput(guild.Id, "announcements", GuildChannelType.Text, 2), adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -159,7 +159,7 @@ public sealed class CreateChannelHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, adminId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Admin));
 
-        var response = await _handler.HandleAsync(new CreateChannelInput(guild.Id, "Gaming", GuildChannelType.Voice, 5), adminId);
+        var response = await _handler.HandleAsync(new CreateChannelInput(guild.Id, "Gaming", GuildChannelType.Voice, 5), adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -179,7 +179,7 @@ public sealed class CreateChannelHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, adminId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Admin));
 
-        await _handler.HandleAsync(new CreateChannelInput(guild.Id, "lounge", GuildChannelType.Text, 3), adminId);
+        await _handler.HandleAsync(new CreateChannelInput(guild.Id, "lounge", GuildChannelType.Text, 3), adminId, TestContext.Current.CancellationToken);
 
         _guildChannelRepositoryMock.Verify(
             x => x.AddAsync(It.IsAny<GuildChannel>(), It.IsAny<CancellationToken>()),
@@ -200,7 +200,7 @@ public sealed class CreateChannelHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, adminId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Admin));
 
-        var response = await _handler.HandleAsync(new CreateChannelInput(guild.Id, "lounge", GuildChannelType.Text, 3), adminId);
+        var response = await _handler.HandleAsync(new CreateChannelInput(guild.Id, "lounge", GuildChannelType.Text, 3), adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 
@@ -233,7 +233,7 @@ public sealed class CreateChannelHandlerTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        var response = await _handler.HandleAsync(new CreateChannelInput(guild.Id, "lounge", GuildChannelType.Text, 3), adminId);
+        var response = await _handler.HandleAsync(new CreateChannelInput(guild.Id, "lounge", GuildChannelType.Text, 3), adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
 

--- a/tests/Harmonie.Application.Tests/Channels/DeleteChannelHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Channels/DeleteChannelHandlerTests.cs
@@ -56,7 +56,7 @@ public sealed class DeleteChannelHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channelId, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((ChannelAccessContext?)null);
 
-        var response = await _handler.HandleAsync(channelId, callerId);
+        var response = await _handler.HandleAsync(channelId, callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -73,7 +73,7 @@ public sealed class DeleteChannelHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelAccessContext(channel, CallerRole: null));
 
-        var response = await _handler.HandleAsync(channel.Id, callerId);
+        var response = await _handler.HandleAsync(channel.Id, callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -90,7 +90,7 @@ public sealed class DeleteChannelHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
 
-        var response = await _handler.HandleAsync(channel.Id, callerId);
+        var response = await _handler.HandleAsync(channel.Id, callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -107,7 +107,7 @@ public sealed class DeleteChannelHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, adminId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Admin));
 
-        var response = await _handler.HandleAsync(channel.Id, adminId);
+        var response = await _handler.HandleAsync(channel.Id, adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -128,7 +128,7 @@ public sealed class DeleteChannelHandlerTests
             .Setup(x => x.DeleteAsync(channel.Id, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var response = await _handler.HandleAsync(channel.Id, adminId);
+        var response = await _handler.HandleAsync(channel.Id, adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();

--- a/tests/Harmonie.Application.Tests/Channels/GetGuildChannelsHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Channels/GetGuildChannelsHandlerTests.cs
@@ -49,7 +49,7 @@ public sealed class GetGuildChannelsHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guildId, userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GuildAccessContext?)null);
 
-        var response = await _handler.HandleAsync(guildId, userId);
+        var response = await _handler.HandleAsync(guildId, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -66,7 +66,7 @@ public sealed class GetGuildChannelsHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, null));
 
-        var response = await _handler.HandleAsync(guild.Id, userId);
+        var response = await _handler.HandleAsync(guild.Id, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -89,7 +89,7 @@ public sealed class GetGuildChannelsHandlerTests
             .Setup(x => x.GetByGuildIdAsync(guild.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync([textChannel, voiceChannel]);
 
-        var response = await _handler.HandleAsync(guild.Id, userId);
+        var response = await _handler.HandleAsync(guild.Id, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -131,7 +131,7 @@ public sealed class GetGuildChannelsHandlerTests
             .Setup(x => x.GetAsync(voiceChannel.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync([participant]);
 
-        var response = await _handler.HandleAsync(guild.Id, userId);
+        var response = await _handler.HandleAsync(guild.Id, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();

--- a/tests/Harmonie.Application.Tests/Channels/ReorderChannelsHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Channels/ReorderChannelsHandlerTests.cs
@@ -53,7 +53,7 @@ public sealed class ReorderChannelsHandlerTests
             .ReturnsAsync((GuildAccessContext?)null);
 
         var request = new ReorderChannelsRequest([new ReorderChannelsItemRequest(GuildChannelId.New(), 0)]);
-        var response = await _handler.HandleAsync(new ReorderChannelsInput(guildId, request.Channels), callerId);
+        var response = await _handler.HandleAsync(new ReorderChannelsInput(guildId, request.Channels), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -71,7 +71,7 @@ public sealed class ReorderChannelsHandlerTests
             .ReturnsAsync(new GuildAccessContext(guild, CallerRole: null));
 
         var request = new ReorderChannelsRequest([new ReorderChannelsItemRequest(GuildChannelId.New(), 0)]);
-        var response = await _handler.HandleAsync(new ReorderChannelsInput(guild.Id, request.Channels), callerId);
+        var response = await _handler.HandleAsync(new ReorderChannelsInput(guild.Id, request.Channels), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -89,7 +89,7 @@ public sealed class ReorderChannelsHandlerTests
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
 
         var request = new ReorderChannelsRequest([new ReorderChannelsItemRequest(GuildChannelId.New(), 0)]);
-        var response = await _handler.HandleAsync(new ReorderChannelsInput(guild.Id, request.Channels), callerId);
+        var response = await _handler.HandleAsync(new ReorderChannelsInput(guild.Id, request.Channels), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -112,7 +112,7 @@ public sealed class ReorderChannelsHandlerTests
 
         var unknownChannelId = GuildChannelId.New();
         var request = new ReorderChannelsRequest([new ReorderChannelsItemRequest(unknownChannelId, 0)]);
-        var response = await _handler.HandleAsync(new ReorderChannelsInput(guild.Id, request.Channels), adminId);
+        var response = await _handler.HandleAsync(new ReorderChannelsInput(guild.Id, request.Channels), adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -139,7 +139,7 @@ public sealed class ReorderChannelsHandlerTests
             new ReorderChannelsItemRequest(channelId, 0),
             new ReorderChannelsItemRequest(channelId, 1)
         ]);
-        var response = await _handler.HandleAsync(new ReorderChannelsInput(guild.Id, request.Channels), adminId);
+        var response = await _handler.HandleAsync(new ReorderChannelsInput(guild.Id, request.Channels), adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -166,7 +166,7 @@ public sealed class ReorderChannelsHandlerTests
             new ReorderChannelsItemRequest(ch1.Id, 5),
             new ReorderChannelsItemRequest(ch2.Id, 3)
         ]);
-        var response = await _handler.HandleAsync(new ReorderChannelsInput(guild.Id, request.Channels), adminId);
+        var response = await _handler.HandleAsync(new ReorderChannelsInput(guild.Id, request.Channels), adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -199,7 +199,7 @@ public sealed class ReorderChannelsHandlerTests
             new ReorderChannelsItemRequest(ch1.Id, 5),
             new ReorderChannelsItemRequest(ch2.Id, 3)
         ]);
-        await _handler.HandleAsync(new ReorderChannelsInput(guild.Id, request.Channels), adminId);
+        await _handler.HandleAsync(new ReorderChannelsInput(guild.Id, request.Channels), adminId, TestContext.Current.CancellationToken);
 
         _guildChannelRepositoryMock.Verify(
             x => x.UpdateAsync(It.IsAny<GuildChannel>(), It.IsAny<CancellationToken>()),
@@ -229,7 +229,7 @@ public sealed class ReorderChannelsHandlerTests
         var request = new ReorderChannelsRequest([
             new ReorderChannelsItemRequest(ch1.Id, 10)
         ]);
-        await _handler.HandleAsync(new ReorderChannelsInput(guild.Id, request.Channels), adminId);
+        await _handler.HandleAsync(new ReorderChannelsInput(guild.Id, request.Channels), adminId, TestContext.Current.CancellationToken);
 
         _guildChannelRepositoryMock.Verify(
             x => x.UpdateAsync(It.IsAny<GuildChannel>(), It.IsAny<CancellationToken>()),
@@ -256,7 +256,7 @@ public sealed class ReorderChannelsHandlerTests
             new ReorderChannelsItemRequest(ch1.Id, 5),
             new ReorderChannelsItemRequest(ch2.Id, 3)
         ]);
-        await _handler.HandleAsync(new ReorderChannelsInput(guild.Id, request.Channels), adminId);
+        await _handler.HandleAsync(new ReorderChannelsInput(guild.Id, request.Channels), adminId, TestContext.Current.CancellationToken);
 
         _guildNotifierMock.Verify(
             x => x.NotifyChannelsReorderedAsync(

--- a/tests/Harmonie.Application.Tests/Channels/UpdateChannelHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Channels/UpdateChannelHandlerTests.cs
@@ -57,7 +57,7 @@ public sealed class UpdateChannelHandlerTests
             .ReturnsAsync((ChannelAccessContext?)null);
 
         var request = new UpdateChannelRequest(Name: "new-name");
-        var response = await _handler.HandleAsync(new UpdateChannelInput(channelId, request.Name, request.Position), callerId);
+        var response = await _handler.HandleAsync(new UpdateChannelInput(channelId, request.Name, request.Position), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -75,7 +75,7 @@ public sealed class UpdateChannelHandlerTests
             .ReturnsAsync(new ChannelAccessContext(channel, CallerRole: null));
 
         var request = new UpdateChannelRequest(Name: "new-name");
-        var response = await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), callerId);
+        var response = await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -93,7 +93,7 @@ public sealed class UpdateChannelHandlerTests
             .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
 
         var request = new UpdateChannelRequest(Name: "new-name");
-        var response = await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), callerId);
+        var response = await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -119,7 +119,7 @@ public sealed class UpdateChannelHandlerTests
             .ReturnsAsync(true);
 
         var request = new UpdateChannelRequest(Name: "existing-channel");
-        var response = await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), adminId);
+        var response = await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -145,7 +145,7 @@ public sealed class UpdateChannelHandlerTests
             .ReturnsAsync(false);
 
         var request = new UpdateChannelRequest(Name: "new-name");
-        var response = await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), adminId);
+        var response = await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -165,7 +165,7 @@ public sealed class UpdateChannelHandlerTests
             .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Admin));
 
         var request = new UpdateChannelRequest(Position: 5);
-        var response = await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), adminId);
+        var response = await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -192,7 +192,7 @@ public sealed class UpdateChannelHandlerTests
             .ReturnsAsync(false);
 
         var request = new UpdateChannelRequest(Name: "new-name");
-        await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), adminId);
+        await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), adminId, TestContext.Current.CancellationToken);
 
         _guildChannelRepositoryMock.Verify(
             x => x.UpdateAsync(It.IsAny<GuildChannel>(), It.IsAny<CancellationToken>()),
@@ -214,7 +214,7 @@ public sealed class UpdateChannelHandlerTests
             .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Admin));
 
         var request = new UpdateChannelRequest();
-        var response = await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), adminId);
+        var response = await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data!.Name.Should().Be("unchanged");
@@ -247,7 +247,7 @@ public sealed class UpdateChannelHandlerTests
             .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Admin));
 
         var request = new UpdateChannelRequest(Name: null, Position: null);
-        var response = await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), adminId);
+        var response = await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -278,7 +278,7 @@ public sealed class UpdateChannelHandlerTests
             .ReturnsAsync(false);
 
         var request = new UpdateChannelRequest(Name: "new-name");
-        var response = await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), adminId);
+        var response = await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 
@@ -303,7 +303,7 @@ public sealed class UpdateChannelHandlerTests
             .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Admin));
 
         var request = new UpdateChannelRequest();
-        var response = await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), adminId);
+        var response = await _handler.HandleAsync(new UpdateChannelInput(channel.Id, request.Name, request.Position), adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 

--- a/tests/Harmonie.Application.Tests/Conversations/AcknowledgeConversationReadHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/AcknowledgeConversationReadHandlerTests.cs
@@ -50,7 +50,7 @@ public sealed class AcknowledgeConversationReadHandlerTests
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversationId, It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((ConversationAccess?)null);
 
-        var response = await _handler.HandleAsync(new AcknowledgeConversationReadInput(conversationId, null), callerId);
+        var response = await _handler.HandleAsync(new AcknowledgeConversationReadInput(conversationId, null), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
@@ -69,7 +69,7 @@ public sealed class AcknowledgeConversationReadHandlerTests
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: false));
 
-        var response = await _handler.HandleAsync(new AcknowledgeConversationReadInput(conversation.Id, null), outsider);
+        var response = await _handler.HandleAsync(new AcknowledgeConversationReadInput(conversation.Id, null), outsider, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
@@ -92,7 +92,7 @@ public sealed class AcknowledgeConversationReadHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Message?)null);
 
-        var response = await _handler.HandleAsync(new AcknowledgeConversationReadInput(conversation.Id, messageId), participantOne);
+        var response = await _handler.HandleAsync(new AcknowledgeConversationReadInput(conversation.Id, messageId), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
@@ -116,7 +116,7 @@ public sealed class AcknowledgeConversationReadHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(messageFromOther);
 
-        var response = await _handler.HandleAsync(new AcknowledgeConversationReadInput(conversation.Id, messageId), participantOne);
+        var response = await _handler.HandleAsync(new AcknowledgeConversationReadInput(conversation.Id, messageId), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
@@ -140,7 +140,7 @@ public sealed class AcknowledgeConversationReadHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new AcknowledgeConversationReadInput(conversation.Id, messageId), participantOne);
+        var response = await _handler.HandleAsync(new AcknowledgeConversationReadInput(conversation.Id, messageId), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 
@@ -169,7 +169,7 @@ public sealed class AcknowledgeConversationReadHandlerTests
             .Setup(x => x.GetLatestConversationMessageIdAsync(conversation.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(latestMessageId);
 
-        var response = await _handler.HandleAsync(new AcknowledgeConversationReadInput(conversation.Id, null), participantOne);
+        var response = await _handler.HandleAsync(new AcknowledgeConversationReadInput(conversation.Id, null), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 
@@ -197,7 +197,7 @@ public sealed class AcknowledgeConversationReadHandlerTests
             .Setup(x => x.GetLatestConversationMessageIdAsync(conversation.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync((MessageId?)null);
 
-        var response = await _handler.HandleAsync(new AcknowledgeConversationReadInput(conversation.Id, null), participantOne);
+        var response = await _handler.HandleAsync(new AcknowledgeConversationReadInput(conversation.Id, null), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 

--- a/tests/Harmonie.Application.Tests/Conversations/CreateGroupConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/CreateGroupConversationHandlerTests.cs
@@ -54,7 +54,8 @@ public sealed class CreateGroupConversationHandlerTests
 
         var response = await _handler.HandleAsync(
             new CreateGroupConversationRequest("Team Chat", [participantA.Value, participantB.Value]),
-            caller);
+            caller,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -76,7 +77,8 @@ public sealed class CreateGroupConversationHandlerTests
 
         var response = await _handler.HandleAsync(
             new CreateGroupConversationRequest("Team Chat", [caller.Value, participantB.Value]),
-            caller);
+            caller,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -105,7 +107,8 @@ public sealed class CreateGroupConversationHandlerTests
 
         var response = await _handler.HandleAsync(
             new CreateGroupConversationRequest("Team Chat", [caller.Value, participantB.Value]),
-            caller);
+            caller,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -145,7 +148,8 @@ public sealed class CreateGroupConversationHandlerTests
 
         var response = await _handler.HandleAsync(
             new CreateGroupConversationRequest(null, [caller.Value, participantB.Value]),
-            caller);
+            caller,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();

--- a/tests/Harmonie.Application.Tests/Conversations/DeleteConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/DeleteConversationHandlerTests.cs
@@ -55,7 +55,7 @@ public sealed class DeleteConversationHandlerTests
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversationId, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((ConversationAccess?)null);
 
-        var response = await _handler.HandleAsync(new DeleteConversationInput(conversationId), callerId);
+        var response = await _handler.HandleAsync(new DeleteConversationInput(conversationId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
@@ -76,7 +76,7 @@ public sealed class DeleteConversationHandlerTests
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: false));
 
-        var response = await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), outsider);
+        var response = await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), outsider, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
@@ -100,7 +100,7 @@ public sealed class DeleteConversationHandlerTests
             .Setup(x => x.RemoveParticipantAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
-        var response = await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId);
+        var response = await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -121,7 +121,7 @@ public sealed class DeleteConversationHandlerTests
             .Setup(x => x.RemoveParticipantAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
-        await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId);
+        await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
 
         _conversationNotifierMock.Verify(
             x => x.NotifyParticipantLeftAsync(
@@ -150,7 +150,7 @@ public sealed class DeleteConversationHandlerTests
             .Setup(x => x.RemoveParticipantAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(0);
 
-        await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId);
+        await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
 
         _conversationRepositoryMock.Verify(
             x => x.DeleteAsync(conversation.Id, It.IsAny<CancellationToken>()),
@@ -172,7 +172,7 @@ public sealed class DeleteConversationHandlerTests
             .Setup(x => x.RemoveParticipantAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
-        await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId);
+        await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
 
         _conversationRepositoryMock.Verify(
             x => x.DeleteAsync(It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()),
@@ -200,7 +200,7 @@ public sealed class DeleteConversationHandlerTests
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("SignalR unavailable"));
 
-        var response = await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId);
+        var response = await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         _conversationRepositoryMock.Verify(

--- a/tests/Harmonie.Application.Tests/Conversations/ListConversationsHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/ListConversationsHandlerTests.cs
@@ -31,7 +31,7 @@ public sealed class ListConversationsHandlerTests
             .Setup(x => x.GetUserConversationsAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
 
-        var response = await _handler.HandleAsync(Unit.Value, userId);
+        var response = await _handler.HandleAsync(Unit.Value, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -72,7 +72,7 @@ public sealed class ListConversationsHandlerTests
                     firstCreatedAt)
             ]);
 
-        var response = await _handler.HandleAsync(Unit.Value, userId);
+        var response = await _handler.HandleAsync(Unit.Value, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();

--- a/tests/Harmonie.Application.Tests/Conversations/OpenConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/OpenConversationHandlerTests.cs
@@ -39,7 +39,8 @@ public sealed class OpenConversationHandlerTests
 
         var response = await _handler.HandleAsync(
             new OpenConversationRequest(callerUserId),
-            callerUserId);
+            callerUserId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -61,7 +62,8 @@ public sealed class OpenConversationHandlerTests
 
         var response = await _handler.HandleAsync(
             new OpenConversationRequest(targetUserId),
-            callerUserId);
+            callerUserId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -89,7 +91,8 @@ public sealed class OpenConversationHandlerTests
 
         var response = await _handler.HandleAsync(
             new OpenConversationRequest(targetUserId),
-            callerUserId);
+            callerUserId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -120,7 +123,8 @@ public sealed class OpenConversationHandlerTests
 
         var response = await _handler.HandleAsync(
             new OpenConversationRequest(targetUserId),
-            callerUserId);
+            callerUserId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();

--- a/tests/Harmonie.Application.Tests/Guilds/AcceptInviteHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/AcceptInviteHandlerTests.cs
@@ -57,7 +57,7 @@ public sealed class AcceptInviteHandlerTests
             .Setup(x => x.GetAcceptDetailsByCodeAsync(InviteCode, It.IsAny<CancellationToken>()))
             .ReturnsAsync((InviteAcceptDetails?)null);
 
-        var response = await _handler.HandleAsync(InviteCode, _callerId);
+        var response = await _handler.HandleAsync(InviteCode, _callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Invite.NotFound);
@@ -74,7 +74,7 @@ public sealed class AcceptInviteHandlerTests
             .Setup(x => x.GetAcceptDetailsByCodeAsync(InviteCode, It.IsAny<CancellationToken>()))
             .ReturnsAsync(details);
 
-        var response = await _handler.HandleAsync(InviteCode, _callerId);
+        var response = await _handler.HandleAsync(InviteCode, _callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Invite.Expired);
@@ -91,7 +91,7 @@ public sealed class AcceptInviteHandlerTests
             .Setup(x => x.GetAcceptDetailsByCodeAsync(InviteCode, It.IsAny<CancellationToken>()))
             .ReturnsAsync(details);
 
-        var response = await _handler.HandleAsync(InviteCode, _callerId);
+        var response = await _handler.HandleAsync(InviteCode, _callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Invite.Exhausted);
@@ -112,7 +112,7 @@ public sealed class AcceptInviteHandlerTests
             .Setup(x => x.IsMemberAsync(_guildId, _callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        var response = await _handler.HandleAsync(InviteCode, _callerId);
+        var response = await _handler.HandleAsync(InviteCode, _callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.MemberAlreadyExists);
@@ -137,7 +137,7 @@ public sealed class AcceptInviteHandlerTests
             .Setup(x => x.TryAddAsync(It.IsAny<GuildMember>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        var response = await _handler.HandleAsync(InviteCode, _callerId);
+        var response = await _handler.HandleAsync(InviteCode, _callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -172,7 +172,7 @@ public sealed class AcceptInviteHandlerTests
             .Setup(x => x.TryAddAsync(It.IsAny<GuildMember>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
-        var response = await _handler.HandleAsync(InviteCode, _callerId);
+        var response = await _handler.HandleAsync(InviteCode, _callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.MemberAlreadyExists);

--- a/tests/Harmonie.Application.Tests/Guilds/BanMemberHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/BanMemberHandlerTests.cs
@@ -60,7 +60,7 @@ public sealed class BanMemberHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guildId, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GuildAccessContext?)null);
 
-        var response = await _handler.HandleAsync(new BanMemberInput(guildId, targetId, null, 0), callerId);
+        var response = await _handler.HandleAsync(new BanMemberInput(guildId, targetId, null, 0), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -78,7 +78,7 @@ public sealed class BanMemberHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
 
-        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, null, 0), callerId);
+        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, null, 0), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
@@ -94,7 +94,7 @@ public sealed class BanMemberHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, ownerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Admin));
 
-        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, ownerId, null, 0), ownerId);
+        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, ownerId, null, 0), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.CannotBanSelf);
@@ -111,7 +111,7 @@ public sealed class BanMemberHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Admin));
 
-        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, ownerId, null, 0), callerId);
+        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, ownerId, null, 0), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.OwnerCannotBeBanned);
@@ -133,7 +133,7 @@ public sealed class BanMemberHandlerTests
             .Setup(x => x.GetRoleAsync(guild.Id, targetId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(GuildRole.Admin);
 
-        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, null, 0), callerId);
+        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, null, 0), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
@@ -158,7 +158,7 @@ public sealed class BanMemberHandlerTests
             .Setup(x => x.TryAddAsync(It.IsAny<GuildBan>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, "Abuse", 0), ownerId);
+        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, "Abuse", 0), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -188,7 +188,7 @@ public sealed class BanMemberHandlerTests
             .Setup(x => x.TryAddAsync(It.IsAny<GuildBan>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
-        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, null, 0), ownerId);
+        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, null, 0), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.AlreadyBanned);
@@ -213,7 +213,7 @@ public sealed class BanMemberHandlerTests
             .Setup(x => x.TryAddAsync(It.IsAny<GuildBan>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, null, 0), ownerId);
+        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, null, 0), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -249,7 +249,7 @@ public sealed class BanMemberHandlerTests
             .Setup(x => x.TryAddAsync(It.IsAny<GuildBan>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, null, 0), ownerId);
+        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, null, 0), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 
@@ -279,7 +279,7 @@ public sealed class BanMemberHandlerTests
             .Setup(x => x.TryAddAsync(It.IsAny<GuildBan>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, null, 0), ownerId);
+        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, null, 0), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 
@@ -311,7 +311,7 @@ public sealed class BanMemberHandlerTests
             .Setup(x => x.SoftDeleteByAuthorInGuildAsync(guild.Id, targetId, 3, It.IsAny<CancellationToken>()))
             .ReturnsAsync(5);
 
-        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, null, 3), ownerId);
+        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, null, 3), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 
@@ -339,7 +339,7 @@ public sealed class BanMemberHandlerTests
             .Setup(x => x.TryAddAsync(It.IsAny<GuildBan>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, null, 0), ownerId);
+        var response = await _handler.HandleAsync(new BanMemberInput(guild.Id, targetId, null, 0), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 

--- a/tests/Harmonie.Application.Tests/Guilds/CreateGuildHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/CreateGuildHandlerTests.cs
@@ -52,7 +52,7 @@ public sealed class CreateGuildHandlerTests
         var request = new CreateGuildRequest("Harmonie Team");
         var userId = UserId.New();
 
-        var response = await _handler.HandleAsync(request, userId);
+        var response = await _handler.HandleAsync(request, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -82,7 +82,7 @@ public sealed class CreateGuildHandlerTests
         var request = new CreateGuildRequest("ab");
         var userId = UserId.New();
 
-        var response = await _handler.HandleAsync(request, userId);
+        var response = await _handler.HandleAsync(request, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Data.Should().BeNull();
@@ -104,7 +104,7 @@ public sealed class CreateGuildHandlerTests
                 Bg: "#1F2937"));
         var userId = UserId.New();
 
-        var response = await _handler.HandleAsync(request, userId);
+        var response = await _handler.HandleAsync(request, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -123,7 +123,7 @@ public sealed class CreateGuildHandlerTests
             Icon: new CreateGuildIconRequest(Color: "#F59E0B"));
         var userId = UserId.New();
 
-        var response = await _handler.HandleAsync(request, userId);
+        var response = await _handler.HandleAsync(request, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -143,7 +143,7 @@ public sealed class CreateGuildHandlerTests
             IconFileId: iconFileId);
         var userId = UserId.New();
 
-        var response = await _handler.HandleAsync(request, userId);
+        var response = await _handler.HandleAsync(request, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();

--- a/tests/Harmonie.Application.Tests/Guilds/CreateGuildInviteHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/CreateGuildInviteHandlerTests.cs
@@ -47,7 +47,7 @@ public sealed class CreateGuildInviteHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guildId, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GuildAccessContext?)null);
 
-        var response = await _handler.HandleAsync(new CreateGuildInviteInput(guildId), callerId);
+        var response = await _handler.HandleAsync(new CreateGuildInviteInput(guildId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.NotFound);
@@ -63,7 +63,7 @@ public sealed class CreateGuildInviteHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
 
-        var response = await _handler.HandleAsync(new CreateGuildInviteInput(guild.Id), callerId);
+        var response = await _handler.HandleAsync(new CreateGuildInviteInput(guild.Id), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.InviteForbidden);
@@ -79,7 +79,7 @@ public sealed class CreateGuildInviteHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, null));
 
-        var response = await _handler.HandleAsync(new CreateGuildInviteInput(guild.Id), callerId);
+        var response = await _handler.HandleAsync(new CreateGuildInviteInput(guild.Id), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.InviteForbidden);
@@ -94,7 +94,7 @@ public sealed class CreateGuildInviteHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Admin));
 
-        var response = await _handler.HandleAsync(new CreateGuildInviteInput(guild.Id, MaxUses: 10, ExpiresInHours: 24), callerId);
+        var response = await _handler.HandleAsync(new CreateGuildInviteInput(guild.Id, MaxUses: 10, ExpiresInHours: 24), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -119,7 +119,7 @@ public sealed class CreateGuildInviteHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Admin));
 
-        var response = await _handler.HandleAsync(new CreateGuildInviteInput(guild.Id), callerId);
+        var response = await _handler.HandleAsync(new CreateGuildInviteInput(guild.Id), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();

--- a/tests/Harmonie.Application.Tests/Guilds/DeleteGuildHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/DeleteGuildHandlerTests.cs
@@ -64,7 +64,7 @@ public sealed class DeleteGuildHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guildId, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GuildAccessContext?)null);
 
-        var response = await _handler.HandleAsync(new DeleteGuildInput(guildId), callerId);
+        var response = await _handler.HandleAsync(new DeleteGuildInput(guildId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -82,7 +82,7 @@ public sealed class DeleteGuildHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Admin));
 
-        var response = await _handler.HandleAsync(new DeleteGuildInput(guild.Id), callerId);
+        var response = await _handler.HandleAsync(new DeleteGuildInput(guild.Id), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -100,7 +100,7 @@ public sealed class DeleteGuildHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, ownerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Admin));
 
-        var response = await _handler.HandleAsync(new DeleteGuildInput(guild.Id), ownerId);
+        var response = await _handler.HandleAsync(new DeleteGuildInput(guild.Id), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         _guildRepositoryMock.Verify(
@@ -144,7 +144,7 @@ public sealed class DeleteGuildHandlerTests
                 It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var response = await _handler.HandleAsync(new DeleteGuildInput(guild.Id), ownerId);
+        var response = await _handler.HandleAsync(new DeleteGuildInput(guild.Id), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
     }
@@ -165,7 +165,7 @@ public sealed class DeleteGuildHandlerTests
             .Setup(x => x.GetByIdAsync(iconFileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(uploadedFile);
 
-        var response = await _handler.HandleAsync(new DeleteGuildInput(guild.Id), ownerId);
+        var response = await _handler.HandleAsync(new DeleteGuildInput(guild.Id), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         _uploadedFileRepositoryMock.Verify(
@@ -190,7 +190,7 @@ public sealed class DeleteGuildHandlerTests
             .Setup(x => x.NotifyGuildDeletedAsync(It.IsAny<GuildDeletedNotification>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("SignalR unavailable"));
 
-        var response = await _handler.HandleAsync(new DeleteGuildInput(guild.Id), ownerId);
+        var response = await _handler.HandleAsync(new DeleteGuildInput(guild.Id), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         _guildRepositoryMock.Verify(

--- a/tests/Harmonie.Application.Tests/Guilds/GetGuildMembersHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/GetGuildMembersHandlerTests.cs
@@ -38,7 +38,7 @@ public sealed class GetGuildMembersHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guildId, requesterUserId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GuildAccessContext?)null);
 
-        var response = await _handler.HandleAsync(guildId, requesterUserId);
+        var response = await _handler.HandleAsync(guildId, requesterUserId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -55,7 +55,7 @@ public sealed class GetGuildMembersHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, requesterUserId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, null));
 
-        var response = await _handler.HandleAsync(guild.Id, requesterUserId);
+        var response = await _handler.HandleAsync(guild.Id, requesterUserId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -78,7 +78,7 @@ public sealed class GetGuildMembersHandlerTests
             .Setup(x => x.GetGuildMembersAsync(guild.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync([adminUser, memberUser]);
 
-        var response = await _handler.HandleAsync(guild.Id, requesterUserId);
+        var response = await _handler.HandleAsync(guild.Id, requesterUserId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();

--- a/tests/Harmonie.Application.Tests/Guilds/LeaveGuildHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/LeaveGuildHandlerTests.cs
@@ -44,7 +44,7 @@ public sealed class LeaveGuildHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guildId, userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GuildAccessContext?)null);
 
-        var response = await _handler.HandleAsync(new LeaveGuildInput(guildId), userId);
+        var response = await _handler.HandleAsync(new LeaveGuildInput(guildId), userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -61,7 +61,7 @@ public sealed class LeaveGuildHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, null));
 
-        var response = await _handler.HandleAsync(new LeaveGuildInput(guild.Id), userId);
+        var response = await _handler.HandleAsync(new LeaveGuildInput(guild.Id), userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -78,7 +78,7 @@ public sealed class LeaveGuildHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, ownerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Admin));
 
-        var response = await _handler.HandleAsync(new LeaveGuildInput(guild.Id), ownerId);
+        var response = await _handler.HandleAsync(new LeaveGuildInput(guild.Id), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -99,7 +99,7 @@ public sealed class LeaveGuildHandlerTests
             .Setup(x => x.RemoveAsync(guild.Id, memberId, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var response = await _handler.HandleAsync(new LeaveGuildInput(guild.Id), memberId);
+        var response = await _handler.HandleAsync(new LeaveGuildInput(guild.Id), memberId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -124,7 +124,7 @@ public sealed class LeaveGuildHandlerTests
             .Setup(x => x.RemoveAsync(guild.Id, adminId, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var response = await _handler.HandleAsync(new LeaveGuildInput(guild.Id), adminId);
+        var response = await _handler.HandleAsync(new LeaveGuildInput(guild.Id), adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();

--- a/tests/Harmonie.Application.Tests/Guilds/ListBansHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/ListBansHandlerTests.cs
@@ -39,7 +39,7 @@ public sealed class ListBansHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guildId, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GuildAccessContext?)null);
 
-        var response = await _handler.HandleAsync(guildId, callerId);
+        var response = await _handler.HandleAsync(guildId, callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -56,7 +56,7 @@ public sealed class ListBansHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
 
-        var response = await _handler.HandleAsync(guild.Id, callerId);
+        var response = await _handler.HandleAsync(guild.Id, callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
@@ -72,7 +72,7 @@ public sealed class ListBansHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, null));
 
-        var response = await _handler.HandleAsync(guild.Id, callerId);
+        var response = await _handler.HandleAsync(guild.Id, callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
@@ -92,7 +92,7 @@ public sealed class ListBansHandlerTests
             .Setup(x => x.GetByGuildIdAsync(guild.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<GuildBanWithUser>());
 
-        var response = await _handler.HandleAsync(guild.Id, ownerId);
+        var response = await _handler.HandleAsync(guild.Id, ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -131,7 +131,7 @@ public sealed class ListBansHandlerTests
             .Setup(x => x.GetByGuildIdAsync(guild.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(bans);
 
-        var response = await _handler.HandleAsync(guild.Id, ownerId);
+        var response = await _handler.HandleAsync(guild.Id, ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();

--- a/tests/Harmonie.Application.Tests/Guilds/ListUserGuildsHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/ListUserGuildsHandlerTests.cs
@@ -34,7 +34,7 @@ public sealed class ListUserGuildsHandlerTests
             .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
 
-        var response = await _handler.HandleAsync(Unit.Value, userId);
+        var response = await _handler.HandleAsync(Unit.Value, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -60,7 +60,7 @@ public sealed class ListUserGuildsHandlerTests
             .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync([guildOne, guildTwo]);
 
-        var response = await _handler.HandleAsync(Unit.Value, userId);
+        var response = await _handler.HandleAsync(Unit.Value, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();

--- a/tests/Harmonie.Application.Tests/Guilds/PreviewInviteHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/PreviewInviteHandlerTests.cs
@@ -30,7 +30,7 @@ public sealed class PreviewInviteHandlerTests
             .Setup(x => x.GetPreviewByCodeAsync("ABCD1234", It.IsAny<CancellationToken>()))
             .ReturnsAsync((InvitePreview?)null);
 
-        var response = await _handler.HandleAsync("ABCD1234");
+        var response = await _handler.HandleAsync("ABCD1234", TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Invite.NotFound);
@@ -55,7 +55,7 @@ public sealed class PreviewInviteHandlerTests
             .Setup(x => x.GetPreviewByCodeAsync("ABCD1234", It.IsAny<CancellationToken>()))
             .ReturnsAsync(preview);
 
-        var response = await _handler.HandleAsync("ABCD1234");
+        var response = await _handler.HandleAsync("ABCD1234", TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Invite.Expired);
@@ -80,7 +80,7 @@ public sealed class PreviewInviteHandlerTests
             .Setup(x => x.GetPreviewByCodeAsync("ABCD1234", It.IsAny<CancellationToken>()))
             .ReturnsAsync(preview);
 
-        var response = await _handler.HandleAsync("ABCD1234");
+        var response = await _handler.HandleAsync("ABCD1234", TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Invite.Exhausted);
@@ -106,7 +106,7 @@ public sealed class PreviewInviteHandlerTests
             .Setup(x => x.GetPreviewByCodeAsync("ABCD1234", It.IsAny<CancellationToken>()))
             .ReturnsAsync(preview);
 
-        var response = await _handler.HandleAsync("ABCD1234");
+        var response = await _handler.HandleAsync("ABCD1234", TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -141,7 +141,7 @@ public sealed class PreviewInviteHandlerTests
             .Setup(x => x.GetPreviewByCodeAsync("ABCD1234", It.IsAny<CancellationToken>()))
             .ReturnsAsync(preview);
 
-        var response = await _handler.HandleAsync("ABCD1234");
+        var response = await _handler.HandleAsync("ABCD1234", TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data!.GuildIconFileId.Should().BeNull();

--- a/tests/Harmonie.Application.Tests/Guilds/RemoveMemberHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/RemoveMemberHandlerTests.cs
@@ -46,7 +46,7 @@ public sealed class RemoveMemberHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guildId, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GuildAccessContext?)null);
 
-        var response = await _handler.HandleAsync(new RemoveMemberInput(guildId, targetId), callerId);
+        var response = await _handler.HandleAsync(new RemoveMemberInput(guildId, targetId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -64,7 +64,7 @@ public sealed class RemoveMemberHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, null));
 
-        var response = await _handler.HandleAsync(new RemoveMemberInput(guild.Id, targetId), callerId);
+        var response = await _handler.HandleAsync(new RemoveMemberInput(guild.Id, targetId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -82,7 +82,7 @@ public sealed class RemoveMemberHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
 
-        var response = await _handler.HandleAsync(new RemoveMemberInput(guild.Id, targetId), callerId);
+        var response = await _handler.HandleAsync(new RemoveMemberInput(guild.Id, targetId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -104,7 +104,7 @@ public sealed class RemoveMemberHandlerTests
             .Setup(x => x.GetRoleAsync(guild.Id, targetId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GuildRole?)null);
 
-        var response = await _handler.HandleAsync(new RemoveMemberInput(guild.Id, targetId), ownerId);
+        var response = await _handler.HandleAsync(new RemoveMemberInput(guild.Id, targetId), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -126,7 +126,7 @@ public sealed class RemoveMemberHandlerTests
             .Setup(x => x.GetRoleAsync(guild.Id, ownerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(GuildRole.Admin);
 
-        var response = await _handler.HandleAsync(new RemoveMemberInput(guild.Id, ownerId), callerId);
+        var response = await _handler.HandleAsync(new RemoveMemberInput(guild.Id, ownerId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -153,7 +153,7 @@ public sealed class RemoveMemberHandlerTests
             .Setup(x => x.RemoveAsync(guild.Id, targetId, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var response = await _handler.HandleAsync(new RemoveMemberInput(guild.Id, targetId), callerId);
+        var response = await _handler.HandleAsync(new RemoveMemberInput(guild.Id, targetId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -188,7 +188,7 @@ public sealed class RemoveMemberHandlerTests
             .Setup(x => x.NotifyMemberRemovedAsync(It.IsAny<MemberRemovedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        await _handler.HandleAsync(new RemoveMemberInput(guild.Id, targetId), callerId);
+        await _handler.HandleAsync(new RemoveMemberInput(guild.Id, targetId), callerId, TestContext.Current.CancellationToken);
 
         _guildNotifierMock.Verify(
             x => x.NotifyMemberRemovedAsync(

--- a/tests/Harmonie.Application.Tests/Guilds/TransferOwnershipHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/TransferOwnershipHandlerTests.cs
@@ -54,7 +54,7 @@ public sealed class TransferOwnershipHandlerTests
         var ownerId = UserId.New();
         var guild = ApplicationTestBuilders.CreateGuild(ownerId);
 
-        var response = await _handler.HandleAsync(new TransferOwnershipInput(guild.Id, ownerId), ownerId);
+        var response = await _handler.HandleAsync(new TransferOwnershipInput(guild.Id, ownerId), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.OwnerTransferToSelf);
@@ -72,7 +72,7 @@ public sealed class TransferOwnershipHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guildId, newOwnerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GuildAccessContext?)null);
 
-        var response = await _handler.HandleAsync(new TransferOwnershipInput(guildId, newOwnerId), callerId);
+        var response = await _handler.HandleAsync(new TransferOwnershipInput(guildId, newOwnerId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.NotFound);
@@ -90,7 +90,7 @@ public sealed class TransferOwnershipHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, newOwnerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
 
-        var response = await _handler.HandleAsync(new TransferOwnershipInput(guild.Id, newOwnerId), callerId);
+        var response = await _handler.HandleAsync(new TransferOwnershipInput(guild.Id, newOwnerId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
@@ -107,7 +107,7 @@ public sealed class TransferOwnershipHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, newOwnerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, null));
 
-        var response = await _handler.HandleAsync(new TransferOwnershipInput(guild.Id, newOwnerId), ownerId);
+        var response = await _handler.HandleAsync(new TransferOwnershipInput(guild.Id, newOwnerId), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.MemberNotFound);
@@ -133,7 +133,7 @@ public sealed class TransferOwnershipHandlerTests
             .Setup(x => x.UpdateRoleAsync(guild.Id, newOwnerId, GuildRole.Admin, It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
-        var response = await _handler.HandleAsync(new TransferOwnershipInput(guild.Id, newOwnerId), ownerId);
+        var response = await _handler.HandleAsync(new TransferOwnershipInput(guild.Id, newOwnerId), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -178,7 +178,7 @@ public sealed class TransferOwnershipHandlerTests
             .Setup(x => x.UpdateRoleAsync(guild.Id, newOwnerId, GuildRole.Admin, It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
-        var response = await _handler.HandleAsync(new TransferOwnershipInput(guild.Id, newOwnerId), ownerId);
+        var response = await _handler.HandleAsync(new TransferOwnershipInput(guild.Id, newOwnerId), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 
@@ -210,7 +210,7 @@ public sealed class TransferOwnershipHandlerTests
             .Setup(x => x.UpdateRoleAsync(guild.Id, newOwnerId, GuildRole.Admin, It.IsAny<CancellationToken>()))
             .ReturnsAsync(0);
 
-        var response = await _handler.HandleAsync(new TransferOwnershipInput(guild.Id, newOwnerId), ownerId);
+        var response = await _handler.HandleAsync(new TransferOwnershipInput(guild.Id, newOwnerId), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.MemberNotFound);

--- a/tests/Harmonie.Application.Tests/Guilds/UnbanMemberHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/UnbanMemberHandlerTests.cs
@@ -49,7 +49,7 @@ public sealed class UnbanMemberHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guildId, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GuildAccessContext?)null);
 
-        var response = await _handler.HandleAsync(new UnbanMemberInput(guildId, targetId), callerId);
+        var response = await _handler.HandleAsync(new UnbanMemberInput(guildId, targetId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -67,7 +67,7 @@ public sealed class UnbanMemberHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
 
-        var response = await _handler.HandleAsync(new UnbanMemberInput(guild.Id, targetId), callerId);
+        var response = await _handler.HandleAsync(new UnbanMemberInput(guild.Id, targetId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
@@ -84,7 +84,7 @@ public sealed class UnbanMemberHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, null));
 
-        var response = await _handler.HandleAsync(new UnbanMemberInput(guild.Id, targetId), callerId);
+        var response = await _handler.HandleAsync(new UnbanMemberInput(guild.Id, targetId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.AccessDenied);
@@ -105,7 +105,7 @@ public sealed class UnbanMemberHandlerTests
             .Setup(x => x.DeleteAsync(guild.Id, targetId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
-        var response = await _handler.HandleAsync(new UnbanMemberInput(guild.Id, targetId), ownerId);
+        var response = await _handler.HandleAsync(new UnbanMemberInput(guild.Id, targetId), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Guild.NotBanned);
@@ -126,7 +126,7 @@ public sealed class UnbanMemberHandlerTests
             .Setup(x => x.DeleteAsync(guild.Id, targetId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        var response = await _handler.HandleAsync(new UnbanMemberInput(guild.Id, targetId), ownerId);
+        var response = await _handler.HandleAsync(new UnbanMemberInput(guild.Id, targetId), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 

--- a/tests/Harmonie.Application.Tests/Guilds/UpdateGuildHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/UpdateGuildHandlerTests.cs
@@ -60,7 +60,7 @@ public sealed class UpdateGuildHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guildId, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GuildAccessContext?)null);
 
-        var response = await _handler.HandleAsync(new UpdateGuildInput(guildId, null, null, null, null, null, false, false, false, false, false), callerId);
+        var response = await _handler.HandleAsync(new UpdateGuildInput(guildId, null, null, null, null, null, false, false, false, false, false), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -77,7 +77,7 @@ public sealed class UpdateGuildHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
 
-        var response = await _handler.HandleAsync(new UpdateGuildInput(guild.Id, null, null, null, null, null, false, false, false, false, false), callerId);
+        var response = await _handler.HandleAsync(new UpdateGuildInput(guild.Id, null, null, null, null, null, false, false, false, false, false), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -109,7 +109,7 @@ public sealed class UpdateGuildHandlerTests
             IconBgIsSet = true
         };
 
-        var response = await _handler.HandleAsync(new UpdateGuildInput(guild.Id, request.Name, request.IconFileId, request.IconColor, request.IconName, request.IconBg, request.NameIsSet, request.IconFileIdIsSet, request.IconColorIsSet, request.IconNameIsSet, request.IconBgIsSet), adminId);
+        var response = await _handler.HandleAsync(new UpdateGuildInput(guild.Id, request.Name, request.IconFileId, request.IconColor, request.IconName, request.IconBg, request.NameIsSet, request.IconFileIdIsSet, request.IconColorIsSet, request.IconNameIsSet, request.IconBgIsSet), adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -157,7 +157,7 @@ public sealed class UpdateGuildHandlerTests
             IconBgIsSet = true
         };
 
-        var response = await _handler.HandleAsync(new UpdateGuildInput(guild.Id, request.Name, request.IconFileId, request.IconColor, request.IconName, request.IconBg, request.NameIsSet, request.IconFileIdIsSet, request.IconColorIsSet, request.IconNameIsSet, request.IconBgIsSet), ownerId);
+        var response = await _handler.HandleAsync(new UpdateGuildInput(guild.Id, request.Name, request.IconFileId, request.IconColor, request.IconName, request.IconBg, request.NameIsSet, request.IconFileIdIsSet, request.IconColorIsSet, request.IconNameIsSet, request.IconBgIsSet), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -174,7 +174,7 @@ public sealed class UpdateGuildHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, ownerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
 
-        var response = await _handler.HandleAsync(new UpdateGuildInput(guild.Id, null, null, null, null, null, false, false, false, false, false), ownerId);
+        var response = await _handler.HandleAsync(new UpdateGuildInput(guild.Id, null, null, null, null, null, false, false, false, false, false), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         _guildRepositoryMock.Verify(
@@ -207,7 +207,7 @@ public sealed class UpdateGuildHandlerTests
             IconFileIdIsSet = true
         };
 
-        var response = await _handler.HandleAsync(new UpdateGuildInput(guild.Id, request.Name, request.IconFileId, request.IconColor, request.IconName, request.IconBg, request.NameIsSet, request.IconFileIdIsSet, request.IconColorIsSet, request.IconNameIsSet, request.IconBgIsSet), ownerId);
+        var response = await _handler.HandleAsync(new UpdateGuildInput(guild.Id, request.Name, request.IconFileId, request.IconColor, request.IconName, request.IconBg, request.NameIsSet, request.IconFileIdIsSet, request.IconColorIsSet, request.IconNameIsSet, request.IconBgIsSet), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         _objectStorageServiceMock.Verify(
@@ -240,7 +240,7 @@ public sealed class UpdateGuildHandlerTests
             IconFileIdIsSet = true
         };
 
-        var response = await _handler.HandleAsync(new UpdateGuildInput(guild.Id, request.Name, request.IconFileId, request.IconColor, request.IconName, request.IconBg, request.NameIsSet, request.IconFileIdIsSet, request.IconColorIsSet, request.IconNameIsSet, request.IconBgIsSet), ownerId);
+        var response = await _handler.HandleAsync(new UpdateGuildInput(guild.Id, request.Name, request.IconFileId, request.IconColor, request.IconName, request.IconBg, request.NameIsSet, request.IconFileIdIsSet, request.IconColorIsSet, request.IconNameIsSet, request.IconBgIsSet), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         _uploadedFileRepositoryMock.Verify(
@@ -267,7 +267,8 @@ public sealed class UpdateGuildHandlerTests
 
         var response = await _handler.HandleAsync(
             new UpdateGuildInput(guild.Id, "Updated Name", null, null, null, null, true, false, false, false, false),
-            ownerId);
+            ownerId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 
@@ -293,7 +294,8 @@ public sealed class UpdateGuildHandlerTests
 
         var response = await _handler.HandleAsync(
             new UpdateGuildInput(guild.Id, null, null, null, null, null, false, false, false, false, false),
-            ownerId);
+            ownerId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         _guildNotifierMock.Verify(

--- a/tests/Harmonie.Application.Tests/Guilds/UpdateMemberRoleHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/UpdateMemberRoleHandlerTests.cs
@@ -43,7 +43,7 @@ public sealed class UpdateMemberRoleHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guildId, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GuildAccessContext?)null);
 
-        var response = await _handler.HandleAsync(new UpdateMemberRoleInput(guildId, targetId, GuildRole.Admin), callerId);
+        var response = await _handler.HandleAsync(new UpdateMemberRoleInput(guildId, targetId, GuildRole.Admin), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -61,7 +61,7 @@ public sealed class UpdateMemberRoleHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, null));
 
-        var response = await _handler.HandleAsync(new UpdateMemberRoleInput(guild.Id, targetId, GuildRole.Admin), callerId);
+        var response = await _handler.HandleAsync(new UpdateMemberRoleInput(guild.Id, targetId, GuildRole.Admin), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -79,7 +79,7 @@ public sealed class UpdateMemberRoleHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
 
-        var response = await _handler.HandleAsync(new UpdateMemberRoleInput(guild.Id, targetId, GuildRole.Admin), callerId);
+        var response = await _handler.HandleAsync(new UpdateMemberRoleInput(guild.Id, targetId, GuildRole.Admin), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -101,7 +101,7 @@ public sealed class UpdateMemberRoleHandlerTests
             .Setup(x => x.GetRoleAsync(guild.Id, targetId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GuildRole?)null);
 
-        var response = await _handler.HandleAsync(new UpdateMemberRoleInput(guild.Id, targetId, GuildRole.Admin), callerId);
+        var response = await _handler.HandleAsync(new UpdateMemberRoleInput(guild.Id, targetId, GuildRole.Admin), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -123,7 +123,7 @@ public sealed class UpdateMemberRoleHandlerTests
             .Setup(x => x.GetRoleAsync(guild.Id, ownerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(GuildRole.Admin);
 
-        var response = await _handler.HandleAsync(new UpdateMemberRoleInput(guild.Id, ownerId, GuildRole.Member), callerId);
+        var response = await _handler.HandleAsync(new UpdateMemberRoleInput(guild.Id, ownerId, GuildRole.Member), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -149,7 +149,7 @@ public sealed class UpdateMemberRoleHandlerTests
             .Setup(x => x.UpdateRoleAsync(guild.Id, targetId, GuildRole.Admin, It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
-        var response = await _handler.HandleAsync(new UpdateMemberRoleInput(guild.Id, targetId, GuildRole.Admin), callerId);
+        var response = await _handler.HandleAsync(new UpdateMemberRoleInput(guild.Id, targetId, GuildRole.Admin), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -179,7 +179,7 @@ public sealed class UpdateMemberRoleHandlerTests
             .Setup(x => x.UpdateRoleAsync(guild.Id, targetId, GuildRole.Member, It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
-        var response = await _handler.HandleAsync(new UpdateMemberRoleInput(guild.Id, targetId, GuildRole.Member), callerId);
+        var response = await _handler.HandleAsync(new UpdateMemberRoleInput(guild.Id, targetId, GuildRole.Member), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -213,7 +213,7 @@ public sealed class UpdateMemberRoleHandlerTests
             .Setup(x => x.NotifyMemberRoleUpdatedAsync(It.IsAny<MemberRoleUpdatedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        await _handler.HandleAsync(new UpdateMemberRoleInput(guild.Id, targetId, GuildRole.Admin), callerId);
+        await _handler.HandleAsync(new UpdateMemberRoleInput(guild.Id, targetId, GuildRole.Admin), callerId, TestContext.Current.CancellationToken);
 
         _guildNotifierMock.Verify(
             x => x.NotifyMemberRoleUpdatedAsync(

--- a/tests/Harmonie.Application.Tests/Harmonie.Application.Tests.csproj
+++ b/tests/Harmonie.Application.Tests/Harmonie.Application.Tests.csproj
@@ -6,9 +6,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Moq" />
   </ItemGroup>

--- a/tests/Harmonie.Application.Tests/Harmonie.Application.Tests.csproj
+++ b/tests/Harmonie.Application.Tests/Harmonie.Application.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Moq" />

--- a/tests/Harmonie.Application.Tests/Messages/AddChannelReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/AddChannelReactionHandlerTests.cs
@@ -62,7 +62,7 @@ public sealed class AddChannelReactionHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channelId, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((ChannelAccessContext?)null);
 
-        var response = await _handler.HandleAsync(new ChannelAddReactionInput(channelId, MessageId.New(), "👍"), callerId);
+        var response = await _handler.HandleAsync(new ChannelAddReactionInput(channelId, MessageId.New(), "👍"), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotFound);
@@ -79,7 +79,7 @@ public sealed class AddChannelReactionHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
 
-        var response = await _handler.HandleAsync(new ChannelAddReactionInput(channel.Id, MessageId.New(), "👍"), callerId);
+        var response = await _handler.HandleAsync(new ChannelAddReactionInput(channel.Id, MessageId.New(), "👍"), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotText);
@@ -96,7 +96,7 @@ public sealed class AddChannelReactionHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelAccessContext(channel, CallerRole: null));
 
-        var response = await _handler.HandleAsync(new ChannelAddReactionInput(channel.Id, MessageId.New(), "👍"), callerId);
+        var response = await _handler.HandleAsync(new ChannelAddReactionInput(channel.Id, MessageId.New(), "👍"), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Channel.AccessDenied);
@@ -118,7 +118,7 @@ public sealed class AddChannelReactionHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Message?)null);
 
-        var response = await _handler.HandleAsync(new ChannelAddReactionInput(channel.Id, messageId, "👍"), callerId);
+        var response = await _handler.HandleAsync(new ChannelAddReactionInput(channel.Id, messageId, "👍"), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
@@ -141,7 +141,7 @@ public sealed class AddChannelReactionHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(messageFromOtherChannel);
 
-        var response = await _handler.HandleAsync(new ChannelAddReactionInput(channel.Id, messageId, "👍"), callerId);
+        var response = await _handler.HandleAsync(new ChannelAddReactionInput(channel.Id, messageId, "👍"), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
@@ -164,7 +164,7 @@ public sealed class AddChannelReactionHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new ChannelAddReactionInput(channel.Id, messageId, "👍"), callerId);
+        var response = await _handler.HandleAsync(new ChannelAddReactionInput(channel.Id, messageId, "👍"), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -186,7 +186,7 @@ public sealed class AddChannelReactionHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        await _handler.HandleAsync(new ChannelAddReactionInput(channel.Id, messageId, "👍"), callerId);
+        await _handler.HandleAsync(new ChannelAddReactionInput(channel.Id, messageId, "👍"), callerId, TestContext.Current.CancellationToken);
 
         _reactionRepositoryMock.Verify(
             x => x.AddAsync(messageId, callerId, "👍", It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
@@ -225,7 +225,7 @@ public sealed class AddChannelReactionHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new ChannelAddReactionInput(channel.Id, messageId, "❤"), callerId);
+        var response = await _handler.HandleAsync(new ChannelAddReactionInput(channel.Id, messageId, "❤"), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
     }
@@ -250,7 +250,7 @@ public sealed class AddChannelReactionHandlerTests
             .Setup(x => x.NotifyReactionAddedToChannelAsync(It.IsAny<ChannelReactionAddedNotification>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("SignalR unavailable"));
 
-        var response = await _handler.HandleAsync(new ChannelAddReactionInput(channel.Id, messageId, "👍"), callerId);
+        var response = await _handler.HandleAsync(new ChannelAddReactionInput(channel.Id, messageId, "👍"), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);

--- a/tests/Harmonie.Application.Tests/Messages/AddConversationReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/AddConversationReactionHandlerTests.cs
@@ -60,7 +60,7 @@ public sealed class AddConversationReactionHandlerTests
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversationId, It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((ConversationAccess?)null);
 
-        var response = await _handler.HandleAsync(new ConversationAddReactionInput(conversationId, MessageId.New(), "👍"), callerId);
+        var response = await _handler.HandleAsync(new ConversationAddReactionInput(conversationId, MessageId.New(), "👍"), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
@@ -79,7 +79,7 @@ public sealed class AddConversationReactionHandlerTests
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: false));
 
-        var response = await _handler.HandleAsync(new ConversationAddReactionInput(conversation.Id, MessageId.New(), "👍"), outsider);
+        var response = await _handler.HandleAsync(new ConversationAddReactionInput(conversation.Id, MessageId.New(), "👍"), outsider, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
@@ -102,7 +102,7 @@ public sealed class AddConversationReactionHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Message?)null);
 
-        var response = await _handler.HandleAsync(new ConversationAddReactionInput(conversation.Id, messageId, "👍"), participantOne);
+        var response = await _handler.HandleAsync(new ConversationAddReactionInput(conversation.Id, messageId, "👍"), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
@@ -126,7 +126,7 @@ public sealed class AddConversationReactionHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new ConversationAddReactionInput(conversation.Id, messageId, "👍"), participantOne);
+        var response = await _handler.HandleAsync(new ConversationAddReactionInput(conversation.Id, messageId, "👍"), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
@@ -150,7 +150,7 @@ public sealed class AddConversationReactionHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new ConversationAddReactionInput(conversation.Id, messageId, "❤"), participantOne);
+        var response = await _handler.HandleAsync(new ConversationAddReactionInput(conversation.Id, messageId, "❤"), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -173,7 +173,7 @@ public sealed class AddConversationReactionHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        await _handler.HandleAsync(new ConversationAddReactionInput(conversation.Id, messageId, "❤"), participantOne);
+        await _handler.HandleAsync(new ConversationAddReactionInput(conversation.Id, messageId, "❤"), participantOne, TestContext.Current.CancellationToken);
 
         _reactionRepositoryMock.Verify(
             x => x.AddAsync(messageId, participantOne, "❤", It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
@@ -211,7 +211,7 @@ public sealed class AddConversationReactionHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new ConversationAddReactionInput(conversation.Id, messageId, "👍"), participantTwo);
+        var response = await _handler.HandleAsync(new ConversationAddReactionInput(conversation.Id, messageId, "👍"), participantTwo, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
     }
@@ -237,7 +237,7 @@ public sealed class AddConversationReactionHandlerTests
             .Setup(x => x.NotifyReactionAddedToConversationAsync(It.IsAny<ConversationReactionAddedNotification>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("SignalR unavailable"));
 
-        var response = await _handler.HandleAsync(new ConversationAddReactionInput(conversation.Id, messageId, "👍"), participantOne);
+        var response = await _handler.HandleAsync(new ConversationAddReactionInput(conversation.Id, messageId, "👍"), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);

--- a/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageAttachmentHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageAttachmentHandlerTests.cs
@@ -64,7 +64,7 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversationId, It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((ConversationAccess?)null);
 
-        var response = await _handler.HandleAsync(new DeleteConversationMessageAttachmentInput(conversationId, messageId, attachmentId), callerId);
+        var response = await _handler.HandleAsync(new DeleteConversationMessageAttachmentInput(conversationId, messageId, attachmentId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -85,7 +85,8 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
 
         var response = await _handler.HandleAsync(
             new DeleteConversationMessageAttachmentInput(conversation.Id, MessageId.New(), UploadedFileId.New()),
-            outsider);
+            outsider,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -109,7 +110,7 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
             .Setup(x => x.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new DeleteConversationMessageAttachmentInput(conversation.Id, message.Id, attachmentId), participantOne);
+        var response = await _handler.HandleAsync(new DeleteConversationMessageAttachmentInput(conversation.Id, message.Id, attachmentId), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -136,7 +137,8 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
 
         var response = await _handler.HandleAsync(
             new DeleteConversationMessageAttachmentInput(conversation.Id, message.Id, missingAttachmentId),
-            participantOne);
+            participantOne,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -203,7 +205,7 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
             .Setup(x => x.DeleteAsync(attachmentId, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var response = await _handler.HandleAsync(new DeleteConversationMessageAttachmentInput(conversation.Id, message.Id, attachmentId), participantOne);
+        var response = await _handler.HandleAsync(new DeleteConversationMessageAttachmentInput(conversation.Id, message.Id, attachmentId), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         message.Attachments.Should().BeEmpty();

--- a/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageHandlerTests.cs
@@ -57,7 +57,7 @@ public sealed class DeleteConversationMessageHandlerTests
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversationId, It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((ConversationAccess?)null);
 
-        var response = await _handler.HandleAsync(new DeleteConversationMessageInput(conversationId, MessageId.New()), callerId);
+        var response = await _handler.HandleAsync(new DeleteConversationMessageInput(conversationId, MessageId.New()), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -77,7 +77,7 @@ public sealed class DeleteConversationMessageHandlerTests
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: false));
 
-        var response = await _handler.HandleAsync(new DeleteConversationMessageInput(conversation.Id, MessageId.New()), outsider);
+        var response = await _handler.HandleAsync(new DeleteConversationMessageInput(conversation.Id, MessageId.New()), outsider, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -101,7 +101,7 @@ public sealed class DeleteConversationMessageHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Message?)null);
 
-        var response = await _handler.HandleAsync(new DeleteConversationMessageInput(conversation.Id, messageId), participantOne);
+        var response = await _handler.HandleAsync(new DeleteConversationMessageInput(conversation.Id, messageId), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -126,7 +126,7 @@ public sealed class DeleteConversationMessageHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new DeleteConversationMessageInput(conversation.Id, messageId), participantOne);
+        var response = await _handler.HandleAsync(new DeleteConversationMessageInput(conversation.Id, messageId), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -151,7 +151,7 @@ public sealed class DeleteConversationMessageHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new DeleteConversationMessageInput(conversation.Id, messageId), participantOne);
+        var response = await _handler.HandleAsync(new DeleteConversationMessageInput(conversation.Id, messageId), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -176,7 +176,7 @@ public sealed class DeleteConversationMessageHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new DeleteConversationMessageInput(conversation.Id, messageId), participantOne);
+        var response = await _handler.HandleAsync(new DeleteConversationMessageInput(conversation.Id, messageId), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -199,7 +199,7 @@ public sealed class DeleteConversationMessageHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        await _handler.HandleAsync(new DeleteConversationMessageInput(conversation.Id, messageId), participantOne);
+        await _handler.HandleAsync(new DeleteConversationMessageInput(conversation.Id, messageId), participantOne, TestContext.Current.CancellationToken);
 
         _directMessageRepositoryMock.Verify(
             x => x.SoftDeleteAsync(
@@ -246,7 +246,7 @@ public sealed class DeleteConversationMessageHandlerTests
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("SignalR unavailable"));
 
-        var response = await _handler.HandleAsync(new DeleteConversationMessageInput(conversation.Id, messageId), participantOne);
+        var response = await _handler.HandleAsync(new DeleteConversationMessageInput(conversation.Id, messageId), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();

--- a/tests/Harmonie.Application.Tests/Messages/DeleteMessageAttachmentHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/DeleteMessageAttachmentHandlerTests.cs
@@ -66,7 +66,7 @@ public sealed class DeleteMessageAttachmentHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channelId, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((ChannelAccessContext?)null);
 
-        var response = await _handler.HandleAsync(new DeleteChannelMessageAttachmentInput(channelId, messageId, attachmentId), callerId);
+        var response = await _handler.HandleAsync(new DeleteChannelMessageAttachmentInput(channelId, messageId, attachmentId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -90,7 +90,7 @@ public sealed class DeleteMessageAttachmentHandlerTests
             .Setup(x => x.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new DeleteChannelMessageAttachmentInput(channel.Id, message.Id, attachmentId), callerId);
+        var response = await _handler.HandleAsync(new DeleteChannelMessageAttachmentInput(channel.Id, message.Id, attachmentId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -114,7 +114,7 @@ public sealed class DeleteMessageAttachmentHandlerTests
             .Setup(x => x.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new DeleteChannelMessageAttachmentInput(channel.Id, message.Id, attachmentId), authorId);
+        var response = await _handler.HandleAsync(new DeleteChannelMessageAttachmentInput(channel.Id, message.Id, attachmentId), authorId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -180,7 +180,7 @@ public sealed class DeleteMessageAttachmentHandlerTests
             .Setup(x => x.DeleteAsync(attachmentId, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var response = await _handler.HandleAsync(new DeleteChannelMessageAttachmentInput(channel.Id, message.Id, attachmentId), authorId);
+        var response = await _handler.HandleAsync(new DeleteChannelMessageAttachmentInput(channel.Id, message.Id, attachmentId), authorId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         message.Attachments.Should().BeEmpty();

--- a/tests/Harmonie.Application.Tests/Messages/DeleteMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/DeleteMessageHandlerTests.cs
@@ -58,7 +58,7 @@ public sealed class DeleteMessageHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channelId, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((ChannelAccessContext?)null);
 
-        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channelId, MessageId.New()), callerId);
+        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channelId, MessageId.New()), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -76,7 +76,7 @@ public sealed class DeleteMessageHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
 
-        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, MessageId.New()), callerId);
+        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, MessageId.New()), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -94,7 +94,7 @@ public sealed class DeleteMessageHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelAccessContext(channel, CallerRole: null));
 
-        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, MessageId.New()), callerId);
+        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, MessageId.New()), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -117,7 +117,7 @@ public sealed class DeleteMessageHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Message?)null);
 
-        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, messageId), callerId);
+        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, messageId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -141,7 +141,7 @@ public sealed class DeleteMessageHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(messageFromOtherChannel);
 
-        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, messageId), callerId);
+        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, messageId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -166,7 +166,7 @@ public sealed class DeleteMessageHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, messageId), callerId);
+        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, messageId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -190,7 +190,7 @@ public sealed class DeleteMessageHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, messageId), authorId);
+        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, messageId), authorId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -212,7 +212,7 @@ public sealed class DeleteMessageHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, messageId), authorId);
+        await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, messageId), authorId, TestContext.Current.CancellationToken);
 
         _channelMessageRepositoryMock.Verify(
             x => x.SoftDeleteAsync(
@@ -245,7 +245,7 @@ public sealed class DeleteMessageHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, messageId), adminId);
+        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, messageId), adminId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -268,7 +268,7 @@ public sealed class DeleteMessageHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, messageId), adminId);
+        await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, messageId), adminId, TestContext.Current.CancellationToken);
 
         _channelMessageRepositoryMock.Verify(
             x => x.SoftDeleteAsync(
@@ -300,7 +300,7 @@ public sealed class DeleteMessageHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, messageId), authorId);
+        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, messageId), authorId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         _textChannelNotifierMock.Verify(
@@ -333,7 +333,7 @@ public sealed class DeleteMessageHandlerTests
             .Setup(x => x.NotifyMessageDeletedAsync(It.IsAny<TextChannelMessageDeletedNotification>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("SignalR unavailable"));
 
-        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, messageId), authorId);
+        var response = await _handler.HandleAsync(new DeleteChannelMessageInput(channel.Id, messageId), authorId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
     }

--- a/tests/Harmonie.Application.Tests/Messages/EditConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/EditConversationMessageHandlerTests.cs
@@ -52,7 +52,8 @@ public sealed class EditConversationMessageHandlerTests
     {
         var response = await _handler.HandleAsync(
             new EditConversationMessageInput(ConversationId.New(), MessageId.New(), "   "),
-            UserId.New());
+            UserId.New(),
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -72,7 +73,8 @@ public sealed class EditConversationMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new EditConversationMessageInput(conversationId, MessageId.New(), "updated content"),
-            callerId);
+            callerId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -94,7 +96,8 @@ public sealed class EditConversationMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new EditConversationMessageInput(conversation.Id, MessageId.New(), "updated content"),
-            outsider);
+            outsider,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -120,7 +123,8 @@ public sealed class EditConversationMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new EditConversationMessageInput(conversation.Id, messageId, "updated content"),
-            participantOne);
+            participantOne,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -147,7 +151,8 @@ public sealed class EditConversationMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new EditConversationMessageInput(conversation.Id, messageId, "updated content"),
-            participantOne);
+            participantOne,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -174,7 +179,8 @@ public sealed class EditConversationMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new EditConversationMessageInput(conversation.Id, messageId, "updated content"),
-            participantOne);
+            participantOne,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -201,7 +207,8 @@ public sealed class EditConversationMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new EditConversationMessageInput(conversation.Id, messageId, "  updated content  "),
-            participantOne);
+            participantOne,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -231,7 +238,8 @@ public sealed class EditConversationMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new EditConversationMessageInput(conversation.Id, messageId, "updated content"),
-            participantOne);
+            participantOne,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         _directMessageRepositoryMock.Verify(
@@ -278,7 +286,8 @@ public sealed class EditConversationMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new EditConversationMessageInput(conversation.Id, messageId, "updated content"),
-            participantOne);
+            participantOne,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();

--- a/tests/Harmonie.Application.Tests/Messages/EditMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/EditMessageHandlerTests.cs
@@ -54,7 +54,8 @@ public sealed class EditMessageHandlerTests
     {
         var response = await _handler.HandleAsync(
             new EditChannelMessageInput(GuildChannelId.New(), MessageId.New(), "   "),
-            UserId.New());
+            UserId.New(),
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -74,7 +75,8 @@ public sealed class EditMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new EditChannelMessageInput(channelId, MessageId.New(), "updated content"),
-            callerId);
+            callerId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -94,7 +96,8 @@ public sealed class EditMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new EditChannelMessageInput(channel.Id, MessageId.New(), "updated content"),
-            callerId);
+            callerId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -114,7 +117,8 @@ public sealed class EditMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new EditChannelMessageInput(channel.Id, MessageId.New(), "updated content"),
-            callerId);
+            callerId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -139,7 +143,8 @@ public sealed class EditMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new EditChannelMessageInput(channel.Id, messageId, "updated content"),
-            callerId);
+            callerId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -165,7 +170,8 @@ public sealed class EditMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new EditChannelMessageInput(channel.Id, messageId, "updated content"),
-            callerId);
+            callerId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -192,7 +198,8 @@ public sealed class EditMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new EditChannelMessageInput(channel.Id, messageId, "updated content"),
-            callerId);
+            callerId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -218,7 +225,8 @@ public sealed class EditMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new EditChannelMessageInput(channel.Id, messageId, "  updated content  "),
-            authorId);
+            authorId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -246,7 +254,8 @@ public sealed class EditMessageHandlerTests
 
         await _handler.HandleAsync(
             new EditChannelMessageInput(channel.Id, messageId, "updated content"),
-            authorId);
+            authorId,
+            TestContext.Current.CancellationToken);
 
         _channelMessageRepositoryMock.Verify(
             x => x.UpdateAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()),
@@ -275,7 +284,8 @@ public sealed class EditMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new EditChannelMessageInput(channel.Id, messageId, "updated content"),
-            authorId);
+            authorId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         _textChannelNotifierMock.Verify(
@@ -310,7 +320,8 @@ public sealed class EditMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new EditChannelMessageInput(channel.Id, messageId, "updated content"),
-            authorId);
+            authorId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
     }

--- a/tests/Harmonie.Application.Tests/Messages/GetConversationMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetConversationMessagesHandlerTests.cs
@@ -35,7 +35,8 @@ public sealed class GetConversationMessagesHandlerTests
     {
         var response = await _handler.HandleAsync(
             new GetConversationMessagesInput(ConversationId.New(), Cursor: "invalid-cursor", Limit: 50),
-            UserId.New());
+            UserId.New(),
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -54,7 +55,8 @@ public sealed class GetConversationMessagesHandlerTests
 
         var response = await _handler.HandleAsync(
             new GetConversationMessagesInput(conversationId, Limit: 50),
-            userId);
+            userId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -75,7 +77,8 @@ public sealed class GetConversationMessagesHandlerTests
 
         var response = await _handler.HandleAsync(
             new GetConversationMessagesInput(conversation.Id, Limit: 50),
-            outsider);
+            outsider,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -110,7 +113,8 @@ public sealed class GetConversationMessagesHandlerTests
 
         var response = await _handler.HandleAsync(
             new GetConversationMessagesInput(conversation.Id, Limit: 50),
-            participantOne);
+            participantOne,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();

--- a/tests/Harmonie.Application.Tests/Messages/GetMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetMessagesHandlerTests.cs
@@ -37,7 +37,8 @@ public sealed class GetMessagesHandlerTests
     {
         var response = await _handler.HandleAsync(
             new GetChannelMessagesInput(GuildChannelId.New(), Before: "invalid-cursor", Limit: 50),
-            UserId.New());
+            UserId.New(),
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -56,7 +57,8 @@ public sealed class GetMessagesHandlerTests
 
         var response = await _handler.HandleAsync(
             new GetChannelMessagesInput(channel.Id, Limit: 50),
-            userId);
+            userId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -75,7 +77,8 @@ public sealed class GetMessagesHandlerTests
 
         var response = await _handler.HandleAsync(
             new GetChannelMessagesInput(channel.Id, Limit: 50),
-            userId);
+            userId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -110,7 +113,8 @@ public sealed class GetMessagesHandlerTests
 
         var response = await _handler.HandleAsync(
             new GetChannelMessagesInput(channel.Id, Limit: 50),
-            userId);
+            userId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();

--- a/tests/Harmonie.Application.Tests/Messages/RemoveChannelReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/RemoveChannelReactionHandlerTests.cs
@@ -63,7 +63,7 @@ public sealed class RemoveChannelReactionHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channelId, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((ChannelAccessContext?)null);
 
-        var response = await _handler.HandleAsync(new ChannelRemoveReactionInput(channelId, MessageId.New(), "👍"), callerId);
+        var response = await _handler.HandleAsync(new ChannelRemoveReactionInput(channelId, MessageId.New(), "👍"), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotFound);
@@ -80,7 +80,7 @@ public sealed class RemoveChannelReactionHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
 
-        var response = await _handler.HandleAsync(new ChannelRemoveReactionInput(channel.Id, MessageId.New(), "👍"), callerId);
+        var response = await _handler.HandleAsync(new ChannelRemoveReactionInput(channel.Id, MessageId.New(), "👍"), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Channel.NotText);
@@ -97,7 +97,7 @@ public sealed class RemoveChannelReactionHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelAccessContext(channel, CallerRole: null));
 
-        var response = await _handler.HandleAsync(new ChannelRemoveReactionInput(channel.Id, MessageId.New(), "👍"), callerId);
+        var response = await _handler.HandleAsync(new ChannelRemoveReactionInput(channel.Id, MessageId.New(), "👍"), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Channel.AccessDenied);
@@ -119,7 +119,7 @@ public sealed class RemoveChannelReactionHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Message?)null);
 
-        var response = await _handler.HandleAsync(new ChannelRemoveReactionInput(channel.Id, messageId, "👍"), callerId);
+        var response = await _handler.HandleAsync(new ChannelRemoveReactionInput(channel.Id, messageId, "👍"), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
@@ -142,7 +142,7 @@ public sealed class RemoveChannelReactionHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(messageFromOtherChannel);
 
-        var response = await _handler.HandleAsync(new ChannelRemoveReactionInput(channel.Id, messageId, "👍"), callerId);
+        var response = await _handler.HandleAsync(new ChannelRemoveReactionInput(channel.Id, messageId, "👍"), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
@@ -165,7 +165,7 @@ public sealed class RemoveChannelReactionHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new ChannelRemoveReactionInput(channel.Id, messageId, "👍"), callerId);
+        var response = await _handler.HandleAsync(new ChannelRemoveReactionInput(channel.Id, messageId, "👍"), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -187,7 +187,7 @@ public sealed class RemoveChannelReactionHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        await _handler.HandleAsync(new ChannelRemoveReactionInput(channel.Id, messageId, "👍"), callerId);
+        await _handler.HandleAsync(new ChannelRemoveReactionInput(channel.Id, messageId, "👍"), callerId, TestContext.Current.CancellationToken);
 
         _reactionRepositoryMock.Verify(
             x => x.RemoveAsync(messageId, callerId, "👍", It.IsAny<CancellationToken>()),
@@ -229,7 +229,7 @@ public sealed class RemoveChannelReactionHandlerTests
             .Setup(x => x.NotifyReactionRemovedFromChannelAsync(It.IsAny<ChannelReactionRemovedNotification>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("SignalR unavailable"));
 
-        var response = await _handler.HandleAsync(new ChannelRemoveReactionInput(channel.Id, messageId, "👍"), callerId);
+        var response = await _handler.HandleAsync(new ChannelRemoveReactionInput(channel.Id, messageId, "👍"), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);

--- a/tests/Harmonie.Application.Tests/Messages/RemoveConversationReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/RemoveConversationReactionHandlerTests.cs
@@ -59,7 +59,7 @@ public sealed class RemoveConversationReactionHandlerTests
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversationId, It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((ConversationAccess?)null);
 
-        var response = await _handler.HandleAsync(new ConversationRemoveReactionInput(conversationId, MessageId.New(), "👍"), callerId);
+        var response = await _handler.HandleAsync(new ConversationRemoveReactionInput(conversationId, MessageId.New(), "👍"), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
@@ -78,7 +78,7 @@ public sealed class RemoveConversationReactionHandlerTests
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: false));
 
-        var response = await _handler.HandleAsync(new ConversationRemoveReactionInput(conversation.Id, MessageId.New(), "👍"), outsider);
+        var response = await _handler.HandleAsync(new ConversationRemoveReactionInput(conversation.Id, MessageId.New(), "👍"), outsider, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
@@ -101,7 +101,7 @@ public sealed class RemoveConversationReactionHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Message?)null);
 
-        var response = await _handler.HandleAsync(new ConversationRemoveReactionInput(conversation.Id, messageId, "👍"), participantOne);
+        var response = await _handler.HandleAsync(new ConversationRemoveReactionInput(conversation.Id, messageId, "👍"), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
@@ -125,7 +125,7 @@ public sealed class RemoveConversationReactionHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new ConversationRemoveReactionInput(conversation.Id, messageId, "👍"), participantOne);
+        var response = await _handler.HandleAsync(new ConversationRemoveReactionInput(conversation.Id, messageId, "👍"), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
@@ -149,7 +149,7 @@ public sealed class RemoveConversationReactionHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        var response = await _handler.HandleAsync(new ConversationRemoveReactionInput(conversation.Id, messageId, "❤"), participantOne);
+        var response = await _handler.HandleAsync(new ConversationRemoveReactionInput(conversation.Id, messageId, "❤"), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -172,7 +172,7 @@ public sealed class RemoveConversationReactionHandlerTests
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        await _handler.HandleAsync(new ConversationRemoveReactionInput(conversation.Id, messageId, "❤"), participantOne);
+        await _handler.HandleAsync(new ConversationRemoveReactionInput(conversation.Id, messageId, "❤"), participantOne, TestContext.Current.CancellationToken);
 
         _reactionRepositoryMock.Verify(
             x => x.RemoveAsync(messageId, participantOne, "❤", It.IsAny<CancellationToken>()),
@@ -214,7 +214,7 @@ public sealed class RemoveConversationReactionHandlerTests
             .Setup(x => x.NotifyReactionRemovedFromConversationAsync(It.IsAny<ConversationReactionRemovedNotification>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("SignalR unavailable"));
 
-        var response = await _handler.HandleAsync(new ConversationRemoveReactionInput(conversation.Id, messageId, "👍"), participantOne);
+        var response = await _handler.HandleAsync(new ConversationRemoveReactionInput(conversation.Id, messageId, "👍"), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);

--- a/tests/Harmonie.Application.Tests/Messages/SearchConversationMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SearchConversationMessagesHandlerTests.cs
@@ -43,7 +43,8 @@ public sealed class SearchConversationMessagesHandlerTests
 
         var response = await _handler.HandleAsync(
             new SearchConversationMessagesInput(conversationId, Q: "deploy"),
-            currentUserId);
+            currentUserId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -64,7 +65,8 @@ public sealed class SearchConversationMessagesHandlerTests
 
         var response = await _handler.HandleAsync(
             new SearchConversationMessagesInput(conversation.Id, Q: "deploy"),
-            outsider);
+            outsider,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -106,7 +108,8 @@ public sealed class SearchConversationMessagesHandlerTests
                 Before: before.ToString("O"),
                 After: after.ToString("O"),
                 Limit: 10),
-            user1);
+            user1,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();

--- a/tests/Harmonie.Application.Tests/Messages/SearchMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SearchMessagesHandlerTests.cs
@@ -50,7 +50,8 @@ public sealed class SearchMessagesHandlerTests
 
         var response = await _handler.HandleAsync(
             new SearchMessagesInput(guild.Id, Q: "deploy", Cursor: "invalid-cursor"),
-            ownerId);
+            ownerId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -69,7 +70,8 @@ public sealed class SearchMessagesHandlerTests
 
         var response = await _handler.HandleAsync(
             new SearchMessagesInput(guildId, Q: "deploy"),
-            currentUserId);
+            currentUserId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -89,7 +91,8 @@ public sealed class SearchMessagesHandlerTests
 
         var response = await _handler.HandleAsync(
             new SearchMessagesInput(guild.Id, Q: "deploy"),
-            currentUserId);
+            currentUserId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -113,7 +116,8 @@ public sealed class SearchMessagesHandlerTests
 
         var response = await _handler.HandleAsync(
             new SearchMessagesInput(guild.Id, Q: "deploy", ChannelId: channel.Id),
-            ownerId);
+            ownerId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -160,7 +164,8 @@ public sealed class SearchMessagesHandlerTests
 
         var response = await _handler.HandleAsync(
             new SearchMessagesInput(guild.Id, Q: " deploy ", ChannelId: channel.Id, AuthorId: authorId, Before: before.ToString("O"), After: after.ToString("O"), Limit: 10),
-            ownerId);
+            ownerId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();

--- a/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
@@ -66,7 +66,8 @@ public sealed class SendConversationMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new SendConversationMessageInput(conversationId, "hello"),
-            userId);
+            userId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -88,7 +89,8 @@ public sealed class SendConversationMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new SendConversationMessageInput(conversation.Id, "hello"),
-            outsider);
+            outsider,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -110,7 +112,8 @@ public sealed class SendConversationMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new SendConversationMessageInput(conversation.Id, rawContent),
-            currentUserId);
+            currentUserId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -136,7 +139,8 @@ public sealed class SendConversationMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new SendConversationMessageInput(conversation.Id, "  hello dm  "),
-            currentUserId);
+            currentUserId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -179,7 +183,8 @@ public sealed class SendConversationMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new SendConversationMessageInput(conversation.Id, "hello dm", [attachment.Id]),
-            currentUserId);
+            currentUserId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -212,7 +217,8 @@ public sealed class SendConversationMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new SendConversationMessageInput(conversation.Id, "hello"),
-            currentUserId);
+            currentUserId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();

--- a/tests/Harmonie.Application.Tests/Messages/SendMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SendMessageHandlerTests.cs
@@ -68,7 +68,7 @@ public sealed class SendMessageHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channelId, userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((ChannelAccessContext?)null);
 
-        var response = await _handler.HandleAsync(new SendChannelMessageInput(channelId, request.Content, request.AttachmentFileIds), userId);
+        var response = await _handler.HandleAsync(new SendChannelMessageInput(channelId, request.Content, request.AttachmentFileIds), userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -87,7 +87,7 @@ public sealed class SendMessageHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
 
-        var response = await _handler.HandleAsync(new SendChannelMessageInput(channel.Id, request.Content, request.AttachmentFileIds), userId);
+        var response = await _handler.HandleAsync(new SendChannelMessageInput(channel.Id, request.Content, request.AttachmentFileIds), userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -106,7 +106,7 @@ public sealed class SendMessageHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelAccessContext(channel, CallerRole: null));
 
-        var response = await _handler.HandleAsync(new SendChannelMessageInput(channel.Id, request.Content, request.AttachmentFileIds), userId);
+        var response = await _handler.HandleAsync(new SendChannelMessageInput(channel.Id, request.Content, request.AttachmentFileIds), userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -128,7 +128,8 @@ public sealed class SendMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new SendChannelMessageInput(channel.Id, rawContent),
-            userId);
+            userId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -159,7 +160,8 @@ public sealed class SendMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new SendChannelMessageInput(channel.Id, null, [attachment.Id]),
-            userId);
+            userId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -190,7 +192,7 @@ public sealed class SendMessageHandlerTests
             .Callback<Message, CancellationToken>((message, _) => persistedMessage = message)
             .Returns(Task.CompletedTask);
 
-        var response = await _handler.HandleAsync(new SendChannelMessageInput(channel.Id, request.Content, request.AttachmentFileIds), userId);
+        var response = await _handler.HandleAsync(new SendChannelMessageInput(channel.Id, request.Content, request.AttachmentFileIds), userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -236,7 +238,8 @@ public sealed class SendMessageHandlerTests
 
         var response = await _handler.HandleAsync(
             new SendChannelMessageInput(channel.Id, "message with file", [attachment.Id]),
-            userId);
+            userId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -268,7 +271,7 @@ public sealed class SendMessageHandlerTests
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("SignalR unavailable"));
 
-        var response = await _handler.HandleAsync(new SendChannelMessageInput(channel.Id, request.Content, request.AttachmentFileIds), userId);
+        var response = await _handler.HandleAsync(new SendChannelMessageInput(channel.Id, request.Content, request.AttachmentFileIds), userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();

--- a/tests/Harmonie.Application.Tests/Uploads/DeleteFileHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Uploads/DeleteFileHandlerTests.cs
@@ -44,7 +44,7 @@ public sealed class DeleteFileHandlerTests
             .Setup(x => x.GetByIdAsync(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Domain.Entities.Uploads.UploadedFile?)null);
 
-        var response = await _handler.HandleAsync(new DeleteFileInput(fileId), userId);
+        var response = await _handler.HandleAsync(new DeleteFileInput(fileId), userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Upload.NotFound);
@@ -61,7 +61,7 @@ public sealed class DeleteFileHandlerTests
             .Setup(x => x.GetByIdAsync(uploadedFile.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(uploadedFile);
 
-        var response = await _handler.HandleAsync(new DeleteFileInput(uploadedFile.Id), requestingUser);
+        var response = await _handler.HandleAsync(new DeleteFileInput(uploadedFile.Id), requestingUser, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Upload.AccessDenied);
@@ -82,7 +82,7 @@ public sealed class DeleteFileHandlerTests
             .Setup(x => x.DeleteIfExistsAsync(uploadedFile.StorageKey, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var response = await _handler.HandleAsync(new DeleteFileInput(uploadedFile.Id), user.Id);
+        var response = await _handler.HandleAsync(new DeleteFileInput(uploadedFile.Id), user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         _uploadedFileRepositoryMock.Verify(
@@ -108,7 +108,7 @@ public sealed class DeleteFileHandlerTests
             .Setup(x => x.DeleteIfExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Storage unavailable"));
 
-        var response = await _handler.HandleAsync(new DeleteFileInput(uploadedFile.Id), user.Id);
+        var response = await _handler.HandleAsync(new DeleteFileInput(uploadedFile.Id), user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);

--- a/tests/Harmonie.Application.Tests/Uploads/DeleteGuildIconHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Uploads/DeleteGuildIconHandlerTests.cs
@@ -66,7 +66,7 @@ public sealed class DeleteGuildIconHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guildId, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GuildAccessContext?)null);
 
-        var response = await _handler.HandleAsync(new DeleteGuildIconInput(guildId), callerId);
+        var response = await _handler.HandleAsync(new DeleteGuildIconInput(guildId), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -83,7 +83,7 @@ public sealed class DeleteGuildIconHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
 
-        var response = await _handler.HandleAsync(new DeleteGuildIconInput(guild.Id), callerId);
+        var response = await _handler.HandleAsync(new DeleteGuildIconInput(guild.Id), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -100,7 +100,7 @@ public sealed class DeleteGuildIconHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, ownerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
 
-        var response = await _handler.HandleAsync(new DeleteGuildIconInput(guild.Id), ownerId);
+        var response = await _handler.HandleAsync(new DeleteGuildIconInput(guild.Id), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -155,7 +155,7 @@ public sealed class DeleteGuildIconHandlerTests
             .Setup(x => x.DeleteAsync(iconFileId, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var response = await _handler.HandleAsync(new DeleteGuildIconInput(guild.Id), ownerId);
+        var response = await _handler.HandleAsync(new DeleteGuildIconInput(guild.Id), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         guild.IconFileId.Should().BeNull();
@@ -191,7 +191,7 @@ public sealed class DeleteGuildIconHandlerTests
             .Setup(x => x.NotifyGuildUpdatedAsync(It.IsAny<GuildUpdatedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var response = await _handler.HandleAsync(new DeleteGuildIconInput(guild.Id), ownerId);
+        var response = await _handler.HandleAsync(new DeleteGuildIconInput(guild.Id), ownerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 

--- a/tests/Harmonie.Application.Tests/Uploads/DeleteMyAvatarHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Uploads/DeleteMyAvatarHandlerTests.cs
@@ -68,7 +68,7 @@ public sealed class DeleteMyAvatarHandlerTests
             .Setup(x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((User?)null);
 
-        var response = await _handler.HandleAsync(Unit.Value, userId);
+        var response = await _handler.HandleAsync(Unit.Value, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -88,7 +88,7 @@ public sealed class DeleteMyAvatarHandlerTests
             .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
-        var response = await _handler.HandleAsync(Unit.Value, user.Id);
+        var response = await _handler.HandleAsync(Unit.Value, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -150,7 +150,7 @@ public sealed class DeleteMyAvatarHandlerTests
             .Setup(x => x.DeleteAsync(avatarFileId, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var response = await _handler.HandleAsync(Unit.Value, user.Id);
+        var response = await _handler.HandleAsync(Unit.Value, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         user.AvatarFileId.Should().BeNull();

--- a/tests/Harmonie.Application.Tests/Uploads/DownloadFileHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Uploads/DownloadFileHandlerTests.cs
@@ -38,7 +38,7 @@ public sealed class DownloadFileHandlerTests
             .Setup(x => x.GetByIdAsync(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((UploadedFile?)null);
 
-        var response = await _handler.HandleAsync(fileId, userId);
+        var response = await _handler.HandleAsync(fileId, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -62,7 +62,7 @@ public sealed class DownloadFileHandlerTests
             .Setup(x => x.GetStreamAsync(uploadedFile.StorageKey, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Stream?)null);
 
-        var response = await _handler.HandleAsync(uploadedFile.Id, userId);
+        var response = await _handler.HandleAsync(uploadedFile.Id, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -84,7 +84,7 @@ public sealed class DownloadFileHandlerTests
             .Setup(x => x.GetStreamAsync(uploadedFile.StorageKey, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileStream);
 
-        var response = await _handler.HandleAsync(uploadedFile.Id, userId);
+        var response = await _handler.HandleAsync(uploadedFile.Id, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();

--- a/tests/Harmonie.Application.Tests/Uploads/UploadFileHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Uploads/UploadFileHandlerTests.cs
@@ -54,7 +54,7 @@ public sealed class UploadFileHandlerTests
         using var stream = CreateStream("hello");
         var input = new UploadFileInput("hello.txt", "text/plain", stream.Length, stream, UploadPurpose.Attachment);
 
-        var response = await _handler.HandleAsync(input, userId);
+        var response = await _handler.HandleAsync(input, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -80,7 +80,7 @@ public sealed class UploadFileHandlerTests
         using var stream = CreateStream("hello");
         var input = new UploadFileInput("hello.txt", "text/plain", stream.Length, stream, UploadPurpose.Attachment);
 
-        var response = await _handler.HandleAsync(input, user.Id);
+        var response = await _handler.HandleAsync(input, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -110,7 +110,7 @@ public sealed class UploadFileHandlerTests
         using var stream = CreateStream("hello");
         var input = new UploadFileInput("hello.txt", "text/plain", stream.Length, stream, UploadPurpose.Attachment);
 
-        var response = await _handler.HandleAsync(input, user.Id);
+        var response = await _handler.HandleAsync(input, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -145,7 +145,7 @@ public sealed class UploadFileHandlerTests
         using var stream = CreateStream("hello");
         var input = new UploadFileInput("hello.txt", "text/plain", stream.Length, stream, UploadPurpose.Attachment);
 
-        var action = async () => await _handler.HandleAsync(input, user.Id);
+        var action = async () => await _handler.HandleAsync(input, user.Id, TestContext.Current.CancellationToken);
 
         await action.Should().ThrowAsync<InvalidOperationException>();
 

--- a/tests/Harmonie.Application.Tests/Uploads/UploadMyAvatarHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Uploads/UploadMyAvatarHandlerTests.cs
@@ -66,7 +66,7 @@ public sealed class UploadMyAvatarHandlerTests
         using var stream = CreateTestImageStream();
         var input = new UploadMyAvatarInput("avatar.png", "image/png", stream);
 
-        var response = await _handler.HandleAsync(input, userId);
+        var response = await _handler.HandleAsync(input, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -92,7 +92,7 @@ public sealed class UploadMyAvatarHandlerTests
         using var stream = CreateTestImageStream();
         var input = new UploadMyAvatarInput("avatar.png", "image/png", stream);
 
-        var response = await _handler.HandleAsync(input, user.Id);
+        var response = await _handler.HandleAsync(input, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -117,7 +117,7 @@ public sealed class UploadMyAvatarHandlerTests
         using var stream = CreateTestImageStream(512, 512);
         var input = new UploadMyAvatarInput("avatar.png", "image/png", stream);
 
-        var response = await _handler.HandleAsync(input, user.Id);
+        var response = await _handler.HandleAsync(input, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -164,7 +164,7 @@ public sealed class UploadMyAvatarHandlerTests
         using var stream = CreateTestImageStream();
         var input = new UploadMyAvatarInput("avatar.png", "image/png", stream);
 
-        var action = async () => await _handler.HandleAsync(input, user.Id);
+        var action = async () => await _handler.HandleAsync(input, user.Id, TestContext.Current.CancellationToken);
 
         await action.Should().ThrowAsync<InvalidOperationException>();
 

--- a/tests/Harmonie.Application.Tests/Users/GetMyProfileHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Users/GetMyProfileHandlerTests.cs
@@ -36,7 +36,7 @@ public sealed class GetMyProfileHandlerTests
             .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
-        var response = await _handler.HandleAsync(Unit.Value, user.Id);
+        var response = await _handler.HandleAsync(Unit.Value, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -60,7 +60,7 @@ public sealed class GetMyProfileHandlerTests
             .Setup(x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((User?)null);
 
-        var response = await _handler.HandleAsync(Unit.Value, userId);
+        var response = await _handler.HandleAsync(Unit.Value, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Data.Should().BeNull();
@@ -80,7 +80,7 @@ public sealed class GetMyProfileHandlerTests
             .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
-        var response = await _handler.HandleAsync(Unit.Value, user.Id);
+        var response = await _handler.HandleAsync(Unit.Value, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -101,7 +101,7 @@ public sealed class GetMyProfileHandlerTests
             .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
-        var response = await _handler.HandleAsync(Unit.Value, user.Id);
+        var response = await _handler.HandleAsync(Unit.Value, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();

--- a/tests/Harmonie.Application.Tests/Users/SearchUsersHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Users/SearchUsersHandlerTests.cs
@@ -46,7 +46,8 @@ public sealed class SearchUsersHandlerTests
                 Q = "alice",
                 GuildId = guildId
             },
-            currentUserId);
+            currentUserId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -70,7 +71,8 @@ public sealed class SearchUsersHandlerTests
                 Q = "alice",
                 GuildId = guild.Id
             },
-            currentUserId);
+            currentUserId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -104,7 +106,8 @@ public sealed class SearchUsersHandlerTests
                 GuildId = guild.Id,
                 Limit = 5
             },
-            ownerId);
+            ownerId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -130,7 +133,8 @@ public sealed class SearchUsersHandlerTests
 
         var response = await _handler.HandleAsync(
             new SearchUsersRequest { Q = "b" },
-            currentUserId);
+            currentUserId,
+            TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         var users = response.Data!.Users;

--- a/tests/Harmonie.Application.Tests/Users/UpdateMyProfileHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Users/UpdateMyProfileHandlerTests.cs
@@ -64,7 +64,7 @@ public sealed class UpdateMyProfileHandlerTests
             .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
-        var response = await _handler.HandleAsync(request, user.Id);
+        var response = await _handler.HandleAsync(request, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -105,7 +105,7 @@ public sealed class UpdateMyProfileHandlerTests
             .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
-        var response = await _handler.HandleAsync(request, user.Id);
+        var response = await _handler.HandleAsync(request, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
@@ -140,7 +140,7 @@ public sealed class UpdateMyProfileHandlerTests
             .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
-        var response = await _handler.HandleAsync(request, user.Id);
+        var response = await _handler.HandleAsync(request, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Data.Should().BeNull();
@@ -170,7 +170,7 @@ public sealed class UpdateMyProfileHandlerTests
             .Setup(x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((User?)null);
 
-        var response = await _handler.HandleAsync(request, userId);
+        var response = await _handler.HandleAsync(request, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Data.Should().BeNull();
@@ -198,7 +198,7 @@ public sealed class UpdateMyProfileHandlerTests
             .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
-        var response = await _handler.HandleAsync(request, user.Id);
+        var response = await _handler.HandleAsync(request, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -229,7 +229,7 @@ public sealed class UpdateMyProfileHandlerTests
             .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
-        var response = await _handler.HandleAsync(request, user.Id);
+        var response = await _handler.HandleAsync(request, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -255,7 +255,7 @@ public sealed class UpdateMyProfileHandlerTests
             .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
-        var response = await _handler.HandleAsync(request, user.Id);
+        var response = await _handler.HandleAsync(request, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -286,7 +286,7 @@ public sealed class UpdateMyProfileHandlerTests
             .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
-        var response = await _handler.HandleAsync(request, user.Id);
+        var response = await _handler.HandleAsync(request, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -316,7 +316,7 @@ public sealed class UpdateMyProfileHandlerTests
             .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
-        var response = await _handler.HandleAsync(request, user.Id);
+        var response = await _handler.HandleAsync(request, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 
@@ -337,7 +337,7 @@ public sealed class UpdateMyProfileHandlerTests
             .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
-        var response = await _handler.HandleAsync(request, user.Id);
+        var response = await _handler.HandleAsync(request, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();

--- a/tests/Harmonie.Application.Tests/Users/UpdateUserStatusHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Users/UpdateUserStatusHandlerTests.cs
@@ -45,7 +45,7 @@ public sealed class UpdateUserStatusHandlerTests
             .Setup(x => x.GetUserGuildMembershipsAsync(user.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<UserGuildMembership>());
 
-        var response = await _handler.HandleAsync(request, user.Id);
+        var response = await _handler.HandleAsync(request, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -71,7 +71,7 @@ public sealed class UpdateUserStatusHandlerTests
             .Setup(x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((User?)null);
 
-        var response = await _handler.HandleAsync(request, userId);
+        var response = await _handler.HandleAsync(request, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Data.Should().BeNull();
@@ -97,7 +97,7 @@ public sealed class UpdateUserStatusHandlerTests
             .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
-        var response = await _handler.HandleAsync(request, user.Id);
+        var response = await _handler.HandleAsync(request, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -133,7 +133,7 @@ public sealed class UpdateUserStatusHandlerTests
                 new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow)
             });
 
-        var response = await _handler.HandleAsync(request, user.Id);
+        var response = await _handler.HandleAsync(request, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data!.Status.Should().Be("invisible");
@@ -168,7 +168,7 @@ public sealed class UpdateUserStatusHandlerTests
                 new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow)
             });
 
-        var response = await _handler.HandleAsync(request, user.Id);
+        var response = await _handler.HandleAsync(request, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 
@@ -194,7 +194,7 @@ public sealed class UpdateUserStatusHandlerTests
             .Setup(x => x.GetUserGuildMembershipsAsync(user.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<UserGuildMembership>());
 
-        var response = await _handler.HandleAsync(request, user.Id);
+        var response = await _handler.HandleAsync(request, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
 

--- a/tests/Harmonie.Application.Tests/Voice/GetGuildVoiceParticipantsHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Voice/GetGuildVoiceParticipantsHandlerTests.cs
@@ -44,7 +44,7 @@ public sealed class GetGuildVoiceParticipantsHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guildId, userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GuildAccessContext?)null);
 
-        var response = await _handler.HandleAsync(guildId, userId);
+        var response = await _handler.HandleAsync(guildId, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -61,7 +61,7 @@ public sealed class GetGuildVoiceParticipantsHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(guild.Id, userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GuildAccessContext(guild, null));
 
-        var response = await _handler.HandleAsync(guild.Id, userId);
+        var response = await _handler.HandleAsync(guild.Id, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -92,7 +92,7 @@ public sealed class GetGuildVoiceParticipantsHandlerTests
             .Setup(x => x.GetGuildMembersAsync(guild.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<GuildMemberUser>());
 
-        var response = await _handler.HandleAsync(guild.Id, requesterUserId);
+        var response = await _handler.HandleAsync(guild.Id, requesterUserId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();

--- a/tests/Harmonie.Application.Tests/Voice/HandleLiveKitWebhookHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Voice/HandleLiveKitWebhookHandlerTests.cs
@@ -45,7 +45,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
             .Setup(x => x.Receive(request.RawBody, request.AuthorizationHeader!))
             .Returns(LiveKitWebhookReceiveResult.Fail("invalid signature"));
 
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -67,7 +67,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
                     null,
                     DateTime.UtcNow)));
 
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -95,7 +95,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
                     "alice",
                     DateTime.UtcNow)));
 
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -133,7 +133,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
             .Setup(x => x.GetWithParticipantAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelWithParticipant(channel, profile));
 
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data!.Processed.Should().BeTrue();
@@ -178,7 +178,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
             .Setup(x => x.GetWithParticipantAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelWithParticipant(channel, null));
 
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data!.Processed.Should().BeTrue();
@@ -219,7 +219,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
             .Setup(x => x.GetWithParticipantAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelWithParticipant(channel, null));
 
-        var response = await _handler.HandleAsync(request);
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data!.Processed.Should().BeTrue();
@@ -266,7 +266,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
             .Setup(x => x.GetWithParticipantAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelWithParticipant(channel, profile));
 
-        await _handler.HandleAsync(request);
+        await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         _voiceParticipantCacheMock.Verify(
             x => x.AddOrUpdateAsync(
@@ -304,7 +304,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
             .Setup(x => x.GetWithParticipantAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelWithParticipant(channel, null));
 
-        await _handler.HandleAsync(request);
+        await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
         _voiceParticipantCacheMock.Verify(
             x => x.RemoveAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()),

--- a/tests/Harmonie.Application.Tests/Voice/JoinVoiceChannelHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Voice/JoinVoiceChannelHandlerTests.cs
@@ -67,7 +67,7 @@ public sealed class JoinVoiceChannelHandlerTests
             .Setup(x => x.GetByIdAsync(channelId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GuildChannel?)null);
 
-        var response = await _handler.HandleAsync(channelId, userId);
+        var response = await _handler.HandleAsync(channelId, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -84,7 +84,7 @@ public sealed class JoinVoiceChannelHandlerTests
             .Setup(x => x.GetByIdAsync(channel.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(channel);
 
-        var response = await _handler.HandleAsync(channel.Id, userId);
+        var response = await _handler.HandleAsync(channel.Id, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -105,7 +105,7 @@ public sealed class JoinVoiceChannelHandlerTests
             .Setup(x => x.IsMemberAsync(channel.GuildId, userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
-        var response = await _handler.HandleAsync(channel.Id, userId);
+        var response = await _handler.HandleAsync(channel.Id, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -130,7 +130,7 @@ public sealed class JoinVoiceChannelHandlerTests
             .Setup(x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((User?)null);
 
-        var response = await _handler.HandleAsync(channel.Id, userId);
+        var response = await _handler.HandleAsync(channel.Id, userId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeFalse();
         response.Error.Should().NotBeNull();
@@ -163,7 +163,7 @@ public sealed class JoinVoiceChannelHandlerTests
             .Setup(x => x.GenerateRoomTokenAsync(channel.Id, user.Id, user.Username.Value, It.IsAny<CancellationToken>()))
             .ReturnsAsync(roomToken);
 
-        var response = await _handler.HandleAsync(channel.Id, user.Id);
+        var response = await _handler.HandleAsync(channel.Id, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
@@ -215,7 +215,7 @@ public sealed class JoinVoiceChannelHandlerTests
             .Setup(x => x.GetAsync(channel.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync([cachedParticipant]);
 
-        var response = await _handler.HandleAsync(channel.Id, user.Id);
+        var response = await _handler.HandleAsync(channel.Id, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data!.CurrentParticipants.Should().HaveCount(1);
@@ -270,7 +270,7 @@ public sealed class JoinVoiceChannelHandlerTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync([dbUser]);
 
-        var response = await _handler.HandleAsync(channel.Id, user.Id);
+        var response = await _handler.HandleAsync(channel.Id, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data!.CurrentParticipants.Should().HaveCount(1);
@@ -324,7 +324,7 @@ public sealed class JoinVoiceChannelHandlerTests
             .Setup(x => x.GetAsync(channel.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync([staleParticipant]);
 
-        var response = await _handler.HandleAsync(channel.Id, user.Id);
+        var response = await _handler.HandleAsync(channel.Id, user.Id, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         response.Data!.CurrentParticipants.Should().BeEmpty();

--- a/tests/Harmonie.Domain.Tests/Harmonie.Domain.Tests.csproj
+++ b/tests/Harmonie.Domain.Tests/Harmonie.Domain.Tests.csproj
@@ -6,9 +6,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Harmonie.Domain.Tests/Harmonie.Domain.Tests.csproj
+++ b/tests/Harmonie.Domain.Tests/Harmonie.Domain.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />
   </ItemGroup>

--- a/tests/Harmonie.Infrastructure.Tests/Harmonie.Infrastructure.Tests.csproj
+++ b/tests/Harmonie.Infrastructure.Tests/Harmonie.Infrastructure.Tests.csproj
@@ -6,9 +6,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Moq" />

--- a/tests/Harmonie.Infrastructure.Tests/Harmonie.Infrastructure.Tests.csproj
+++ b/tests/Harmonie.Infrastructure.Tests/Harmonie.Infrastructure.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.Extensions.Options" />

--- a/tests/Harmonie.Infrastructure.Tests/LocalFileSystemObjectStorageServiceTests.cs
+++ b/tests/Harmonie.Infrastructure.Tests/LocalFileSystemObjectStorageServiceTests.cs
@@ -29,7 +29,8 @@ public sealed class LocalFileSystemObjectStorageServiceTests : IDisposable
                 "uploads/2026/03/test.txt",
                 "text/plain",
                 content.Length,
-                content));
+                content),
+            TestContext.Current.CancellationToken);
 
         result.Success.Should().BeTrue();
         File.ReadAllText(Path.Combine(_tempDirectory, "uploads", "2026", "03", "test.txt"))
@@ -47,7 +48,8 @@ public sealed class LocalFileSystemObjectStorageServiceTests : IDisposable
                 "../outside.txt",
                 "text/plain",
                 content.Length,
-                content));
+                content),
+            TestContext.Current.CancellationToken);
 
         result.Success.Should().BeFalse();
         File.Exists(Path.Combine(_tempDirectory, "..", "outside.txt")).Should().BeFalse();


### PR DESCRIPTION
## Summary

- Upgrade xUnit packages from v2 to v3 across all test projects
- Fix xUnit1051 warnings in `Application.Tests` (previous commit)
- Fix xUnit1051 warnings in `API.IntegrationTests`: pass `TestContext.Current.CancellationToken` to all async HTTP calls (`GetAsync`, `PostAsJsonAsync`, `PutAsync`, `DeleteAsync`, `PatchAsJsonAsync`, `SendAsync`) and `Task.Delay` calls

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 959 tests passed, 0 failed

Closes #330