### PR TITLE
fix(docker): add Directory.Packages.props to both Dockerfiles before dotnet restore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy solution and project files
+COPY ["Directory.Packages.props", "./"]
 COPY ["Harmonie.sln", "./"]
 COPY ["src/Harmonie.Domain/Harmonie.Domain.csproj", "src/Harmonie.Domain/"]
 COPY ["src/Harmonie.Application/Harmonie.Application.csproj", "src/Harmonie.Application/"]

--- a/tools/Harmonie.Migrations/Dockerfile
+++ b/tools/Harmonie.Migrations/Dockerfile
@@ -2,6 +2,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
+COPY ["Directory.Packages.props", "./"]
 COPY ["tools/Harmonie.Migrations/Harmonie.Migrations.csproj", "tools/Harmonie.Migrations/"]
 RUN dotnet restore "tools/Harmonie.Migrations/Harmonie.Migrations.csproj"
 


### PR DESCRIPTION
## Summary

- Both `Dockerfile` and `tools/Harmonie.Migrations/Dockerfile` were missing a `COPY ["Directory.Packages.props", "./"]` before `dotnet restore`
- With central package management enabled (`ManagePackageVersionsCentrally=true`), the `.csproj` files have no inline versions — `Directory.Packages.props` is required at restore time
- Without it, `dotnet restore` fails with `NU1015` on every package

## Test plan

- [x] `podman compose build` runs successfully — both `harmonie-migrations` and `harmonie-api` images build with 0 warnings, 0 errors

Closes #341