### PR TITLE
feat(conversations): update group conversation name — PATCH /api/conversations/{conversationId}

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy solution and project files
+COPY ["Directory.Packages.props", "./"]
 COPY ["Harmonie.sln", "./"]
 COPY ["src/Harmonie.Domain/Harmonie.Domain.csproj", "src/Harmonie.Domain/"]
 COPY ["src/Harmonie.Application/Harmonie.Application.csproj", "src/Harmonie.Application/"]

--- a/src/Harmonie.API/Endpoints/ConversationEndpoints.cs
+++ b/src/Harmonie.API/Endpoints/ConversationEndpoints.cs
@@ -11,6 +11,7 @@ using ConversationEditMessage = Harmonie.Application.Features.Conversations.Edit
 using ConversationGetMessages = Harmonie.Application.Features.Conversations.GetMessages.GetMessagesEndpoint;
 using ConversationRemoveReaction = Harmonie.Application.Features.Conversations.RemoveReaction.RemoveReactionEndpoint;
 using ConversationSendMessage = Harmonie.Application.Features.Conversations.SendMessage.SendMessageEndpoint;
+using ConversationUpdateGroup = Harmonie.Application.Features.Conversations.UpdateGroupConversation.UpdateGroupConversationEndpoint;
 
 namespace Harmonie.API.Endpoints;
 
@@ -20,6 +21,7 @@ public static class ConversationEndpoints
     {
         OpenConversationEndpoint.Map(app);
         CreateGroupConversationEndpoint.Map(app);
+        ConversationUpdateGroup.Map(app);
         DeleteConversationEndpoint.Map(app);
         ListConversationsEndpoint.Map(app);
         SearchConversationMessagesEndpoint.Map(app);

--- a/src/Harmonie.API/RealTime/Common/IRealtimeClient.cs
+++ b/src/Harmonie.API/RealTime/Common/IRealtimeClient.cs
@@ -24,6 +24,7 @@ public interface IRealtimeClient
     // Conversations
     Task ConversationCreated(ConversationCreatedEvent payload, CancellationToken cancellationToken = default);
     Task ConversationParticipantLeft(ConversationParticipantLeftEvent payload, CancellationToken cancellationToken = default);
+    Task ConversationUpdated(ConversationUpdatedEvent payload, CancellationToken cancellationToken = default);
     Task ConversationMessageCreated(ConversationMessageCreatedEvent payload, CancellationToken cancellationToken = default);
     Task ConversationMessageUpdated(ConversationMessageUpdatedEvent payload, CancellationToken cancellationToken = default);
     Task ConversationMessageDeleted(ConversationMessageDeletedEvent payload, CancellationToken cancellationToken = default);

--- a/src/Harmonie.API/RealTime/Conversations/SignalRConversationNotifier.cs
+++ b/src/Harmonie.API/RealTime/Conversations/SignalRConversationNotifier.cs
@@ -54,6 +54,21 @@ public sealed class SignalRConversationNotifier : IConversationNotifier
             .Group(RealtimeHub.GetConversationGroupName(notification.ConversationId))
             .ConversationParticipantLeft(payload, cancellationToken);
     }
+
+    public async Task NotifyConversationUpdatedAsync(
+        ConversationUpdatedNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var payload = new ConversationUpdatedEvent(
+            ConversationId: notification.ConversationId.Value,
+            Name: notification.Name);
+
+        await _hubContext.Clients
+            .Group(RealtimeHub.GetConversationGroupName(notification.ConversationId))
+            .ConversationUpdated(payload, cancellationToken);
+    }
 }
 
 public sealed record ConversationCreatedEvent(
@@ -71,3 +86,7 @@ public sealed record ConversationParticipantEventDto(
 public sealed record ConversationParticipantLeftEvent(
     Guid ConversationId,
     Guid UserId);
+
+public sealed record ConversationUpdatedEvent(
+    Guid ConversationId,
+    string? Name);

--- a/src/Harmonie.Application/Common/ApplicationErrorCodes.cs
+++ b/src/Harmonie.Application/Common/ApplicationErrorCodes.cs
@@ -105,5 +105,6 @@ public static class ApplicationErrorCodes
         public const string NotFound = "CONVERSATION_NOT_FOUND";
         public const string CannotOpenSelf = "CONVERSATION_CANNOT_OPEN_SELF";
         public const string AccessDenied = "CONVERSATION_ACCESS_DENIED";
+        public const string InvalidConversationType = "CONVERSATION_INVALID_TYPE";
     }
 }

