### PR TITLE
feat(conversations): hide direct conversation instead of removing participant

### DIFF
--- a/src/Harmonie.Application/Features/Conversations/DeleteConversation/DeleteConversationHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteConversation/DeleteConversationHandler.cs
@@ -1,6 +1,7 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Domain.Entities.Conversations;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Users;
 using Microsoft.Extensions.Logging;
@@ -50,6 +51,22 @@ public sealed class DeleteConversationHandler : IAuthenticatedHandler<DeleteConv
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Conversation.AccessDenied,
                 "You are not a participant of this conversation");
+        }
+
+        if (access.Conversation.Type == ConversationType.Direct)
+        {
+            await BestEffortNotificationHelper.TryNotifyAsync(
+                ct => _realtimeGroupManager.RemoveUserFromConversationGroupAsync(currentUserId, request.ConversationId, ct),
+                NotificationTimeout,
+                _logger,
+                "Failed to remove user {UserId} from conversation {ConversationId} SignalR group",
+                currentUserId,
+                request.ConversationId);
+
+            await _conversationRepository.HideConversationAsync(
+                request.ConversationId, currentUserId, cancellationToken);
+
+            return ApplicationResponse<bool>.Ok(true);
         }
 
         await BestEffortNotificationHelper.TryNotifyAsync(

--- a/src/Harmonie.Application/Features/Conversations/DeleteConversation/DeleteConversationHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteConversation/DeleteConversationHandler.cs
@@ -55,14 +55,6 @@ public sealed class DeleteConversationHandler : IAuthenticatedHandler<DeleteConv
 
         if (access.Conversation.Type == ConversationType.Direct)
         {
-            await BestEffortNotificationHelper.TryNotifyAsync(
-                ct => _realtimeGroupManager.RemoveUserFromConversationGroupAsync(currentUserId, request.ConversationId, ct),
-                NotificationTimeout,
-                _logger,
-                "Failed to remove user {UserId} from conversation {ConversationId} SignalR group",
-                currentUserId,
-                request.ConversationId);
-
             await _conversationRepository.HideConversationAsync(
                 request.ConversationId, currentUserId, cancellationToken);
 

--- a/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
@@ -49,6 +49,11 @@ public interface IConversationRepository
         UserId userId,
         CancellationToken cancellationToken = default);
 
+    Task HideConversationAsync(
+        ConversationId conversationId,
+        UserId userId,
+        CancellationToken cancellationToken = default);
+
     Task<int> RemoveParticipantAsync(
         ConversationId conversationId,
         UserId userId,

--- a/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
@@ -71,6 +71,19 @@ public sealed class ConversationRepository : IConversationRepository
         var existingConversationId = await connection.QueryFirstOrDefaultAsync<Guid?>(selectCommand);
         if (existingConversationId is not null)
         {
+            // Clear hidden_at_utc for both participants so the conversation reappears
+            const string clearHiddenSql = """
+                                           UPDATE conversation_participants
+                                           SET hidden_at_utc = NULL
+                                           WHERE conversation_id = @ConversationId
+                                             AND hidden_at_utc IS NOT NULL
+                                           """;
+            await connection.ExecuteAsync(new CommandDefinition(
+                clearHiddenSql,
+                new { ConversationId = existingConversationId.Value },
+                transaction: _dbSession.Transaction,
+                cancellationToken: cancellationToken));
+
             var existing = await GetByIdAsync(ConversationId.From(existingConversationId.Value), cancellationToken);
             return new ConversationGetOrCreateResult(existing!, WasCreated: false);
         }
@@ -180,6 +193,7 @@ public sealed class ConversationRepository : IConversationRepository
                            INNER JOIN conversation_participants cp2 ON cp2.conversation_id = c.id
                            INNER JOIN users u ON u.id = cp2.user_id
                            WHERE cp1.user_id = @UserId
+                             AND cp1.hidden_at_utc IS NULL
                              AND u.deleted_at IS NULL
                            ORDER BY c.created_at_utc DESC, c.id ASC, cp2.user_id ASC
                            """;
@@ -281,6 +295,26 @@ public sealed class ConversationRepository : IConversationRepository
             cancellationToken: cancellationToken));
 
         return remaining;
+    }
+
+    public async Task HideConversationAsync(
+        ConversationId conversationId,
+        UserId userId,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+
+        const string sql = """
+                            UPDATE conversation_participants
+                            SET hidden_at_utc = NOW()
+                            WHERE conversation_id = @ConversationId AND user_id = @UserId
+                              AND hidden_at_utc IS NULL
+                            """;
+        await connection.ExecuteAsync(new CommandDefinition(
+            sql,
+            new { ConversationId = conversationId.Value, UserId = userId.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken));
     }
 
     public async Task DeleteAsync(

--- a/tests/Harmonie.API.IntegrationTests/Conversations/DeleteConversationTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/DeleteConversationTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using FluentAssertions;
 using Harmonie.API.IntegrationTests.Common;
 using Harmonie.Application.Common;
+using Harmonie.Application.Features.Conversations.ListConversations;
 using Xunit;
 
 namespace Harmonie.API.IntegrationTests.Conversations;
@@ -16,19 +17,7 @@ public sealed class DeleteConversationTests : IClassFixture<HarmonieWebApplicati
         _client = factory.CreateClient();
     }
 
-    [Fact]
-    public async Task DeleteConversation_WhenParticipantDeletes_ShouldReturn204()
-    {
-        var caller = await AuthTestHelper.RegisterAsync(_client);
-        var other = await AuthTestHelper.RegisterAsync(_client);
-        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, other.UserId);
-
-        var response = await _client.SendAuthorizedDeleteAsync(
-            $"/api/conversations/{conversationId}",
-            caller.AccessToken);
-
-        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
-    }
+    // ── Common ──
 
     [Fact]
     public async Task DeleteConversation_WhenConversationDoesNotExist_ShouldReturnNotFound()
@@ -73,39 +62,30 @@ public sealed class DeleteConversationTests : IClassFixture<HarmonieWebApplicati
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
+    // ── Direct conversations ──
+
     [Fact]
-    public async Task DeleteConversation_WhenLastParticipantDeletes_ConversationShouldBeGone()
+    public async Task DeleteDirectConversation_ShouldReturn204()
     {
         var caller = await AuthTestHelper.RegisterAsync(_client);
         var other = await AuthTestHelper.RegisterAsync(_client);
         var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, other.UserId);
 
-        // Both participants delete the conversation
-        var firstDelete = await _client.SendAuthorizedDeleteAsync(
+        var response = await _client.SendAuthorizedDeleteAsync(
             $"/api/conversations/{conversationId}",
             caller.AccessToken);
-        firstDelete.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
-        var secondDelete = await _client.SendAuthorizedDeleteAsync(
-            $"/api/conversations/{conversationId}",
-            other.AccessToken);
-        secondDelete.StatusCode.Should().Be(HttpStatusCode.NoContent);
-
-        // Conversation should now be gone for both
-        var getResponse = await _client.SendAuthorizedDeleteAsync(
-            $"/api/conversations/{conversationId}",
-            caller.AccessToken);
-        getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
 
     [Fact]
-    public async Task DeleteConversation_WhenOneParticipantLeaves_OtherShouldStillHaveAccess()
+    public async Task DeleteDirectConversation_WhenOneHides_OtherShouldStillHaveAccess()
     {
         var caller = await AuthTestHelper.RegisterAsync(_client);
         var other = await AuthTestHelper.RegisterAsync(_client);
         var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, other.UserId);
 
-        // Caller deletes their side
+        // Caller hides their side
         var deleteResponse = await _client.SendAuthorizedDeleteAsync(
             $"/api/conversations/{conversationId}",
             caller.AccessToken);
@@ -119,31 +99,184 @@ public sealed class DeleteConversationTests : IClassFixture<HarmonieWebApplicati
     }
 
     [Fact]
-    public async Task DeleteConversation_AfterLeavingGroupConversation_OtherParticipantsShouldStillHaveAccess()
+    public async Task DeleteDirectConversation_WhenOneHides_ConversationDisappearsFromTheirList()
     {
-        var tag = Guid.NewGuid().ToString("N")[..8];
-        var callerReg = await AuthTestHelper.RegisterAsync(_client, $"leaver_{tag}");
-        var other1Reg = await AuthTestHelper.RegisterAsync(_client, $"remain1_{tag}");
-        var other2Reg = await AuthTestHelper.RegisterAsync(_client, $"remain2_{tag}");
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var other = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, other.UserId);
 
-        var groupConversation = await ConversationTestHelper.CreateGroupConversationAsync(
-            _client,
-            callerReg.AccessToken,
-            "Test group",
-            [callerReg.UserId, other1Reg.UserId, other2Reg.UserId]);
-
-        var conversationId = groupConversation.ConversationId;
-
-        // Caller leaves the group
+        // Caller hides the conversation
         var deleteResponse = await _client.SendAuthorizedDeleteAsync(
             $"/api/conversations/{conversationId}",
-            callerReg.AccessToken);
+            caller.AccessToken);
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Caller's conversation list should no longer contain the hidden conversation
+        var listResponse = await _client.SendAuthorizedGetAsync(
+            "/api/conversations",
+            caller.AccessToken);
+        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var list = await listResponse.Content.ReadFromJsonAsync<ListConversationsResponse>(TestContext.Current.CancellationToken);
+        list.Should().NotBeNull();
+        list!.Conversations.Should().NotContain(c => c.ConversationId == conversationId);
+    }
+
+    [Fact]
+    public async Task DeleteDirectConversation_WhenOneHides_OtherStillSeesItInList()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var other = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, other.UserId);
+
+        // Caller hides the conversation
+        var deleteResponse = await _client.SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}",
+            caller.AccessToken);
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Other participant should still see it in their list
+        var listResponse = await _client.SendAuthorizedGetAsync(
+            "/api/conversations",
+            other.AccessToken);
+        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var list = await listResponse.Content.ReadFromJsonAsync<ListConversationsResponse>(TestContext.Current.CancellationToken);
+        list.Should().NotBeNull();
+        list!.Conversations.Should().Contain(c => c.ConversationId == conversationId);
+    }
+
+    [Fact]
+    public async Task DeleteDirectConversation_WhenBothHide_ConversationStillExists()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var other = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, other.UserId);
+
+        // Both hide
+        var firstDelete = await _client.SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}",
+            caller.AccessToken);
+        firstDelete.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var secondDelete = await _client.SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}",
+            other.AccessToken);
+        secondDelete.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Conversation should disappear from both lists
+        var callerListResponse = await _client.SendAuthorizedGetAsync(
+            "/api/conversations",
+            caller.AccessToken);
+        var callerList = await callerListResponse.Content.ReadFromJsonAsync<ListConversationsResponse>(TestContext.Current.CancellationToken);
+        callerList!.Conversations.Should().NotContain(c => c.ConversationId == conversationId);
+
+        var otherListResponse = await _client.SendAuthorizedGetAsync(
+            "/api/conversations",
+            other.AccessToken);
+        var otherList = await otherListResponse.Content.ReadFromJsonAsync<ListConversationsResponse>(TestContext.Current.CancellationToken);
+        otherList!.Conversations.Should().NotContain(c => c.ConversationId == conversationId);
+    }
+
+    [Fact]
+    public async Task DeleteDirectConversation_AfterHiding_CanReopenViaOpenConversation()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var other = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, other.UserId);
+
+        // Caller hides
+        var deleteResponse = await _client.SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}",
+            caller.AccessToken);
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Caller reopens
+        var reopenedId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, other.UserId);
+        reopenedId.Should().Be(conversationId);
+
+        // Conversation reappears in caller's list
+        var listResponse = await _client.SendAuthorizedGetAsync(
+            "/api/conversations",
+            caller.AccessToken);
+        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var list = await listResponse.Content.ReadFromJsonAsync<ListConversationsResponse>(TestContext.Current.CancellationToken);
+        list.Should().NotBeNull();
+        list!.Conversations.Should().Contain(c => c.ConversationId == conversationId);
+    }
+
+    [Fact]
+    public async Task DeleteDirectConversation_AfterHiding_ReceivesIncomingMessages()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var other = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, other.UserId);
+
+        // Caller hides
+        var deleteResponse = await _client.SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}",
+            caller.AccessToken);
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Other sends a message
+        await ConversationTestHelper.SendConversationMessageAsync(
+            _client, conversationId, "Hello, are you there?", other.AccessToken);
+
+        // Caller can still fetch messages (participant row still exists)
+        var messagesResponse = await _client.SendAuthorizedGetAsync(
+            $"/api/conversations/{conversationId}/messages",
+            caller.AccessToken);
+        messagesResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // ── Group conversations ──
+
+    [Fact]
+    public async Task DeleteGroupConversation_WhenParticipantLeaves_ShouldReturn204()
+    {
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var leaver = await AuthTestHelper.RegisterAsync(_client, $"leaver_{tag}");
+        var other1 = await AuthTestHelper.RegisterAsync(_client, $"remain1_{tag}");
+        var other2 = await AuthTestHelper.RegisterAsync(_client, $"remain2_{tag}");
+
+        var group = await ConversationTestHelper.CreateGroupConversationAsync(
+            _client,
+            leaver.AccessToken,
+            "Test group",
+            [leaver.UserId, other1.UserId, other2.UserId]);
+
+        var deleteResponse = await _client.SendAuthorizedDeleteAsync(
+            $"/api/conversations/{group.ConversationId}",
+            leaver.AccessToken);
+
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task DeleteGroupConversation_RemainingParticipantsShouldStillHaveAccess()
+    {
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var leaver = await AuthTestHelper.RegisterAsync(_client, $"leaver_{tag}");
+        var other1 = await AuthTestHelper.RegisterAsync(_client, $"remain1_{tag}");
+        var other2 = await AuthTestHelper.RegisterAsync(_client, $"remain2_{tag}");
+
+        var group = await ConversationTestHelper.CreateGroupConversationAsync(
+            _client,
+            leaver.AccessToken,
+            "Test group",
+            [leaver.UserId, other1.UserId, other2.UserId]);
+
+        // Leaver leaves the group
+        var deleteResponse = await _client.SendAuthorizedDeleteAsync(
+            $"/api/conversations/{group.ConversationId}",
+            leaver.AccessToken);
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
         // Remaining participants can still access the conversation
         var messagesResponse = await _client.SendAuthorizedGetAsync(
-            $"/api/conversations/{conversationId}/messages",
-            other1Reg.AccessToken);
+            $"/api/conversations/{group.ConversationId}/messages",
+            other1.AccessToken);
         messagesResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 }

--- a/tests/Harmonie.Application.Tests/Conversations/DeleteConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/DeleteConversationHandlerTests.cs
@@ -157,7 +157,7 @@ public sealed class DeleteConversationHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_WhenDirectConversation_ShouldRemoveFromSignalRGroup()
+    public async Task HandleAsync_WhenDirectConversation_ShouldNotRemoveFromSignalRGroup()
     {
         var callerId = UserId.New();
         var otherId = UserId.New();
@@ -170,32 +170,8 @@ public sealed class DeleteConversationHandlerTests
         await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
 
         _realtimeGroupManagerMock.Verify(
-            x => x.RemoveUserFromConversationGroupAsync(callerId, conversation.Id, It.IsAny<CancellationToken>()),
-            Times.Once);
-    }
-
-    [Fact]
-    public async Task HandleAsync_WhenDirectConversationAndNotifierThrows_ShouldStillHide()
-    {
-        var callerId = UserId.New();
-        var otherId = UserId.New();
-        var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
-
-        _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
-
-        _realtimeGroupManagerMock
-            .Setup(x => x.RemoveUserFromConversationGroupAsync(
-                callerId, conversation.Id, It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("SignalR unavailable"));
-
-        var response = await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
-
-        response.Success.Should().BeTrue();
-        _conversationRepositoryMock.Verify(
-            x => x.HideConversationAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()),
-            Times.Once);
+            x => x.RemoveUserFromConversationGroupAsync(It.IsAny<UserId>(), It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     // ── Group conversation tests ──

--- a/tests/Harmonie.Application.Tests/Conversations/DeleteConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/DeleteConversationHandlerTests.cs
@@ -4,6 +4,7 @@ using Harmonie.Application.Features.Conversations.DeleteConversation;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.Entities.Conversations;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Users;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -62,6 +63,9 @@ public sealed class DeleteConversationHandlerTests
         _conversationRepositoryMock.Verify(
             x => x.RemoveParticipantAsync(It.IsAny<ConversationId>(), It.IsAny<UserId>(), It.IsAny<CancellationToken>()),
             Times.Never);
+        _conversationRepositoryMock.Verify(
+            x => x.HideConversationAsync(It.IsAny<ConversationId>(), It.IsAny<UserId>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
@@ -83,10 +87,15 @@ public sealed class DeleteConversationHandlerTests
         _conversationRepositoryMock.Verify(
             x => x.RemoveParticipantAsync(It.IsAny<ConversationId>(), It.IsAny<UserId>(), It.IsAny<CancellationToken>()),
             Times.Never);
+        _conversationRepositoryMock.Verify(
+            x => x.HideConversationAsync(It.IsAny<ConversationId>(), It.IsAny<UserId>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
+    // ── Direct conversation tests ──
+
     [Fact]
-    public async Task HandleAsync_WhenParticipantLeaves_ShouldReturnSuccess()
+    public async Task HandleAsync_WhenDirectConversation_ShouldHideAndReturnSuccess()
     {
         var callerId = UserId.New();
         var otherId = UserId.New();
@@ -97,8 +106,8 @@ public sealed class DeleteConversationHandlerTests
             .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
 
         _conversationRepositoryMock
-            .Setup(x => x.RemoveParticipantAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(1);
+            .Setup(x => x.HideConversationAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
         var response = await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
 
@@ -107,7 +116,7 @@ public sealed class DeleteConversationHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_WhenParticipantLeaves_ShouldNotifyAndRemoveFromSignalRGroup()
+    public async Task HandleAsync_WhenDirectConversation_ShouldCallHideConversationAsync()
     {
         var callerId = UserId.New();
         var otherId = UserId.New();
@@ -117,18 +126,48 @@ public sealed class DeleteConversationHandlerTests
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
 
+        await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
+
+        _conversationRepositoryMock.Verify(
+            x => x.HideConversationAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _conversationRepositoryMock.Verify(
+            x => x.RemoveParticipantAsync(It.IsAny<ConversationId>(), It.IsAny<UserId>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenDirectConversation_ShouldNotNotifyParticipantLeft()
+    {
+        var callerId = UserId.New();
+        var otherId = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
+
         _conversationRepositoryMock
-            .Setup(x => x.RemoveParticipantAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(1);
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
 
         await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
 
         _conversationNotifierMock.Verify(
             x => x.NotifyParticipantLeftAsync(
-                It.Is<ConversationParticipantLeftNotification>(n =>
-                    n.ConversationId == conversation.Id && n.UserId == callerId),
+                It.IsAny<ConversationParticipantLeftNotification>(),
                 It.IsAny<CancellationToken>()),
-            Times.Once);
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenDirectConversation_ShouldRemoveFromSignalRGroup()
+    {
+        var callerId = UserId.New();
+        var otherId = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+
+        await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
 
         _realtimeGroupManagerMock.Verify(
             x => x.RemoveUserFromConversationGroupAsync(callerId, conversation.Id, It.IsAny<CancellationToken>()),
@@ -136,7 +175,7 @@ public sealed class DeleteConversationHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_WhenLastParticipantLeaves_ShouldDeleteConversation()
+    public async Task HandleAsync_WhenDirectConversationAndNotifierThrows_ShouldStillHide()
     {
         var callerId = UserId.New();
         var otherId = UserId.New();
@@ -146,33 +185,101 @@ public sealed class DeleteConversationHandlerTests
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
 
-        _conversationRepositoryMock
-            .Setup(x => x.RemoveParticipantAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(0);
+        _realtimeGroupManagerMock
+            .Setup(x => x.RemoveUserFromConversationGroupAsync(
+                callerId, conversation.Id, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("SignalR unavailable"));
 
-        await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
+        var response = await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
 
+        response.Success.Should().BeTrue();
         _conversationRepositoryMock.Verify(
-            x => x.DeleteAsync(conversation.Id, It.IsAny<CancellationToken>()),
+            x => x.HideConversationAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ── Group conversation tests ──
+
+    [Fact]
+    public async Task HandleAsync_WhenGroupConversation_ShouldRemoveParticipantAndReturnSuccess()
+    {
+        var callerId = UserId.New();
+        var groupConversation = ApplicationTestBuilders.CreateGroupConversation("Test Group");
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(groupConversation, IsParticipant: true));
+
+        _conversationRepositoryMock
+            .Setup(x => x.RemoveParticipantAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+
+        var response = await _handler.HandleAsync(new DeleteConversationInput(groupConversation.Id), callerId, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Error.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenGroupConversation_ShouldNotifyParticipantLeft()
+    {
+        var callerId = UserId.New();
+        var groupConversation = ApplicationTestBuilders.CreateGroupConversation("Test Group");
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(groupConversation, IsParticipant: true));
+
+        _conversationRepositoryMock
+            .Setup(x => x.RemoveParticipantAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+
+        await _handler.HandleAsync(new DeleteConversationInput(groupConversation.Id), callerId, TestContext.Current.CancellationToken);
+
+        _conversationNotifierMock.Verify(
+            x => x.NotifyParticipantLeftAsync(
+                It.Is<ConversationParticipantLeftNotification>(n =>
+                    n.ConversationId == groupConversation.Id && n.UserId == callerId),
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
     [Fact]
-    public async Task HandleAsync_WhenParticipantsRemain_ShouldNotDeleteConversation()
+    public async Task HandleAsync_WhenGroupConversationLastParticipantLeaves_ShouldDeleteConversation()
     {
         var callerId = UserId.New();
-        var otherId = UserId.New();
-        var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
+        var groupConversation = ApplicationTestBuilders.CreateGroupConversation("Test Group");
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(groupConversation, IsParticipant: true));
 
         _conversationRepositoryMock
-            .Setup(x => x.RemoveParticipantAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(1);
+            .Setup(x => x.RemoveParticipantAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
 
-        await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
+        await _handler.HandleAsync(new DeleteConversationInput(groupConversation.Id), callerId, TestContext.Current.CancellationToken);
+
+        _conversationRepositoryMock.Verify(
+            x => x.DeleteAsync(groupConversation.Id, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenGroupConversationParticipantsRemain_ShouldNotDeleteConversation()
+    {
+        var callerId = UserId.New();
+        var groupConversation = ApplicationTestBuilders.CreateGroupConversation("Test Group");
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(groupConversation, IsParticipant: true));
+
+        _conversationRepositoryMock
+            .Setup(x => x.RemoveParticipantAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+
+        await _handler.HandleAsync(new DeleteConversationInput(groupConversation.Id), callerId, TestContext.Current.CancellationToken);
 
         _conversationRepositoryMock.Verify(
             x => x.DeleteAsync(It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()),
@@ -180,19 +287,18 @@ public sealed class DeleteConversationHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_WhenNotifierThrows_ShouldStillSucceedAndRemoveParticipant()
+    public async Task HandleAsync_WhenGroupConversationNotifierThrows_ShouldStillRemoveParticipant()
     {
         var callerId = UserId.New();
-        var otherId = UserId.New();
-        var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
+        var groupConversation = ApplicationTestBuilders.CreateGroupConversation("Test Group");
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(groupConversation, IsParticipant: true));
 
         _conversationRepositoryMock
-            .Setup(x => x.RemoveParticipantAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(1);
+            .Setup(x => x.RemoveParticipantAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
 
         _conversationNotifierMock
             .Setup(x => x.NotifyParticipantLeftAsync(
@@ -200,11 +306,11 @@ public sealed class DeleteConversationHandlerTests
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("SignalR unavailable"));
 
-        var response = await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
+        var response = await _handler.HandleAsync(new DeleteConversationInput(groupConversation.Id), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
         _conversationRepositoryMock.Verify(
-            x => x.RemoveParticipantAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()),
+            x => x.RemoveParticipantAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 }

--- a/tools/Harmonie.Migrations/Scripts/20260501_1_AddHiddenAtUtcToConversationParticipants.sql
+++ b/tools/Harmonie.Migrations/Scripts/20260501_1_AddHiddenAtUtcToConversationParticipants.sql
@@ -1,0 +1,6 @@
+-- Migration: Add hidden_at_utc to conversation_participants
+-- Date: 2026-05-01
+-- Description: Allows hiding a direct conversation without removing the participant row
+
+ALTER TABLE conversation_participants
+ADD COLUMN hidden_at_utc TIMESTAMPTZ NULL;


### PR DESCRIPTION
Closes #334

## Summary

Currently `DELETE /api/conversations/{id}` removes the calling user from `conversation_participants`. For **Direct** conversations this is too destructive — the user is fully removed and stops receiving messages until `OpenConversation` re-adds them.

## Changes

- **Migration**: Adds `hidden_at_utc TIMESTAMPTZ NULL` to `conversation_participants`
- **DeleteConversationHandler**: Branches on `Type`:
  - **Direct**: sets `hidden_at_utc = NOW()` (hide)
  - **Group**: removes participant row (unchanged)
  - SignalR `ParticipantLeft` only emitted for Group, not Direct
- **ListConversations**: Filters out `hidden_at_utc IS NOT NULL` rows
- **OpenConversation**: Clears `hidden_at_utc` so hidden conversations reappear

## Tests
- 12 unit tests covering both Direct (hide, no notification, no remove, SignalR group removal) and Group (remove, notify, delete when empty)
- 11 integration tests: hide/unhide, list filtering, reopen after hide, messages after hide, group leave