--- a/src/Harmonie.Application/Common/EndpointExtensions.cs
+++ b/src/Harmonie.Application/Common/EndpointExtensions.cs
@@ -334,6 +334,7 @@ public static class EndpointExtensions
             ApplicationErrorCodes.Conversation.NotFound => HttpStatusCode.NotFound,
             ApplicationErrorCodes.Conversation.CannotOpenSelf => HttpStatusCode.BadRequest,
             ApplicationErrorCodes.Conversation.AccessDenied => HttpStatusCode.Forbidden,
+            ApplicationErrorCodes.Conversation.InvalidConversationType => HttpStatusCode.BadRequest,
             ApplicationErrorCodes.Reaction.MessageNotFound => HttpStatusCode.NotFound,
             ApplicationErrorCodes.Invite.NotFound => HttpStatusCode.NotFound,
             ApplicationErrorCodes.Invite.Expired => HttpStatusCode.Gone,

--- a/src/Harmonie.Application/Features/Conversations/UpdateGroupConversation/UpdateGroupConversationEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/UpdateGroupConversation/UpdateGroupConversationEndpoint.cs
@@ -1,0 +1,51 @@
+using FluentValidation;
+using Harmonie.Application.Common;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Harmonie.Application.Features.Conversations.UpdateGroupConversation;
+
+public static class UpdateGroupConversationEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        app.MapPatch("/api/conversations/{conversationId}", HandleAsync)
+            .WithName("UpdateGroupConversation")
+            .WithTags("Conversations")
+            .RequireAuthorization()
+            .WithSummary("Update a group conversation")
+            .WithDescription("Updates the name of a group conversation. Only participants can update group conversations. Direct conversations cannot be updated.")
+            .Produces<UpdateGroupConversationResponse>(StatusCodes.Status200OK)
+            .ProducesErrors(
+                ApplicationErrorCodes.Common.ValidationFailed,
+                ApplicationErrorCodes.Auth.InvalidCredentials,
+                ApplicationErrorCodes.Common.DomainRuleViolation,
+                ApplicationErrorCodes.Conversation.NotFound,
+                ApplicationErrorCodes.Conversation.AccessDenied,
+                ApplicationErrorCodes.Conversation.InvalidConversationType);
+    }
+
+    private static async Task<IResult> HandleAsync(
+        ConversationId conversationId,
+        [FromBody] UpdateGroupConversationRequest request,
+        [FromServices] IAuthenticatedHandler<UpdateGroupConversationInput, UpdateGroupConversationResponse> handler,
+        [FromServices] IValidator<UpdateGroupConversationRequest> validator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var validationError = await request.ValidateAsync(validator, cancellationToken);
+        if (validationError is not null)
+            return ApplicationResponse<UpdateGroupConversationResponse>.Fail(validationError).ToHttpResult(httpContext);
+
+        var callerId = httpContext.GetRequiredAuthenticatedUserId();
+
+        var response = await handler.HandleAsync(
+            new UpdateGroupConversationInput(conversationId, request.Name),
+            callerId,
+            cancellationToken);
+        return response.ToHttpResult(httpContext);
+    }
+}

--- a/src/Harmonie.Application/Features/Conversations/UpdateGroupConversation/UpdateGroupConversationHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/UpdateGroupConversation/UpdateGroupConversationHandler.cs
@@ -1,0 +1,96 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Interfaces.Common;
+using Harmonie.Domain.Entities.Conversations;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging;
+
+namespace Harmonie.Application.Features.Conversations.UpdateGroupConversation;
+
+public sealed record UpdateGroupConversationInput(ConversationId ConversationId, string? Name);
+
+public sealed class UpdateGroupConversationHandler : IAuthenticatedHandler<UpdateGroupConversationInput, UpdateGroupConversationResponse>
+{
+    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly IConversationRepository _conversationRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IConversationNotifier _conversationNotifier;
+    private readonly ILogger<UpdateGroupConversationHandler> _logger;
+
+    public UpdateGroupConversationHandler(
+        IConversationRepository conversationRepository,
+        IUnitOfWork unitOfWork,
+        IConversationNotifier conversationNotifier,
+        ILogger<UpdateGroupConversationHandler> logger)
+    {
+        _conversationRepository = conversationRepository;
+        _unitOfWork = unitOfWork;
+        _conversationNotifier = conversationNotifier;
+        _logger = logger;
+    }
+
+    public async Task<ApplicationResponse<UpdateGroupConversationResponse>> HandleAsync(
+        UpdateGroupConversationInput request,
+        UserId currentUserId,
+        CancellationToken cancellationToken = default)
+    {
+        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(
+            request.ConversationId, currentUserId, cancellationToken);
+
+        if (access is null)
+        {
+            return ApplicationResponse<UpdateGroupConversationResponse>.Fail(
+                ApplicationErrorCodes.Conversation.NotFound,
+                "Conversation was not found");
+        }
+
+        if (!access.IsParticipant)
+        {
+            return ApplicationResponse<UpdateGroupConversationResponse>.Fail(
+                ApplicationErrorCodes.Conversation.AccessDenied,
+                "You are not a participant of this conversation");
+        }
+
+        if (access.Conversation.Type != ConversationType.Group)
+        {
+            return ApplicationResponse<UpdateGroupConversationResponse>.Fail(
+                ApplicationErrorCodes.Conversation.InvalidConversationType,
+                "Only group conversations can be updated");
+        }
+
+        var conversation = access.Conversation;
+
+        if (request.Name is not null)
+        {
+            var updateResult = conversation.UpdateName(request.Name);
+            if (updateResult.IsFailure)
+            {
+                return ApplicationResponse<UpdateGroupConversationResponse>.Fail(
+                    ApplicationErrorCodes.Common.DomainRuleViolation,
+                    updateResult.Error ?? "Conversation name update failed");
+            }
+
+            await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
+            await _conversationRepository.UpdateAsync(conversation, cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+
+            await BestEffortNotificationHelper.TryNotifyAsync(
+                ct => _conversationNotifier.NotifyConversationUpdatedAsync(
+                    new ConversationUpdatedNotification(
+                        ConversationId: conversation.Id,
+                        Name: conversation.Name),
+                    ct),
+                NotificationTimeout,
+                _logger,
+                "Failed to notify participants of conversation {ConversationId} update",
+                conversation.Id);
+        }
+
+        return ApplicationResponse<UpdateGroupConversationResponse>.Ok(
+            new UpdateGroupConversationResponse(
+                ConversationId: conversation.Id.Value,
+                Name: conversation.Name));
+    }
+}

--- a/src/Harmonie.Application/Features/Conversations/UpdateGroupConversation/UpdateGroupConversationRequest.cs
+++ b/src/Harmonie.Application/Features/Conversations/UpdateGroupConversation/UpdateGroupConversationRequest.cs
@@ -1,0 +1,3 @@
+namespace Harmonie.Application.Features.Conversations.UpdateGroupConversation;
+
+public sealed record UpdateGroupConversationRequest(string? Name = null);

--- a/src/Harmonie.Application/Features/Conversations/UpdateGroupConversation/UpdateGroupConversationResponse.cs
+++ b/src/Harmonie.Application/Features/Conversations/UpdateGroupConversation/UpdateGroupConversationResponse.cs
@@ -1,0 +1,5 @@
+namespace Harmonie.Application.Features.Conversations.UpdateGroupConversation;
+
+public sealed record UpdateGroupConversationResponse(
+    Guid ConversationId,
+    string? Name);

--- a/src/Harmonie.Application/Features/Conversations/UpdateGroupConversation/UpdateGroupConversationValidator.cs
+++ b/src/Harmonie.Application/Features/Conversations/UpdateGroupConversation/UpdateGroupConversationValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+
+namespace Harmonie.Application.Features.Conversations.UpdateGroupConversation;
+
+public sealed class UpdateGroupConversationValidator : AbstractValidator<UpdateGroupConversationRequest>
+{
+    public UpdateGroupConversationValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .WithMessage("Conversation name cannot be empty")
+            .When(x => x.Name is not null);
+
+        RuleFor(x => x.Name)
+            .MaximumLength(100)
+            .WithMessage("Conversation name must be 100 characters or less")
+            .When(x => x.Name is not null);
+    }
+}

--- a/src/Harmonie.Application/Interfaces/Conversations/IConversationNotifier.cs
+++ b/src/Harmonie.Application/Interfaces/Conversations/IConversationNotifier.cs
@@ -13,6 +13,10 @@ public interface IConversationNotifier
     Task NotifyParticipantLeftAsync(
         ConversationParticipantLeftNotification notification,
         CancellationToken cancellationToken = default);
+
+    Task NotifyConversationUpdatedAsync(
+        ConversationUpdatedNotification notification,
+        CancellationToken cancellationToken = default);
 }
 
 public sealed record ConversationCreatedNotification(
@@ -23,3 +27,7 @@ public sealed record ConversationCreatedNotification(
 public sealed record ConversationParticipantLeftNotification(
     ConversationId ConversationId,
     UserId UserId);
+
+public sealed record ConversationUpdatedNotification(
+    ConversationId ConversationId,
+    string? Name);

--- a/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
@@ -57,4 +57,8 @@ public interface IConversationRepository
     Task DeleteAsync(
         ConversationId conversationId,
         CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(
+        Conversation conversation,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Harmonie.Application/Registration/ConversationRegistration.cs
+++ b/src/Harmonie.Application/Registration/ConversationRegistration.cs
@@ -12,6 +12,7 @@ using Harmonie.Application.Features.Conversations.OpenConversation;
 using Harmonie.Application.Features.Conversations.RemoveReaction;
 using Harmonie.Application.Features.Conversations.SearchConversationMessages;
 using Harmonie.Application.Features.Conversations.SendMessage;
+using Harmonie.Application.Features.Conversations.UpdateGroupConversation;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Harmonie.Application.Registration;
@@ -22,6 +23,7 @@ public static class ConversationRegistration
     {
         services.AddAuthenticatedHandler<OpenConversationRequest, OpenConversationResponse, OpenConversationHandler>();
         services.AddAuthenticatedHandler<CreateGroupConversationRequest, CreateGroupConversationResponse, CreateGroupConversationHandler>();
+        services.AddAuthenticatedHandler<UpdateGroupConversationInput, UpdateGroupConversationResponse, UpdateGroupConversationHandler>();
         services.AddAuthenticatedHandler<DeleteConversationInput, bool, DeleteConversationHandler>();
         services.AddAuthenticatedHandler<Unit, ListConversationsResponse, ListConversationsHandler>();
         services.AddAuthenticatedHandler<SearchConversationMessagesInput, SearchConversationMessagesResponse, SearchConversationMessagesHandler>();

--- a/src/Harmonie.Domain/Entities/Conversations/Conversation.cs
+++ b/src/Harmonie.Domain/Entities/Conversations/Conversation.cs
@@ -66,6 +66,9 @@ public sealed class Conversation : Entity<ConversationId>
 
     public Result UpdateName(string? name)
     {
+        if (name is not null && string.IsNullOrWhiteSpace(name))
+            return Result.Failure("Conversation name cannot be empty");
+
         if (name is not null && name.Length > 100)
             return Result.Failure("Conversation name must be 100 characters or less");
 

--- a/src/Harmonie.Domain/Entities/Conversations/Conversation.cs
+++ b/src/Harmonie.Domain/Entities/Conversations/Conversation.cs
@@ -63,4 +63,13 @@ public sealed class Conversation : Entity<ConversationId>
 
         return new Conversation(id, type, name, createdAtUtc);
     }
+
+    public Result UpdateName(string? name)
+    {
+        if (name is not null && name.Length > 100)
+            return Result.Failure("Conversation name must be 100 characters or less");
+
+        Name = name;
+        return Result.Success();
+    }
 }

--- a/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
@@ -310,6 +310,24 @@ public sealed class ConversationRepository : IConversationRepository
             cancellationToken: cancellationToken));
     }
 
+    public async Task UpdateAsync(
+        Conversation conversation,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+
+        const string sql = """
+                            UPDATE conversations
+                            SET name = @Name
+                            WHERE id = @Id
+                            """;
+        await connection.ExecuteAsync(new CommandDefinition(
+            sql,
+            new { Name = conversation.Name, Id = conversation.Id.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken));
+    }
+
     private static Conversation MapToConversation(ConversationRow row)
         => Conversation.Rehydrate(
             ConversationId.From(row.Id),

--- a/tests/Harmonie.API.IntegrationTests/Conversations/UpdateGroupConversationTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/UpdateGroupConversationTests.cs
@@ -1,0 +1,186 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Harmonie.API.IntegrationTests.Common;
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Conversations.UpdateGroupConversation;
+using Xunit;
+
+namespace Harmonie.API.IntegrationTests.Conversations;
+
+public sealed class UpdateGroupConversationTests : IClassFixture<HarmonieWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public UpdateGroupConversationTests(HarmonieWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task UpdateGroupConversation_WhenParticipantUpdatesName_ShouldReturnOk()
+    {
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var callerReg = await AuthTestHelper.RegisterAsync(_client, $"caller_{tag}");
+        var otherReg = await AuthTestHelper.RegisterAsync(_client, $"other_{tag}");
+
+        var groupConversation = await ConversationTestHelper.CreateGroupConversationAsync(
+            _client,
+            callerReg.AccessToken,
+            "Original Name",
+            [callerReg.UserId, otherReg.UserId]);
+
+        var response = await _client.SendAuthorizedPatchAsync(
+            $"/api/conversations/{groupConversation.ConversationId}",
+            new UpdateGroupConversationRequest("New Name"),
+            callerReg.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<UpdateGroupConversationResponse>(TestContext.Current.CancellationToken);
+        payload.Should().NotBeNull();
+        payload!.ConversationId.Should().Be(groupConversation.ConversationId);
+        payload.Name.Should().Be("New Name");
+    }
+
+    [Fact]
+    public async Task UpdateGroupConversation_WhenConversationDoesNotExist_ShouldReturnNotFound()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+
+        var response = await _client.SendAuthorizedPatchAsync(
+            $"/api/conversations/{Guid.NewGuid()}",
+            new UpdateGroupConversationRequest("New Name"),
+            caller.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
+    }
+
+    [Fact]
+    public async Task UpdateGroupConversation_WhenCallerIsNotParticipant_ShouldReturnForbidden()
+    {
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var participantOne = await AuthTestHelper.RegisterAsync(_client, $"p1_{tag}");
+        var participantTwo = await AuthTestHelper.RegisterAsync(_client, $"p2_{tag}");
+        var outsider = await AuthTestHelper.RegisterAsync(_client, $"outsider_{tag}");
+
+        var groupConversation = await ConversationTestHelper.CreateGroupConversationAsync(
+            _client,
+            participantOne.AccessToken,
+            "Test Group",
+            [participantOne.UserId, participantTwo.UserId]);
+
+        var response = await _client.SendAuthorizedPatchAsync(
+            $"/api/conversations/{groupConversation.ConversationId}",
+            new UpdateGroupConversationRequest("New Name"),
+            outsider.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
+    }
+
+    [Fact]
+    public async Task UpdateGroupConversation_WhenConversationIsDirect_ShouldReturnBadRequest()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var other = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, other.UserId);
+
+        var response = await _client.SendAuthorizedPatchAsync(
+            $"/api/conversations/{conversationId}",
+            new UpdateGroupConversationRequest("New Name"),
+            caller.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Conversation.InvalidConversationType);
+    }
+
+    [Fact]
+    public async Task UpdateGroupConversation_WithoutAuthentication_ShouldReturnUnauthorized()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Patch, $"/api/conversations/{Guid.NewGuid()}")
+        {
+            Content = System.Net.Http.Json.JsonContent.Create(new UpdateGroupConversationRequest("New Name"))
+        };
+        var response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task UpdateGroupConversation_WhenNameIsEmpty_ShouldReturnValidationFailed()
+    {
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var callerReg = await AuthTestHelper.RegisterAsync(_client, $"caller_{tag}");
+        var otherReg = await AuthTestHelper.RegisterAsync(_client, $"other_{tag}");
+
+        var groupConversation = await ConversationTestHelper.CreateGroupConversationAsync(
+            _client,
+            callerReg.AccessToken,
+            "Original Name",
+            [callerReg.UserId, otherReg.UserId]);
+
+        var response = await _client.SendAuthorizedPatchAsync(
+            $"/api/conversations/{groupConversation.ConversationId}",
+            new UpdateGroupConversationRequest(""),
+            callerReg.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task UpdateGroupConversation_WhenNameExceedsMaxLength_ShouldReturnValidationFailed()
+    {
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var callerReg = await AuthTestHelper.RegisterAsync(_client, $"caller_{tag}");
+        var otherReg = await AuthTestHelper.RegisterAsync(_client, $"other_{tag}");
+
+        var groupConversation = await ConversationTestHelper.CreateGroupConversationAsync(
+            _client,
+            callerReg.AccessToken,
+            "Original Name",
+            [callerReg.UserId, otherReg.UserId]);
+
+        var response = await _client.SendAuthorizedPatchAsync(
+            $"/api/conversations/{groupConversation.ConversationId}",
+            new UpdateGroupConversationRequest(new string('a', 101)),
+            callerReg.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task UpdateGroupConversation_SecondParticipantCanAlsoUpdate()
+    {
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var callerReg = await AuthTestHelper.RegisterAsync(_client, $"caller_{tag}");
+        var otherReg = await AuthTestHelper.RegisterAsync(_client, $"other_{tag}");
+
+        var groupConversation = await ConversationTestHelper.CreateGroupConversationAsync(
+            _client,
+            callerReg.AccessToken,
+            "Original Name",
+            [callerReg.UserId, otherReg.UserId]);
+
+        var response = await _client.SendAuthorizedPatchAsync(
+            $"/api/conversations/{groupConversation.ConversationId}",
+            new UpdateGroupConversationRequest("Updated By Other"),
+            otherReg.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<UpdateGroupConversationResponse>(TestContext.Current.CancellationToken);
+        payload.Should().NotBeNull();
+        payload!.Name.Should().Be("Updated By Other");
+    }
+}

--- a/tests/Harmonie.Application.Tests/Common/ApplicationTestBuilders.cs
+++ b/tests/Harmonie.Application.Tests/Common/ApplicationTestBuilders.cs
@@ -141,6 +141,13 @@ internal static class ApplicationTestBuilders
             null,
             DateTime.UtcNow);
 
+    public static Conversation CreateGroupConversation(string? name, params UserId[] participantIds)
+        => Conversation.Rehydrate(
+            ConversationId.New(),
+            Harmonie.Domain.Entities.Conversations.ConversationType.Group,
+            name,
+            DateTime.UtcNow);
+
     public static UploadedFile CreateUploadedFile(
         UserId? uploaderUserId = null,
         UploadedFileId? id = null,

--- a/tests/Harmonie.Application.Tests/Common/ApplicationTestBuilders.cs
+++ b/tests/Harmonie.Application.Tests/Common/ApplicationTestBuilders.cs
@@ -141,7 +141,7 @@ internal static class ApplicationTestBuilders
             null,
             DateTime.UtcNow);
 
-    public static Conversation CreateGroupConversation(string? name, params UserId[] participantIds)
+    public static Conversation CreateGroupConversation(string? name)
         => Conversation.Rehydrate(
             ConversationId.New(),
             Harmonie.Domain.Entities.Conversations.ConversationType.Group,

--- a/tests/Harmonie.Application.Tests/Conversations/UpdateGroupConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/UpdateGroupConversationHandlerTests.cs
@@ -1,0 +1,217 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Conversations.UpdateGroupConversation;
+using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.Entities.Conversations;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Conversations;
+
+public sealed class UpdateGroupConversationHandlerTests
+{
+    private readonly Mock<IConversationRepository> _conversationRepositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly Mock<IConversationNotifier> _conversationNotifierMock;
+    private readonly UpdateGroupConversationHandler _handler;
+
+    public UpdateGroupConversationHandlerTests()
+    {
+        _conversationRepositoryMock = new Mock<IConversationRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _transactionMock = new Mock<IUnitOfWorkTransaction>();
+        _conversationNotifierMock = new Mock<IConversationNotifier>();
+
+        _transactionMock = _unitOfWorkMock.SetupTransactionMock();
+
+        _conversationNotifierMock
+            .Setup(x => x.NotifyConversationUpdatedAsync(
+                It.IsAny<ConversationUpdatedNotification>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _handler = new UpdateGroupConversationHandler(
+            _conversationRepositoryMock.Object,
+            _unitOfWorkMock.Object,
+            _conversationNotifierMock.Object,
+            NullLogger<UpdateGroupConversationHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenConversationDoesNotExist_ShouldReturnNotFound()
+    {
+        var conversationId = ConversationId.New();
+        var callerId = UserId.New();
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversationId, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConversationAccess?)null);
+
+        var response = await _handler.HandleAsync(
+            new UpdateGroupConversationInput(conversationId, "New Name"),
+            callerId,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCallerIsNotParticipant_ShouldReturnAccessDenied()
+    {
+        var participantOne = UserId.New();
+        var participantTwo = UserId.New();
+        var outsider = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateGroupConversation("Original Name", participantOne, participantTwo);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: false));
+
+        var response = await _handler.HandleAsync(
+            new UpdateGroupConversationInput(conversation.Id, "New Name"),
+            outsider,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenConversationIsDirect_ShouldReturnInvalidType()
+    {
+        var participantOne = UserId.New();
+        var participantTwo = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(participantOne, participantTwo);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+
+        var response = await _handler.HandleAsync(
+            new UpdateGroupConversationInput(conversation.Id, "New Name"),
+            participantOne,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.InvalidConversationType);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenGroupConversationUpdated_ShouldReturnSuccess()
+    {
+        var callerId = UserId.New();
+        var otherId = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateGroupConversation("Original Name", callerId, otherId);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+
+        var response = await _handler.HandleAsync(
+            new UpdateGroupConversationInput(conversation.Id, "New Name"),
+            callerId,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Error.Should().BeNull();
+        response.Data.Should().NotBeNull();
+        response.Data!.ConversationId.Should().Be(conversation.Id.Value);
+        response.Data.Name.Should().Be("New Name");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenGroupConversationUpdated_ShouldPersistAndNotify()
+    {
+        var callerId = UserId.New();
+        var otherId = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateGroupConversation("Original Name", callerId, otherId);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+
+        await _handler.HandleAsync(
+            new UpdateGroupConversationInput(conversation.Id, "New Name"),
+            callerId,
+            TestContext.Current.CancellationToken);
+
+        _conversationRepositoryMock.Verify(
+            x => x.UpdateAsync(It.Is<Conversation>(c => c.Name == "New Name"), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _conversationNotifierMock.Verify(
+            x => x.NotifyConversationUpdatedAsync(
+                It.Is<ConversationUpdatedNotification>(n =>
+                    n.ConversationId == conversation.Id && n.Name == "New Name"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenNameIsNull_ShouldNotUpdateButReturnSuccess()
+    {
+        var callerId = UserId.New();
+        var otherId = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateGroupConversation("Original Name", callerId, otherId);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+
+        var response = await _handler.HandleAsync(
+            new UpdateGroupConversationInput(conversation.Id, null),
+            callerId,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data.Should().NotBeNull();
+        response.Data!.Name.Should().Be("Original Name");
+
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _conversationRepositoryMock.Verify(
+            x => x.UpdateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _conversationNotifierMock.Verify(
+            x => x.NotifyConversationUpdatedAsync(It.IsAny<ConversationUpdatedNotification>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenNotifierThrows_ShouldStillSucceed()
+    {
+        var callerId = UserId.New();
+        var otherId = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateGroupConversation("Original Name", callerId, otherId);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+
+        _conversationNotifierMock
+            .Setup(x => x.NotifyConversationUpdatedAsync(
+                It.IsAny<ConversationUpdatedNotification>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("SignalR unavailable"));
+
+        var response = await _handler.HandleAsync(
+            new UpdateGroupConversationInput(conversation.Id, "New Name"),
+            callerId,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        _conversationRepositoryMock.Verify(
+            x => x.UpdateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/tests/Harmonie.Application.Tests/Conversations/UpdateGroupConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/UpdateGroupConversationHandlerTests.cs
@@ -66,10 +66,8 @@ public sealed class UpdateGroupConversationHandlerTests
     [Fact]
     public async Task HandleAsync_WhenCallerIsNotParticipant_ShouldReturnAccessDenied()
     {
-        var participantOne = UserId.New();
-        var participantTwo = UserId.New();
         var outsider = UserId.New();
-        var conversation = ApplicationTestBuilders.CreateGroupConversation("Original Name", participantOne, participantTwo);
+        var conversation = ApplicationTestBuilders.CreateGroupConversation("Original Name");
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
@@ -110,8 +108,7 @@ public sealed class UpdateGroupConversationHandlerTests
     public async Task HandleAsync_WhenGroupConversationUpdated_ShouldReturnSuccess()
     {
         var callerId = UserId.New();
-        var otherId = UserId.New();
-        var conversation = ApplicationTestBuilders.CreateGroupConversation("Original Name", callerId, otherId);
+        var conversation = ApplicationTestBuilders.CreateGroupConversation("Original Name");
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
@@ -133,8 +130,7 @@ public sealed class UpdateGroupConversationHandlerTests
     public async Task HandleAsync_WhenGroupConversationUpdated_ShouldPersistAndNotify()
     {
         var callerId = UserId.New();
-        var otherId = UserId.New();
-        var conversation = ApplicationTestBuilders.CreateGroupConversation("Original Name", callerId, otherId);
+        var conversation = ApplicationTestBuilders.CreateGroupConversation("Original Name");
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
@@ -161,8 +157,7 @@ public sealed class UpdateGroupConversationHandlerTests
     public async Task HandleAsync_WhenNameIsNull_ShouldNotUpdateButReturnSuccess()
     {
         var callerId = UserId.New();
-        var otherId = UserId.New();
-        var conversation = ApplicationTestBuilders.CreateGroupConversation("Original Name", callerId, otherId);
+        var conversation = ApplicationTestBuilders.CreateGroupConversation("Original Name");
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
@@ -191,8 +186,7 @@ public sealed class UpdateGroupConversationHandlerTests
     public async Task HandleAsync_WhenNotifierThrows_ShouldStillSucceed()
     {
         var callerId = UserId.New();
-        var otherId = UserId.New();
-        var conversation = ApplicationTestBuilders.CreateGroupConversation("Original Name", callerId, otherId);
+        var conversation = ApplicationTestBuilders.CreateGroupConversation("Original Name");
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))

--- a/tests/Harmonie.Domain.Tests/ConversationTests.cs
+++ b/tests/Harmonie.Domain.Tests/ConversationTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Harmonie.Domain.Entities.Conversations;
+using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Users;
 using Xunit;
 
@@ -65,5 +66,71 @@ public sealed class ConversationTests
 
         result.IsFailure.Should().BeTrue();
         result.Error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void UpdateName_WithValidName_ShouldSucceed()
+    {
+        var conversation = Conversation.Rehydrate(ConversationId.New(), ConversationType.Group, "Original", DateTime.UtcNow);
+
+        var result = conversation.UpdateName("New Name");
+
+        result.IsSuccess.Should().BeTrue();
+        conversation.Name.Should().Be("New Name");
+    }
+
+    [Fact]
+    public void UpdateName_WithNull_ShouldSucceed()
+    {
+        var conversation = Conversation.Rehydrate(ConversationId.New(), ConversationType.Group, "Original", DateTime.UtcNow);
+
+        var result = conversation.UpdateName(null);
+
+        result.IsSuccess.Should().BeTrue();
+        conversation.Name.Should().BeNull();
+    }
+
+    [Fact]
+    public void UpdateName_WithEmptyString_ShouldFail()
+    {
+        var conversation = Conversation.Rehydrate(ConversationId.New(), ConversationType.Group, "Original", DateTime.UtcNow);
+
+        var result = conversation.UpdateName("");
+
+        result.IsFailure.Should().BeTrue();
+        conversation.Name.Should().Be("Original");
+    }
+
+    [Fact]
+    public void UpdateName_WithWhitespaceOnly_ShouldFail()
+    {
+        var conversation = Conversation.Rehydrate(ConversationId.New(), ConversationType.Group, "Original", DateTime.UtcNow);
+
+        var result = conversation.UpdateName("   ");
+
+        result.IsFailure.Should().BeTrue();
+        conversation.Name.Should().Be("Original");
+    }
+
+    [Fact]
+    public void UpdateName_WithNameExceedingMaxLength_ShouldFail()
+    {
+        var conversation = Conversation.Rehydrate(ConversationId.New(), ConversationType.Group, "Original", DateTime.UtcNow);
+
+        var result = conversation.UpdateName(new string('a', 101));
+
+        result.IsFailure.Should().BeTrue();
+        conversation.Name.Should().Be("Original");
+    }
+
+    [Fact]
+    public void UpdateName_WithNameAtMaxLength_ShouldSucceed()
+    {
+        var conversation = Conversation.Rehydrate(ConversationId.New(), ConversationType.Group, "Original", DateTime.UtcNow);
+
+        var result = conversation.UpdateName(new string('a', 100));
+
+        result.IsSuccess.Should().BeTrue();
+        conversation.Name.Should().Be(new string('a', 100));
     }
 }

--- a/tools/Harmonie.Migrations/Dockerfile
+++ b/tools/Harmonie.Migrations/Dockerfile
@@ -2,6 +2,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
+COPY ["Directory.Packages.props", "./"]
 COPY ["tools/Harmonie.Migrations/Harmonie.Migrations.csproj", "tools/Harmonie.Migrations/"]
 RUN dotnet restore "tools/Harmonie.Migrations/Harmonie.Migrations.csproj"
 


### PR DESCRIPTION
## Summary

- Add `PATCH /api/conversations/{conversationId}` endpoint to rename group conversations
- Only group conversations can be updated; direct conversations are rejected with 400
- Only participants can update a conversation
- Emits `ConversationUpdated` SignalR event to all participants on successful update

## Changes

- New `UpdateGroupConversation` feature with request, validator, handler, response, and endpoint
- `Conversation.UpdateName()` domain method with 100-character max validation
- `GetByIdWithParticipantCheckAsync` on `IConversationRepository` for single-query access check
- `UpdateAsync` on `IConversationRepository` to persist name changes
- `ConversationUpdated` notification in `IConversationNotifier` / `SignalRConversationNotifier`
- `InvalidConversationType` error code mapped to `400 BadRequest`
- Unit tests and integration tests covering success, access denial, not-found, direct conversation rejection, validation failures, and unauthenticated access

## Related Issue

Closes #333