### PR TITLE
refactor(conversations): extract ConversationParticipant entity and repository

### DIFF
--- a/src/Harmonie.API/RealTime/Common/RealtimeHub.cs
+++ b/src/Harmonie.API/RealTime/Common/RealtimeHub.cs
@@ -123,7 +123,7 @@ public sealed class RealtimeHub : Hub<IRealtimeClient>
         if (access is null)
             throw new HubException(ApplicationErrorCodes.Conversation.NotFound);
 
-        if (!access.IsParticipant)
+        if (access.Participant is null)
             throw new HubException(ApplicationErrorCodes.Conversation.AccessDenied);
 
         var throttleKey = $"conversation:{currentUserId}:{conversationId}";

--- a/src/Harmonie.Application/Features/Conversations/AcknowledgeRead/AcknowledgeReadHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/AcknowledgeRead/AcknowledgeReadHandler.cs
@@ -41,7 +41,7 @@ public sealed class AcknowledgeReadHandler : IAuthenticatedHandler<AcknowledgeCo
                 ApplicationErrorCodes.Conversation.NotFound,
                 "Conversation was not found");
         }
-        if (!access.IsParticipant)
+        if (access.Participant is null)
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Conversation.AccessDenied,

--- a/src/Harmonie.Application/Features/Conversations/AddReaction/AddReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/AddReaction/AddReactionHandler.cs
@@ -50,7 +50,7 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ConversationAddRe
                 ApplicationErrorCodes.Conversation.NotFound,
                 "Conversation was not found");
         }
-        if (!access.IsParticipant)
+        if (access.Participant is null)
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Conversation.AccessDenied,

--- a/src/Harmonie.Application/Features/Conversations/DeleteConversation/DeleteConversationHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteConversation/DeleteConversationHandler.cs
@@ -49,7 +49,7 @@ public sealed class DeleteConversationHandler : IAuthenticatedHandler<DeleteConv
                 "Conversation was not found");
         }
 
-        if (!access.IsParticipant)
+        if (access.Participant is null)
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Conversation.AccessDenied,
@@ -58,18 +58,8 @@ public sealed class DeleteConversationHandler : IAuthenticatedHandler<DeleteConv
 
         if (access.Conversation.Type == ConversationType.Direct)
         {
-            var participant = await _participantRepository.GetAsync(
-                request.ConversationId, currentUserId, cancellationToken);
-
-            if (participant is null)
-            {
-                return ApplicationResponse<bool>.Fail(
-                    ApplicationErrorCodes.Conversation.AccessDenied,
-                    "You are not a participant of this conversation");
-            }
-
-            participant.Hide();
-            await _participantRepository.UpdateAsync(participant, cancellationToken);
+            access.Participant.Hide();
+            await _participantRepository.UpdateAsync(access.Participant, cancellationToken);
 
             return ApplicationResponse<bool>.Ok(true);
         }
@@ -83,17 +73,7 @@ public sealed class DeleteConversationHandler : IAuthenticatedHandler<DeleteConv
             request.ConversationId,
             currentUserId);
 
-        var participantToRemove = await _participantRepository.GetAsync(
-            request.ConversationId, currentUserId, cancellationToken);
-
-        if (participantToRemove is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Conversation.AccessDenied,
-                "You are not a participant of this conversation");
-        }
-
-        var remaining = await _participantRepository.RemoveAsync(participantToRemove, cancellationToken);
+        var remaining = await _participantRepository.RemoveAsync(access.Participant, cancellationToken);
 
         await BestEffortNotificationHelper.TryNotifyAsync(
             ct => _realtimeGroupManager.RemoveUserFromConversationGroupAsync(currentUserId, request.ConversationId, ct),

--- a/src/Harmonie.Application/Features/Conversations/DeleteConversation/DeleteConversationHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteConversation/DeleteConversationHandler.cs
@@ -15,17 +15,20 @@ public sealed class DeleteConversationHandler : IAuthenticatedHandler<DeleteConv
     private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
 
     private readonly IConversationRepository _conversationRepository;
+    private readonly IConversationParticipantRepository _participantRepository;
     private readonly IRealtimeGroupManager _realtimeGroupManager;
     private readonly IConversationNotifier _conversationNotifier;
     private readonly ILogger<DeleteConversationHandler> _logger;
 
     public DeleteConversationHandler(
         IConversationRepository conversationRepository,
+        IConversationParticipantRepository participantRepository,
         IRealtimeGroupManager realtimeGroupManager,
         IConversationNotifier conversationNotifier,
         ILogger<DeleteConversationHandler> logger)
     {
         _conversationRepository = conversationRepository;
+        _participantRepository = participantRepository;
         _realtimeGroupManager = realtimeGroupManager;
         _conversationNotifier = conversationNotifier;
         _logger = logger;
@@ -55,8 +58,18 @@ public sealed class DeleteConversationHandler : IAuthenticatedHandler<DeleteConv
 
         if (access.Conversation.Type == ConversationType.Direct)
         {
-            await _conversationRepository.HideConversationAsync(
+            var participant = await _participantRepository.GetAsync(
                 request.ConversationId, currentUserId, cancellationToken);
+
+            if (participant is null)
+            {
+                return ApplicationResponse<bool>.Fail(
+                    ApplicationErrorCodes.Conversation.AccessDenied,
+                    "You are not a participant of this conversation");
+            }
+
+            participant.Hide();
+            await _participantRepository.UpdateAsync(participant, cancellationToken);
 
             return ApplicationResponse<bool>.Ok(true);
         }
@@ -70,8 +83,17 @@ public sealed class DeleteConversationHandler : IAuthenticatedHandler<DeleteConv
             request.ConversationId,
             currentUserId);
 
-        var remaining = await _conversationRepository.RemoveParticipantAsync(
+        var participantToRemove = await _participantRepository.GetAsync(
             request.ConversationId, currentUserId, cancellationToken);
+
+        if (participantToRemove is null)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Conversation.AccessDenied,
+                "You are not a participant of this conversation");
+        }
+
+        var remaining = await _participantRepository.RemoveAsync(participantToRemove, cancellationToken);
 
         await BestEffortNotificationHelper.TryNotifyAsync(
             ct => _realtimeGroupManager.RemoveUserFromConversationGroupAsync(currentUserId, request.ConversationId, ct),

--- a/src/Harmonie.Application/Features/Conversations/DeleteMessage/DeleteMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteMessage/DeleteMessageHandler.cs
@@ -47,7 +47,7 @@ public sealed class DeleteMessageHandler : IAuthenticatedHandler<DeleteConversat
                 ApplicationErrorCodes.Conversation.NotFound,
                 "Conversation was not found");
         }
-        if (!access.IsParticipant)
+        if (access.Participant is null)
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Conversation.AccessDenied,

--- a/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
@@ -47,7 +47,7 @@ public sealed class DeleteMessageAttachmentHandler : IAuthenticatedHandler<Delet
                 ApplicationErrorCodes.Conversation.NotFound,
                 "Conversation was not found");
         }
-        if (!access.IsParticipant)
+        if (access.Participant is null)
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Conversation.AccessDenied,

--- a/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageHandler.cs
@@ -57,7 +57,7 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditConversationM
                 ApplicationErrorCodes.Conversation.NotFound,
                 "Conversation was not found");
         }
-        if (!access.IsParticipant)
+        if (access.Participant is null)
         {
             return ApplicationResponse<EditMessageResponse>.Fail(
                 ApplicationErrorCodes.Conversation.AccessDenied,

--- a/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesHandler.cs
@@ -55,7 +55,7 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetConversationMe
                 ApplicationErrorCodes.Conversation.NotFound,
                 "Conversation was not found");
         }
-        if (!access.IsParticipant)
+        if (access.Participant is null)
         {
             return ApplicationResponse<GetMessagesResponse>.Fail(
                 ApplicationErrorCodes.Conversation.AccessDenied,

--- a/src/Harmonie.Application/Features/Conversations/OpenConversation/OpenConversationHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/OpenConversation/OpenConversationHandler.cs
@@ -85,22 +85,19 @@ public sealed class OpenConversationHandler : IAuthenticatedHandler<OpenConversa
         }
         else
         {
-            // Reopen: clear hidden_at_utc for both participants so the conversation reappears
+            // Reopen: clear hidden_at_utc for hidden participants so the conversation reappears
             var conversationId = result.Conversation.Id;
+            var participants = await _participantRepository.GetByConversationIdAsync(conversationId, cancellationToken);
 
-            var currentParticipant = await _participantRepository.GetAsync(conversationId, currentUserId, cancellationToken);
-            if (currentParticipant is { HiddenAtUtc: not null })
-            {
-                currentParticipant.Unhide();
-                await _participantRepository.UpdateAsync(currentParticipant, cancellationToken);
-            }
+            var hidden = participants
+                .Where(p => p.HiddenAtUtc is not null)
+                .ToArray();
 
-            var targetParticipant = await _participantRepository.GetAsync(conversationId, targetUserId, cancellationToken);
-            if (targetParticipant is { HiddenAtUtc: not null })
-            {
-                targetParticipant.Unhide();
-                await _participantRepository.UpdateAsync(targetParticipant, cancellationToken);
-            }
+            foreach (var p in hidden)
+                p.Unhide();
+
+            if (hidden.Length > 0)
+                await _participantRepository.UpdateRangeAsync(hidden, cancellationToken);
         }
 
         var payload = new OpenConversationResponse(

--- a/src/Harmonie.Application/Features/Conversations/OpenConversation/OpenConversationHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/OpenConversation/OpenConversationHandler.cs
@@ -13,17 +13,20 @@ public sealed class OpenConversationHandler : IAuthenticatedHandler<OpenConversa
 {
     private readonly IUserRepository _userRepository;
     private readonly IConversationRepository _conversationRepository;
+    private readonly IConversationParticipantRepository _participantRepository;
     private readonly IRealtimeGroupManager _realtimeGroupManager;
     private readonly ILogger<OpenConversationHandler> _logger;
 
     public OpenConversationHandler(
         IUserRepository userRepository,
         IConversationRepository conversationRepository,
+        IConversationParticipantRepository participantRepository,
         IRealtimeGroupManager realtimeGroupManager,
         ILogger<OpenConversationHandler> logger)
     {
         _userRepository = userRepository;
         _conversationRepository = conversationRepository;
+        _participantRepository = participantRepository;
         _realtimeGroupManager = realtimeGroupManager;
         _logger = logger;
     }
@@ -79,6 +82,25 @@ public sealed class OpenConversationHandler : IAuthenticatedHandler<OpenConversa
                 _logger,
                 "Failed to subscribe users to conversation {ConversationId} SignalR group",
                 conversationId);
+        }
+        else
+        {
+            // Reopen: clear hidden_at_utc for both participants so the conversation reappears
+            var conversationId = result.Conversation.Id;
+
+            var currentParticipant = await _participantRepository.GetAsync(conversationId, currentUserId, cancellationToken);
+            if (currentParticipant is { HiddenAtUtc: not null })
+            {
+                currentParticipant.Unhide();
+                await _participantRepository.UpdateAsync(currentParticipant, cancellationToken);
+            }
+
+            var targetParticipant = await _participantRepository.GetAsync(conversationId, targetUserId, cancellationToken);
+            if (targetParticipant is { HiddenAtUtc: not null })
+            {
+                targetParticipant.Unhide();
+                await _participantRepository.UpdateAsync(targetParticipant, cancellationToken);
+            }
         }
 
         var payload = new OpenConversationResponse(

--- a/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionHandler.cs
@@ -50,7 +50,7 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ConversationRe
                 ApplicationErrorCodes.Conversation.NotFound,
                 "Conversation was not found");
         }
-        if (!access.IsParticipant)
+        if (access.Participant is null)
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Conversation.AccessDenied,

--- a/src/Harmonie.Application/Features/Conversations/SearchConversationMessages/SearchConversationMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/SearchConversationMessages/SearchConversationMessagesHandler.cs
@@ -109,7 +109,7 @@ public sealed class SearchConversationMessagesHandler : IAuthenticatedHandler<Se
                 ApplicationErrorCodes.Conversation.NotFound,
                 "Conversation was not found");
         }
-        if (!access.IsParticipant)
+        if (access.Participant is null)
         {
             return ApplicationResponse<SearchConversationMessagesResponse>.Fail(
                 ApplicationErrorCodes.Conversation.AccessDenied,

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageHandler.cs
@@ -66,7 +66,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
                 ApplicationErrorCodes.Conversation.NotFound,
                 "Conversation was not found");
         }
-        if (!access.IsParticipant)
+        if (access.Participant is null)
         {
             return ApplicationResponse<SendMessageResponse>.Fail(
                 ApplicationErrorCodes.Conversation.AccessDenied,

--- a/src/Harmonie.Application/Features/Conversations/UpdateGroupConversation/UpdateGroupConversationHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/UpdateGroupConversation/UpdateGroupConversationHandler.cs
@@ -46,7 +46,7 @@ public sealed class UpdateGroupConversationHandler : IAuthenticatedHandler<Updat
                 "Conversation was not found");
         }
 
-        if (!access.IsParticipant)
+        if (access.Participant is null)
         {
             return ApplicationResponse<UpdateGroupConversationResponse>.Fail(
                 ApplicationErrorCodes.Conversation.AccessDenied,

--- a/src/Harmonie.Application/Interfaces/Conversations/IConversationParticipantRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Conversations/IConversationParticipantRepository.cs
@@ -15,8 +15,16 @@ public interface IConversationParticipantRepository
         UserId userId,
         CancellationToken cancellationToken = default);
 
+    Task<IReadOnlyList<ConversationParticipant>> GetByConversationIdAsync(
+        ConversationId conversationId,
+        CancellationToken cancellationToken = default);
+
     Task UpdateAsync(
         ConversationParticipant participant,
+        CancellationToken cancellationToken = default);
+
+    Task UpdateRangeAsync(
+        IReadOnlyList<ConversationParticipant> participants,
         CancellationToken cancellationToken = default);
 
     Task<int> RemoveAsync(

--- a/src/Harmonie.Application/Interfaces/Conversations/IConversationParticipantRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Conversations/IConversationParticipantRepository.cs
@@ -6,6 +6,10 @@ namespace Harmonie.Application.Interfaces.Conversations;
 
 public interface IConversationParticipantRepository
 {
+    Task<bool> TryAddAsync(
+        ConversationParticipant participant,
+        CancellationToken cancellationToken = default);
+
     Task<ConversationParticipant?> GetAsync(
         ConversationId conversationId,
         UserId userId,

--- a/src/Harmonie.Application/Interfaces/Conversations/IConversationParticipantRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Conversations/IConversationParticipantRepository.cs
@@ -1,0 +1,21 @@
+using Harmonie.Domain.Entities.Conversations;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Interfaces.Conversations;
+
+public interface IConversationParticipantRepository
+{
+    Task<ConversationParticipant?> GetAsync(
+        ConversationId conversationId,
+        UserId userId,
+        CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(
+        ConversationParticipant participant,
+        CancellationToken cancellationToken = default);
+
+    Task<int> RemoveAsync(
+        ConversationParticipant participant,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
@@ -15,7 +15,7 @@ public sealed record ConversationParticipantSummary(
 
 public sealed record ConversationGetOrCreateResult(Conversation Conversation, bool WasCreated);
 
-public sealed record ConversationAccess(Conversation Conversation, bool IsParticipant);
+public sealed record ConversationAccess(Conversation Conversation, ConversationParticipant? Participant);
 
 public sealed record UserConversationSummary(
     ConversationId ConversationId,

--- a/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
@@ -49,16 +49,6 @@ public interface IConversationRepository
         UserId userId,
         CancellationToken cancellationToken = default);
 
-    Task HideConversationAsync(
-        ConversationId conversationId,
-        UserId userId,
-        CancellationToken cancellationToken = default);
-
-    Task<int> RemoveParticipantAsync(
-        ConversationId conversationId,
-        UserId userId,
-        CancellationToken cancellationToken = default);
-
     Task DeleteAsync(
         ConversationId conversationId,
         CancellationToken cancellationToken = default);

--- a/src/Harmonie.Domain/Entities/Conversations/ConversationParticipant.cs
+++ b/src/Harmonie.Domain/Entities/Conversations/ConversationParticipant.cs
@@ -1,0 +1,71 @@
+using Harmonie.Domain.Common;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Domain.Entities.Conversations;
+
+public sealed class ConversationParticipant
+{
+    public ConversationId ConversationId { get; }
+
+    public UserId UserId { get; }
+
+    public DateTime JoinedAtUtc { get; }
+
+    public DateTime? HiddenAtUtc { get; private set; }
+
+    private ConversationParticipant(
+        ConversationId conversationId,
+        UserId userId,
+        DateTime joinedAtUtc,
+        DateTime? hiddenAtUtc)
+    {
+        ConversationId = conversationId;
+        UserId = userId;
+        JoinedAtUtc = joinedAtUtc;
+        HiddenAtUtc = hiddenAtUtc;
+    }
+
+    public static Result<ConversationParticipant> Create(
+        ConversationId conversationId,
+        UserId userId)
+    {
+        if (conversationId is null)
+            return Result.Failure<ConversationParticipant>("Conversation ID is required");
+
+        if (userId is null)
+            return Result.Failure<ConversationParticipant>("User ID is required");
+
+        return Result.Success(new ConversationParticipant(
+            conversationId,
+            userId,
+            DateTime.UtcNow,
+            hiddenAtUtc: null));
+    }
+
+    public static ConversationParticipant Rehydrate(
+        ConversationId conversationId,
+        UserId userId,
+        DateTime joinedAtUtc,
+        DateTime? hiddenAtUtc)
+    {
+        ArgumentNullException.ThrowIfNull(conversationId);
+        ArgumentNullException.ThrowIfNull(userId);
+
+        return new ConversationParticipant(
+            conversationId,
+            userId,
+            joinedAtUtc,
+            hiddenAtUtc);
+    }
+
+    public void Hide()
+    {
+        HiddenAtUtc = DateTime.UtcNow;
+    }
+
+    public void Unhide()
+    {
+        HiddenAtUtc = null;
+    }
+}

--- a/src/Harmonie.Infrastructure/DependencyInjection.cs
+++ b/src/Harmonie.Infrastructure/DependencyInjection.cs
@@ -76,6 +76,7 @@ public static class DependencyInjection
         services.AddScoped<IMessagePaginationRepository, MessagePaginationRepository>();
         services.AddScoped<IMessageSearchRepository, MessageSearchRepository>();
         services.AddScoped<IConversationRepository, ConversationRepository>();
+        services.AddScoped<IConversationParticipantRepository, ConversationParticipantRepository>();
         services.AddScoped<IUploadedFileRepository, UploadedFileRepository>();
         services.AddScoped<IMessageReactionRepository, MessageReactionRepository>();
         services.AddScoped<IChannelReadStateRepository, ChannelReadStateRepository>();

--- a/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationParticipantRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationParticipantRepository.cs
@@ -68,6 +68,30 @@ public sealed class ConversationParticipantRepository : IConversationParticipant
         return row is null ? null : MapToParticipant(row);
     }
 
+    public async Task<IReadOnlyList<ConversationParticipant>> GetByConversationIdAsync(
+        ConversationId conversationId,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+                           SELECT conversation_id AS "ConversationId",
+                                  user_id         AS "UserId",
+                                  joined_at_utc   AS "JoinedAtUtc",
+                                  hidden_at_utc   AS "HiddenAtUtc"
+                           FROM conversation_participants
+                           WHERE conversation_id = @ConversationId
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new { ConversationId = conversationId.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        var rows = await connection.QueryAsync<ConversationParticipantRow>(command);
+        return rows.Select(MapToParticipant).ToArray();
+    }
+
     public async Task UpdateAsync(
         ConversationParticipant participant,
         CancellationToken cancellationToken = default)
@@ -86,6 +110,32 @@ public sealed class ConversationParticipantRepository : IConversationParticipant
                 ConversationId = participant.ConversationId.Value,
                 UserId = participant.UserId.Value,
                 HiddenAtUtc = participant.HiddenAtUtc
+            },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken));
+    }
+
+    public async Task UpdateRangeAsync(
+        IReadOnlyList<ConversationParticipant> participants,
+        CancellationToken cancellationToken = default)
+    {
+        if (participants.Count == 0)
+            return;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+
+        const string sql = """
+                            UPDATE conversation_participants
+                            SET hidden_at_utc = @HiddenAtUtc
+                            WHERE conversation_id = @ConversationId AND user_id = ANY(@UserIds)
+                            """;
+        await connection.ExecuteAsync(new CommandDefinition(
+            sql,
+            new
+            {
+                ConversationId = participants[0].ConversationId.Value,
+                UserIds = participants.Select(p => p.UserId.Value).ToArray(),
+                HiddenAtUtc = participants[0].HiddenAtUtc
             },
             transaction: _dbSession.Transaction,
             cancellationToken: cancellationToken));

--- a/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationParticipantRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationParticipantRepository.cs
@@ -17,6 +17,32 @@ public sealed class ConversationParticipantRepository : IConversationParticipant
         _dbSession = dbSession;
     }
 
+    public async Task<bool> TryAddAsync(
+        ConversationParticipant participant,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+                           INSERT INTO conversation_participants (conversation_id, user_id, joined_at_utc)
+                           VALUES (@ConversationId, @UserId, @JoinedAtUtc)
+                           ON CONFLICT (conversation_id, user_id) DO NOTHING
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new
+            {
+                ConversationId = participant.ConversationId.Value,
+                UserId = participant.UserId.Value,
+                JoinedAtUtc = participant.JoinedAtUtc
+            },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        var rows = await connection.ExecuteAsync(command);
+        return rows > 0;
+    }
+
     public async Task<ConversationParticipant?> GetAsync(
         ConversationId conversationId,
         UserId userId,

--- a/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationParticipantRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationParticipantRepository.cs
@@ -1,0 +1,114 @@
+using Dapper;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Domain.Entities.Conversations;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Users;
+using Harmonie.Infrastructure.Persistence.Common;
+using Harmonie.Infrastructure.Rows.Conversations;
+
+namespace Harmonie.Infrastructure.Persistence.Conversations;
+
+public sealed class ConversationParticipantRepository : IConversationParticipantRepository
+{
+    private readonly DbSession _dbSession;
+
+    public ConversationParticipantRepository(DbSession dbSession)
+    {
+        _dbSession = dbSession;
+    }
+
+    public async Task<ConversationParticipant?> GetAsync(
+        ConversationId conversationId,
+        UserId userId,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+                           SELECT conversation_id AS "ConversationId",
+                                  user_id         AS "UserId",
+                                  joined_at_utc   AS "JoinedAtUtc",
+                                  hidden_at_utc   AS "HiddenAtUtc"
+                           FROM conversation_participants
+                           WHERE conversation_id = @ConversationId AND user_id = @UserId
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new { ConversationId = conversationId.Value, UserId = userId.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        var row = await connection.QueryFirstOrDefaultAsync<ConversationParticipantRow>(command);
+        return row is null ? null : MapToParticipant(row);
+    }
+
+    public async Task UpdateAsync(
+        ConversationParticipant participant,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+
+        const string sql = """
+                            UPDATE conversation_participants
+                            SET hidden_at_utc = @HiddenAtUtc
+                            WHERE conversation_id = @ConversationId AND user_id = @UserId
+                            """;
+        await connection.ExecuteAsync(new CommandDefinition(
+            sql,
+            new
+            {
+                ConversationId = participant.ConversationId.Value,
+                UserId = participant.UserId.Value,
+                HiddenAtUtc = participant.HiddenAtUtc
+            },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken));
+    }
+
+    public async Task<int> RemoveAsync(
+        ConversationParticipant participant,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+
+        const string deleteSql = """
+                                  DELETE FROM conversation_participants
+                                  WHERE conversation_id = @ConversationId AND user_id = @UserId
+                                  """;
+        await connection.ExecuteAsync(new CommandDefinition(
+            deleteSql,
+            new { ConversationId = participant.ConversationId.Value, UserId = participant.UserId.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken));
+
+        const string countSql = """
+                                 SELECT COUNT(*) FROM conversation_participants
+                                 WHERE conversation_id = @ConversationId
+                                 """;
+        var remaining = await connection.ExecuteScalarAsync<int>(new CommandDefinition(
+            countSql,
+            new { ConversationId = participant.ConversationId.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken));
+
+        return remaining;
+    }
+
+    private static ConversationParticipant MapToParticipant(ConversationParticipantRow row)
+        => ConversationParticipant.Rehydrate(
+            ConversationId.From(row.ConversationId),
+            UserId.From(row.UserId),
+            row.JoinedAtUtc,
+            row.HiddenAtUtc);
+
+    private sealed class ConversationParticipantRow
+    {
+        public Guid ConversationId { get; init; }
+
+        public Guid UserId { get; init; }
+
+        public DateTime JoinedAtUtc { get; init; }
+
+        public DateTime? HiddenAtUtc { get; init; }
+    }
+}

--- a/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
@@ -244,15 +244,16 @@ public sealed class ConversationRepository : IConversationRepository
         CancellationToken cancellationToken = default)
     {
         const string sql = """
-                           SELECT c.id             AS "Id",
-                                  c.type           AS "Type",
-                                  c.name           AS "Name",
-                                  c.created_at_utc AS "CreatedAtUtc",
-                                  EXISTS(
-                                      SELECT 1 FROM conversation_participants
-                                      WHERE conversation_id = c.id AND user_id = @UserId
-                                  ) AS "IsParticipant"
+                           SELECT c.id              AS "Id",
+                                  c.type            AS "Type",
+                                  c.name            AS "Name",
+                                  c.created_at_utc  AS "CreatedAtUtc",
+                                  cp.user_id        AS "ParticipantUserId",
+                                  cp.joined_at_utc  AS "JoinedAtUtc",
+                                  cp.hidden_at_utc  AS "HiddenAtUtc"
                            FROM conversations c
+                           LEFT JOIN conversation_participants cp
+                             ON cp.conversation_id = c.id AND cp.user_id = @UserId
                            WHERE c.id = @ConversationId
                            """;
 
@@ -264,7 +265,19 @@ public sealed class ConversationRepository : IConversationRepository
             cancellationToken: cancellationToken);
 
         var row = await connection.QueryFirstOrDefaultAsync<ConversationWithParticipantRow>(command);
-        return row is null ? null : new ConversationAccess(MapToConversation(row), row.IsParticipant);
+        if (row is null)
+            return null;
+
+        var conversation = MapToConversation(row);
+        var participant = row.ParticipantUserId is not null
+            ? ConversationParticipant.Rehydrate(
+                ConversationId.From(conversationId.Value),
+                UserId.From(row.ParticipantUserId.Value),
+                row.JoinedAtUtc!.Value,
+                row.HiddenAtUtc)
+            : null;
+
+        return new ConversationAccess(conversation, participant);
     }
 
     public async Task DeleteAsync(
@@ -344,7 +357,11 @@ public sealed class ConversationRepository : IConversationRepository
 
         public DateTime CreatedAtUtc { get; init; }
 
-        public bool IsParticipant { get; init; }
+        public Guid? ParticipantUserId { get; init; }
+
+        public DateTime? JoinedAtUtc { get; init; }
+
+        public DateTime? HiddenAtUtc { get; init; }
     }
 
 }

--- a/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
@@ -267,56 +267,6 @@ public sealed class ConversationRepository : IConversationRepository
         return row is null ? null : new ConversationAccess(MapToConversation(row), row.IsParticipant);
     }
 
-    public async Task<int> RemoveParticipantAsync(
-        ConversationId conversationId,
-        UserId userId,
-        CancellationToken cancellationToken = default)
-    {
-        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
-
-        const string deleteSql = """
-                                  DELETE FROM conversation_participants
-                                  WHERE conversation_id = @ConversationId AND user_id = @UserId
-                                  """;
-        await connection.ExecuteAsync(new CommandDefinition(
-            deleteSql,
-            new { ConversationId = conversationId.Value, UserId = userId.Value },
-            transaction: _dbSession.Transaction,
-            cancellationToken: cancellationToken));
-
-        const string countSql = """
-                                 SELECT COUNT(*) FROM conversation_participants
-                                 WHERE conversation_id = @ConversationId
-                                 """;
-        var remaining = await connection.ExecuteScalarAsync<int>(new CommandDefinition(
-            countSql,
-            new { ConversationId = conversationId.Value },
-            transaction: _dbSession.Transaction,
-            cancellationToken: cancellationToken));
-
-        return remaining;
-    }
-
-    public async Task HideConversationAsync(
-        ConversationId conversationId,
-        UserId userId,
-        CancellationToken cancellationToken = default)
-    {
-        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
-
-        const string sql = """
-                            UPDATE conversation_participants
-                            SET hidden_at_utc = NOW()
-                            WHERE conversation_id = @ConversationId AND user_id = @UserId
-                              AND hidden_at_utc IS NULL
-                            """;
-        await connection.ExecuteAsync(new CommandDefinition(
-            sql,
-            new { ConversationId = conversationId.Value, UserId = userId.Value },
-            transaction: _dbSession.Transaction,
-            cancellationToken: cancellationToken));
-    }
-
     public async Task DeleteAsync(
         ConversationId conversationId,
         CancellationToken cancellationToken = default)

--- a/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
@@ -71,19 +71,6 @@ public sealed class ConversationRepository : IConversationRepository
         var existingConversationId = await connection.QueryFirstOrDefaultAsync<Guid?>(selectCommand);
         if (existingConversationId is not null)
         {
-            // Clear hidden_at_utc for both participants so the conversation reappears
-            const string clearHiddenSql = """
-                                           UPDATE conversation_participants
-                                           SET hidden_at_utc = NULL
-                                           WHERE conversation_id = @ConversationId
-                                             AND hidden_at_utc IS NOT NULL
-                                           """;
-            await connection.ExecuteAsync(new CommandDefinition(
-                clearHiddenSql,
-                new { ConversationId = existingConversationId.Value },
-                transaction: _dbSession.Transaction,
-                cancellationToken: cancellationToken));
-
             var existing = await GetByIdAsync(ConversationId.From(existingConversationId.Value), cancellationToken);
             return new ConversationGetOrCreateResult(existing!, WasCreated: false);
         }

--- a/tests/Harmonie.Application.Tests/Common/ApplicationTestBuilders.cs
+++ b/tests/Harmonie.Application.Tests/Common/ApplicationTestBuilders.cs
@@ -141,6 +141,9 @@ internal static class ApplicationTestBuilders
             null,
             DateTime.UtcNow);
 
+    public static ConversationParticipant CreateConversationParticipant(ConversationId conversationId, UserId userId)
+        => ConversationParticipant.Rehydrate(conversationId, userId, DateTime.UtcNow, hiddenAtUtc: null);
+
     public static Conversation CreateGroupConversation(string? name)
         => Conversation.Rehydrate(
             ConversationId.New(),

--- a/tests/Harmonie.Application.Tests/Conversations/AcknowledgeConversationReadHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/AcknowledgeConversationReadHandlerTests.cs
@@ -67,7 +67,7 @@ public sealed class AcknowledgeConversationReadHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: false));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: null));
 
         var response = await _handler.HandleAsync(new AcknowledgeConversationReadInput(conversation.Id, null), outsider, TestContext.Current.CancellationToken);
 
@@ -86,7 +86,7 @@ public sealed class AcknowledgeConversationReadHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -110,7 +110,7 @@ public sealed class AcknowledgeConversationReadHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -134,7 +134,7 @@ public sealed class AcknowledgeConversationReadHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -163,7 +163,7 @@ public sealed class AcknowledgeConversationReadHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _messageRepositoryMock
             .Setup(x => x.GetLatestConversationMessageIdAsync(conversation.Id, It.IsAny<CancellationToken>()))
@@ -191,7 +191,7 @@ public sealed class AcknowledgeConversationReadHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _messageRepositoryMock
             .Setup(x => x.GetLatestConversationMessageIdAsync(conversation.Id, It.IsAny<CancellationToken>()))

--- a/tests/Harmonie.Application.Tests/Conversations/DeleteConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/DeleteConversationHandlerTests.cs
@@ -84,7 +84,7 @@ public sealed class DeleteConversationHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: false));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: null));
 
         var response = await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), outsider, TestContext.Current.CancellationToken);
 
@@ -110,11 +110,7 @@ public sealed class DeleteConversationHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
-
-        _participantRepositoryMock
-            .Setup(x => x.GetAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(participant);
+            .ReturnsAsync(new ConversationAccess(conversation, participant));
 
         var response = await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
 
@@ -132,11 +128,7 @@ public sealed class DeleteConversationHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
-
-        _participantRepositoryMock
-            .Setup(x => x.GetAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(participant);
+            .ReturnsAsync(new ConversationAccess(conversation, participant));
 
         await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
 
@@ -163,11 +155,7 @@ public sealed class DeleteConversationHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
-
-        _participantRepositoryMock
-            .Setup(x => x.GetAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(participant);
+            .ReturnsAsync(new ConversationAccess(conversation, participant));
 
         await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
 
@@ -188,38 +176,13 @@ public sealed class DeleteConversationHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
-
-        _participantRepositoryMock
-            .Setup(x => x.GetAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(participant);
+            .ReturnsAsync(new ConversationAccess(conversation, participant));
 
         await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
 
         _realtimeGroupManagerMock.Verify(
             x => x.RemoveUserFromConversationGroupAsync(It.IsAny<UserId>(), It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()),
             Times.Never);
-    }
-
-    [Fact]
-    public async Task HandleAsync_WhenDirectConversationAndParticipantNotFound_ShouldReturnAccessDenied()
-    {
-        var callerId = UserId.New();
-        var otherId = UserId.New();
-        var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
-
-        _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
-
-        _participantRepositoryMock
-            .Setup(x => x.GetAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((ConversationParticipant?)null);
-
-        var response = await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
-
-        response.Success.Should().BeFalse();
-        response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
     }
 
     // ── Group conversation tests ──
@@ -233,14 +196,10 @@ public sealed class DeleteConversationHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(groupConversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(groupConversation, participant));
 
         _participantRepositoryMock
-            .Setup(x => x.GetAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(participant);
-
-        _participantRepositoryMock
-            .Setup(x => x.RemoveAsync(participant, It.IsAny<CancellationToken>()))
+            .Setup(x => x.RemoveAsync(It.IsAny<ConversationParticipant>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(2);
 
         var response = await _handler.HandleAsync(new DeleteConversationInput(groupConversation.Id), callerId, TestContext.Current.CancellationToken);
@@ -258,14 +217,10 @@ public sealed class DeleteConversationHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(groupConversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(groupConversation, participant));
 
         _participantRepositoryMock
-            .Setup(x => x.GetAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(participant);
-
-        _participantRepositoryMock
-            .Setup(x => x.RemoveAsync(participant, It.IsAny<CancellationToken>()))
+            .Setup(x => x.RemoveAsync(It.IsAny<ConversationParticipant>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(2);
 
         await _handler.HandleAsync(new DeleteConversationInput(groupConversation.Id), callerId, TestContext.Current.CancellationToken);
@@ -287,14 +242,10 @@ public sealed class DeleteConversationHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(groupConversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(groupConversation, participant));
 
         _participantRepositoryMock
-            .Setup(x => x.GetAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(participant);
-
-        _participantRepositoryMock
-            .Setup(x => x.RemoveAsync(participant, It.IsAny<CancellationToken>()))
+            .Setup(x => x.RemoveAsync(It.IsAny<ConversationParticipant>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(0);
 
         await _handler.HandleAsync(new DeleteConversationInput(groupConversation.Id), callerId, TestContext.Current.CancellationToken);
@@ -313,14 +264,10 @@ public sealed class DeleteConversationHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(groupConversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(groupConversation, participant));
 
         _participantRepositoryMock
-            .Setup(x => x.GetAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(participant);
-
-        _participantRepositoryMock
-            .Setup(x => x.RemoveAsync(participant, It.IsAny<CancellationToken>()))
+            .Setup(x => x.RemoveAsync(It.IsAny<ConversationParticipant>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(2);
 
         await _handler.HandleAsync(new DeleteConversationInput(groupConversation.Id), callerId, TestContext.Current.CancellationToken);
@@ -339,14 +286,10 @@ public sealed class DeleteConversationHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(groupConversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(groupConversation, participant));
 
         _participantRepositoryMock
-            .Setup(x => x.GetAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(participant);
-
-        _participantRepositoryMock
-            .Setup(x => x.RemoveAsync(participant, It.IsAny<CancellationToken>()))
+            .Setup(x => x.RemoveAsync(It.IsAny<ConversationParticipant>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(2);
 
         _conversationNotifierMock
@@ -359,7 +302,7 @@ public sealed class DeleteConversationHandlerTests
 
         response.Success.Should().BeTrue();
         _participantRepositoryMock.Verify(
-            x => x.RemoveAsync(participant, It.IsAny<CancellationToken>()),
+            x => x.RemoveAsync(It.IsAny<ConversationParticipant>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 }

--- a/tests/Harmonie.Application.Tests/Conversations/DeleteConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/DeleteConversationHandlerTests.cs
@@ -49,9 +49,6 @@ public sealed class DeleteConversationHandlerTests
             NullLogger<DeleteConversationHandler>.Instance);
     }
 
-    private static ConversationParticipant CreateParticipant(ConversationId conversationId, UserId userId)
-        => ConversationParticipant.Rehydrate(conversationId, userId, DateTime.UtcNow, hiddenAtUtc: null);
-
     [Fact]
     public async Task HandleAsync_WhenConversationDoesNotExist_ShouldReturnNotFound()
     {
@@ -106,7 +103,7 @@ public sealed class DeleteConversationHandlerTests
         var callerId = UserId.New();
         var otherId = UserId.New();
         var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
-        var participant = CreateParticipant(conversation.Id, callerId);
+        var participant = ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, callerId);
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
@@ -124,7 +121,7 @@ public sealed class DeleteConversationHandlerTests
         var callerId = UserId.New();
         var otherId = UserId.New();
         var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
-        var participant = CreateParticipant(conversation.Id, callerId);
+        var participant = ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, callerId);
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
@@ -151,7 +148,7 @@ public sealed class DeleteConversationHandlerTests
         var callerId = UserId.New();
         var otherId = UserId.New();
         var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
-        var participant = CreateParticipant(conversation.Id, callerId);
+        var participant = ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, callerId);
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
@@ -172,7 +169,7 @@ public sealed class DeleteConversationHandlerTests
         var callerId = UserId.New();
         var otherId = UserId.New();
         var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
-        var participant = CreateParticipant(conversation.Id, callerId);
+        var participant = ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, callerId);
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
@@ -192,7 +189,7 @@ public sealed class DeleteConversationHandlerTests
     {
         var callerId = UserId.New();
         var groupConversation = ApplicationTestBuilders.CreateGroupConversation("Test Group");
-        var participant = CreateParticipant(groupConversation.Id, callerId);
+        var participant = ApplicationTestBuilders.CreateConversationParticipant(groupConversation.Id, callerId);
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
@@ -213,7 +210,7 @@ public sealed class DeleteConversationHandlerTests
     {
         var callerId = UserId.New();
         var groupConversation = ApplicationTestBuilders.CreateGroupConversation("Test Group");
-        var participant = CreateParticipant(groupConversation.Id, callerId);
+        var participant = ApplicationTestBuilders.CreateConversationParticipant(groupConversation.Id, callerId);
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
@@ -238,7 +235,7 @@ public sealed class DeleteConversationHandlerTests
     {
         var callerId = UserId.New();
         var groupConversation = ApplicationTestBuilders.CreateGroupConversation("Test Group");
-        var participant = CreateParticipant(groupConversation.Id, callerId);
+        var participant = ApplicationTestBuilders.CreateConversationParticipant(groupConversation.Id, callerId);
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
@@ -260,7 +257,7 @@ public sealed class DeleteConversationHandlerTests
     {
         var callerId = UserId.New();
         var groupConversation = ApplicationTestBuilders.CreateGroupConversation("Test Group");
-        var participant = CreateParticipant(groupConversation.Id, callerId);
+        var participant = ApplicationTestBuilders.CreateConversationParticipant(groupConversation.Id, callerId);
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
@@ -282,7 +279,7 @@ public sealed class DeleteConversationHandlerTests
     {
         var callerId = UserId.New();
         var groupConversation = ApplicationTestBuilders.CreateGroupConversation("Test Group");
-        var participant = CreateParticipant(groupConversation.Id, callerId);
+        var participant = ApplicationTestBuilders.CreateConversationParticipant(groupConversation.Id, callerId);
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))

--- a/tests/Harmonie.Application.Tests/Conversations/DeleteConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/DeleteConversationHandlerTests.cs
@@ -16,6 +16,7 @@ namespace Harmonie.Application.Tests.Conversations;
 public sealed class DeleteConversationHandlerTests
 {
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
+    private readonly Mock<IConversationParticipantRepository> _participantRepositoryMock;
     private readonly Mock<IRealtimeGroupManager> _realtimeGroupManagerMock;
     private readonly Mock<IConversationNotifier> _conversationNotifierMock;
     private readonly DeleteConversationHandler _handler;
@@ -23,6 +24,7 @@ public sealed class DeleteConversationHandlerTests
     public DeleteConversationHandlerTests()
     {
         _conversationRepositoryMock = new Mock<IConversationRepository>();
+        _participantRepositoryMock = new Mock<IConversationParticipantRepository>();
         _realtimeGroupManagerMock = new Mock<IRealtimeGroupManager>();
         _conversationNotifierMock = new Mock<IConversationNotifier>();
 
@@ -41,10 +43,14 @@ public sealed class DeleteConversationHandlerTests
 
         _handler = new DeleteConversationHandler(
             _conversationRepositoryMock.Object,
+            _participantRepositoryMock.Object,
             _realtimeGroupManagerMock.Object,
             _conversationNotifierMock.Object,
             NullLogger<DeleteConversationHandler>.Instance);
     }
+
+    private static ConversationParticipant CreateParticipant(ConversationId conversationId, UserId userId)
+        => ConversationParticipant.Rehydrate(conversationId, userId, DateTime.UtcNow, hiddenAtUtc: null);
 
     [Fact]
     public async Task HandleAsync_WhenConversationDoesNotExist_ShouldReturnNotFound()
@@ -60,11 +66,11 @@ public sealed class DeleteConversationHandlerTests
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
-        _conversationRepositoryMock.Verify(
-            x => x.RemoveParticipantAsync(It.IsAny<ConversationId>(), It.IsAny<UserId>(), It.IsAny<CancellationToken>()),
+        _participantRepositoryMock.Verify(
+            x => x.RemoveAsync(It.IsAny<ConversationParticipant>(), It.IsAny<CancellationToken>()),
             Times.Never);
-        _conversationRepositoryMock.Verify(
-            x => x.HideConversationAsync(It.IsAny<ConversationId>(), It.IsAny<UserId>(), It.IsAny<CancellationToken>()),
+        _participantRepositoryMock.Verify(
+            x => x.UpdateAsync(It.IsAny<ConversationParticipant>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -84,11 +90,11 @@ public sealed class DeleteConversationHandlerTests
 
         response.Success.Should().BeFalse();
         response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
-        _conversationRepositoryMock.Verify(
-            x => x.RemoveParticipantAsync(It.IsAny<ConversationId>(), It.IsAny<UserId>(), It.IsAny<CancellationToken>()),
+        _participantRepositoryMock.Verify(
+            x => x.RemoveAsync(It.IsAny<ConversationParticipant>(), It.IsAny<CancellationToken>()),
             Times.Never);
-        _conversationRepositoryMock.Verify(
-            x => x.HideConversationAsync(It.IsAny<ConversationId>(), It.IsAny<UserId>(), It.IsAny<CancellationToken>()),
+        _participantRepositoryMock.Verify(
+            x => x.UpdateAsync(It.IsAny<ConversationParticipant>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -100,14 +106,15 @@ public sealed class DeleteConversationHandlerTests
         var callerId = UserId.New();
         var otherId = UserId.New();
         var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
+        var participant = CreateParticipant(conversation.Id, callerId);
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
 
-        _conversationRepositoryMock
-            .Setup(x => x.HideConversationAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+        _participantRepositoryMock
+            .Setup(x => x.GetAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(participant);
 
         var response = await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
 
@@ -116,23 +123,33 @@ public sealed class DeleteConversationHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_WhenDirectConversation_ShouldCallHideConversationAsync()
+    public async Task HandleAsync_WhenDirectConversation_ShouldCallUpdateWithHiddenAtUtc()
     {
         var callerId = UserId.New();
         var otherId = UserId.New();
         var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
+        var participant = CreateParticipant(conversation.Id, callerId);
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
 
+        _participantRepositoryMock
+            .Setup(x => x.GetAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(participant);
+
         await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
 
-        _conversationRepositoryMock.Verify(
-            x => x.HideConversationAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()),
+        _participantRepositoryMock.Verify(
+            x => x.UpdateAsync(
+                It.Is<ConversationParticipant>(p =>
+                    p.ConversationId == conversation.Id &&
+                    p.UserId == callerId &&
+                    p.HiddenAtUtc.HasValue),
+                It.IsAny<CancellationToken>()),
             Times.Once);
-        _conversationRepositoryMock.Verify(
-            x => x.RemoveParticipantAsync(It.IsAny<ConversationId>(), It.IsAny<UserId>(), It.IsAny<CancellationToken>()),
+        _participantRepositoryMock.Verify(
+            x => x.RemoveAsync(It.IsAny<ConversationParticipant>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -142,10 +159,15 @@ public sealed class DeleteConversationHandlerTests
         var callerId = UserId.New();
         var otherId = UserId.New();
         var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
+        var participant = CreateParticipant(conversation.Id, callerId);
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+
+        _participantRepositoryMock
+            .Setup(x => x.GetAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(participant);
 
         await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
 
@@ -162,16 +184,42 @@ public sealed class DeleteConversationHandlerTests
         var callerId = UserId.New();
         var otherId = UserId.New();
         var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
+        var participant = CreateParticipant(conversation.Id, callerId);
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+
+        _participantRepositoryMock
+            .Setup(x => x.GetAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(participant);
 
         await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
 
         _realtimeGroupManagerMock.Verify(
             x => x.RemoveUserFromConversationGroupAsync(It.IsAny<UserId>(), It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenDirectConversationAndParticipantNotFound_ShouldReturnAccessDenied()
+    {
+        var callerId = UserId.New();
+        var otherId = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(callerId, otherId);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+
+        _participantRepositoryMock
+            .Setup(x => x.GetAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConversationParticipant?)null);
+
+        var response = await _handler.HandleAsync(new DeleteConversationInput(conversation.Id), callerId, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
     }
 
     // ── Group conversation tests ──
@@ -181,13 +229,18 @@ public sealed class DeleteConversationHandlerTests
     {
         var callerId = UserId.New();
         var groupConversation = ApplicationTestBuilders.CreateGroupConversation("Test Group");
+        var participant = CreateParticipant(groupConversation.Id, callerId);
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(groupConversation, IsParticipant: true));
 
-        _conversationRepositoryMock
-            .Setup(x => x.RemoveParticipantAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+        _participantRepositoryMock
+            .Setup(x => x.GetAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(participant);
+
+        _participantRepositoryMock
+            .Setup(x => x.RemoveAsync(participant, It.IsAny<CancellationToken>()))
             .ReturnsAsync(2);
 
         var response = await _handler.HandleAsync(new DeleteConversationInput(groupConversation.Id), callerId, TestContext.Current.CancellationToken);
@@ -201,13 +254,18 @@ public sealed class DeleteConversationHandlerTests
     {
         var callerId = UserId.New();
         var groupConversation = ApplicationTestBuilders.CreateGroupConversation("Test Group");
+        var participant = CreateParticipant(groupConversation.Id, callerId);
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(groupConversation, IsParticipant: true));
 
-        _conversationRepositoryMock
-            .Setup(x => x.RemoveParticipantAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+        _participantRepositoryMock
+            .Setup(x => x.GetAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(participant);
+
+        _participantRepositoryMock
+            .Setup(x => x.RemoveAsync(participant, It.IsAny<CancellationToken>()))
             .ReturnsAsync(2);
 
         await _handler.HandleAsync(new DeleteConversationInput(groupConversation.Id), callerId, TestContext.Current.CancellationToken);
@@ -225,13 +283,18 @@ public sealed class DeleteConversationHandlerTests
     {
         var callerId = UserId.New();
         var groupConversation = ApplicationTestBuilders.CreateGroupConversation("Test Group");
+        var participant = CreateParticipant(groupConversation.Id, callerId);
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(groupConversation, IsParticipant: true));
 
-        _conversationRepositoryMock
-            .Setup(x => x.RemoveParticipantAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+        _participantRepositoryMock
+            .Setup(x => x.GetAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(participant);
+
+        _participantRepositoryMock
+            .Setup(x => x.RemoveAsync(participant, It.IsAny<CancellationToken>()))
             .ReturnsAsync(0);
 
         await _handler.HandleAsync(new DeleteConversationInput(groupConversation.Id), callerId, TestContext.Current.CancellationToken);
@@ -246,13 +309,18 @@ public sealed class DeleteConversationHandlerTests
     {
         var callerId = UserId.New();
         var groupConversation = ApplicationTestBuilders.CreateGroupConversation("Test Group");
+        var participant = CreateParticipant(groupConversation.Id, callerId);
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(groupConversation, IsParticipant: true));
 
-        _conversationRepositoryMock
-            .Setup(x => x.RemoveParticipantAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+        _participantRepositoryMock
+            .Setup(x => x.GetAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(participant);
+
+        _participantRepositoryMock
+            .Setup(x => x.RemoveAsync(participant, It.IsAny<CancellationToken>()))
             .ReturnsAsync(2);
 
         await _handler.HandleAsync(new DeleteConversationInput(groupConversation.Id), callerId, TestContext.Current.CancellationToken);
@@ -267,13 +335,18 @@ public sealed class DeleteConversationHandlerTests
     {
         var callerId = UserId.New();
         var groupConversation = ApplicationTestBuilders.CreateGroupConversation("Test Group");
+        var participant = CreateParticipant(groupConversation.Id, callerId);
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(groupConversation, IsParticipant: true));
 
-        _conversationRepositoryMock
-            .Setup(x => x.RemoveParticipantAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+        _participantRepositoryMock
+            .Setup(x => x.GetAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(participant);
+
+        _participantRepositoryMock
+            .Setup(x => x.RemoveAsync(participant, It.IsAny<CancellationToken>()))
             .ReturnsAsync(2);
 
         _conversationNotifierMock
@@ -285,8 +358,8 @@ public sealed class DeleteConversationHandlerTests
         var response = await _handler.HandleAsync(new DeleteConversationInput(groupConversation.Id), callerId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
-        _conversationRepositoryMock.Verify(
-            x => x.RemoveParticipantAsync(groupConversation.Id, callerId, It.IsAny<CancellationToken>()),
+        _participantRepositoryMock.Verify(
+            x => x.RemoveAsync(participant, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 }

--- a/tests/Harmonie.Application.Tests/Conversations/OpenConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/OpenConversationHandlerTests.cs
@@ -7,6 +7,7 @@ using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Conversations;
 using Harmonie.Domain.Entities.Users;
+using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Users;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -18,17 +19,23 @@ public sealed class OpenConversationHandlerTests
 {
     private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
+    private readonly Mock<IConversationParticipantRepository> _participantRepositoryMock;
     private readonly OpenConversationHandler _handler;
 
     public OpenConversationHandlerTests()
     {
         _userRepositoryMock = new Mock<IUserRepository>();
         _conversationRepositoryMock = new Mock<IConversationRepository>();
+        _participantRepositoryMock = new Mock<IConversationParticipantRepository>();
+
+        _participantRepositoryMock
+            .Setup(x => x.GetByConversationIdAsync(It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
 
         _handler = new OpenConversationHandler(
             _userRepositoryMock.Object,
             _conversationRepositoryMock.Object,
-            new Mock<IConversationParticipantRepository>().Object,
+            _participantRepositoryMock.Object,
             new Mock<IRealtimeGroupManager>().Object,
             NullLogger<OpenConversationHandler>.Instance);
     }

--- a/tests/Harmonie.Application.Tests/Conversations/OpenConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/OpenConversationHandlerTests.cs
@@ -28,6 +28,7 @@ public sealed class OpenConversationHandlerTests
         _handler = new OpenConversationHandler(
             _userRepositoryMock.Object,
             _conversationRepositoryMock.Object,
+            new Mock<IConversationParticipantRepository>().Object,
             new Mock<IRealtimeGroupManager>().Object,
             NullLogger<OpenConversationHandler>.Instance);
     }

--- a/tests/Harmonie.Application.Tests/Conversations/OpenConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/OpenConversationHandlerTests.cs
@@ -140,6 +140,121 @@ public sealed class OpenConversationHandlerTests
         response.Data.ConversationId.Should().Be(conversation.Id.Value);
     }
 
+    [Fact]
+    public async Task HandleAsync_WhenConversationExistsAndParticipantsHidden_ShouldUnhideThem()
+    {
+        var callerUserId = UserId.New();
+        var targetUserId = UserId.New();
+        var callerUser = CreateUser(callerUserId, "caller");
+        var targetUser = CreateUser(targetUserId, "target");
+        var conversation = ApplicationTestBuilders.CreateConversation(callerUserId, targetUserId);
+
+        var hiddenCaller = ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, callerUserId);
+        hiddenCaller.Hide();
+        var hiddenTarget = ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, targetUserId);
+        hiddenTarget.Hide();
+
+        _userRepositoryMock
+            .Setup(x => x.GetManyByIdsAsync(
+                It.Is<IReadOnlyList<UserId>>(ids => ids.Contains(callerUserId) && ids.Contains(targetUserId)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([callerUser, targetUser]);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetOrCreateDirectAsync(callerUserId, targetUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationGetOrCreateResult(conversation, false));
+
+        _participantRepositoryMock
+            .Setup(x => x.GetByConversationIdAsync(conversation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([hiddenCaller, hiddenTarget]);
+
+        var response = await _handler.HandleAsync(
+            new OpenConversationRequest(targetUserId),
+            callerUserId,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data!.Created.Should().BeFalse();
+
+        _participantRepositoryMock.Verify(
+            x => x.UpdateRangeAsync(
+                It.Is<IReadOnlyList<ConversationParticipant>>(list =>
+                    list.Count == 2 &&
+                    list.All(p => p.HiddenAtUtc == null)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenConversationExistsAndNoParticipantsHidden_ShouldNotUpdate()
+    {
+        var callerUserId = UserId.New();
+        var targetUserId = UserId.New();
+        var callerUser = CreateUser(callerUserId, "caller");
+        var targetUser = CreateUser(targetUserId, "target");
+        var conversation = ApplicationTestBuilders.CreateConversation(callerUserId, targetUserId);
+
+        var visibleCaller = ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, callerUserId);
+        var visibleTarget = ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, targetUserId);
+
+        _userRepositoryMock
+            .Setup(x => x.GetManyByIdsAsync(
+                It.Is<IReadOnlyList<UserId>>(ids => ids.Contains(callerUserId) && ids.Contains(targetUserId)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([callerUser, targetUser]);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetOrCreateDirectAsync(callerUserId, targetUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationGetOrCreateResult(conversation, false));
+
+        _participantRepositoryMock
+            .Setup(x => x.GetByConversationIdAsync(conversation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([visibleCaller, visibleTarget]);
+
+        var response = await _handler.HandleAsync(
+            new OpenConversationRequest(targetUserId),
+            callerUserId,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data!.Created.Should().BeFalse();
+
+        _participantRepositoryMock.Verify(
+            x => x.UpdateRangeAsync(It.IsAny<IReadOnlyList<ConversationParticipant>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenConversationIsCreated_ShouldNotCallGetByConversationIdAsync()
+    {
+        var callerUserId = UserId.New();
+        var targetUserId = UserId.New();
+        var callerUser = CreateUser(callerUserId, "caller");
+        var targetUser = CreateUser(targetUserId, "target");
+        var conversation = ApplicationTestBuilders.CreateConversation(callerUserId, targetUserId);
+
+        _userRepositoryMock
+            .Setup(x => x.GetManyByIdsAsync(
+                It.Is<IReadOnlyList<UserId>>(ids => ids.Contains(callerUserId) && ids.Contains(targetUserId)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([callerUser, targetUser]);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetOrCreateDirectAsync(callerUserId, targetUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationGetOrCreateResult(conversation, true));
+
+        var response = await _handler.HandleAsync(
+            new OpenConversationRequest(targetUserId),
+            callerUserId,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+
+        _participantRepositoryMock.Verify(
+            x => x.GetByConversationIdAsync(It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     private static User CreateUser(UserId userId, string suffix)
     {
         var emailResult = Email.Create($"{suffix}@harmonie.chat");

--- a/tests/Harmonie.Application.Tests/Conversations/UpdateGroupConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/UpdateGroupConversationHandlerTests.cs
@@ -71,7 +71,7 @@ public sealed class UpdateGroupConversationHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: false));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: null));
 
         var response = await _handler.HandleAsync(
             new UpdateGroupConversationInput(conversation.Id, "New Name"),
@@ -92,7 +92,7 @@ public sealed class UpdateGroupConversationHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         var response = await _handler.HandleAsync(
             new UpdateGroupConversationInput(conversation.Id, "New Name"),
@@ -112,7 +112,7 @@ public sealed class UpdateGroupConversationHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, callerId)));
 
         var response = await _handler.HandleAsync(
             new UpdateGroupConversationInput(conversation.Id, "New Name"),
@@ -134,7 +134,7 @@ public sealed class UpdateGroupConversationHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, callerId)));
 
         await _handler.HandleAsync(
             new UpdateGroupConversationInput(conversation.Id, "New Name"),
@@ -161,7 +161,7 @@ public sealed class UpdateGroupConversationHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, callerId)));
 
         var response = await _handler.HandleAsync(
             new UpdateGroupConversationInput(conversation.Id, null),
@@ -190,7 +190,7 @@ public sealed class UpdateGroupConversationHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, callerId)));
 
         _conversationNotifierMock
             .Setup(x => x.NotifyConversationUpdatedAsync(

--- a/tests/Harmonie.Application.Tests/Messages/AddConversationReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/AddConversationReactionHandlerTests.cs
@@ -77,7 +77,7 @@ public sealed class AddConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: false));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: null));
 
         var response = await _handler.HandleAsync(new ConversationAddReactionInput(conversation.Id, MessageId.New(), "👍"), outsider, TestContext.Current.CancellationToken);
 
@@ -96,7 +96,7 @@ public sealed class AddConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -120,7 +120,7 @@ public sealed class AddConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -144,7 +144,7 @@ public sealed class AddConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -167,7 +167,7 @@ public sealed class AddConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -205,7 +205,7 @@ public sealed class AddConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantTwo, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantTwo)));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -227,7 +227,7 @@ public sealed class AddConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))

--- a/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageAttachmentHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageAttachmentHandlerTests.cs
@@ -81,7 +81,7 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: false));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: null));
 
         var response = await _handler.HandleAsync(
             new DeleteConversationMessageAttachmentInput(conversation.Id, MessageId.New(), UploadedFileId.New()),
@@ -104,7 +104,7 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _conversationMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))
@@ -129,7 +129,7 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _conversationMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))
@@ -159,7 +159,7 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
         _conversationRepositoryMock
             .InSequence(sequence)
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _conversationMessageRepositoryMock
             .InSequence(sequence)

--- a/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageHandlerTests.cs
@@ -75,7 +75,7 @@ public sealed class DeleteConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: false));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: null));
 
         var response = await _handler.HandleAsync(new DeleteConversationMessageInput(conversation.Id, MessageId.New()), outsider, TestContext.Current.CancellationToken);
 
@@ -95,7 +95,7 @@ public sealed class DeleteConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -120,7 +120,7 @@ public sealed class DeleteConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -145,7 +145,7 @@ public sealed class DeleteConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -170,7 +170,7 @@ public sealed class DeleteConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -193,7 +193,7 @@ public sealed class DeleteConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -234,7 +234,7 @@ public sealed class DeleteConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))

--- a/tests/Harmonie.Application.Tests/Messages/EditConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/EditConversationMessageHandlerTests.cs
@@ -92,7 +92,7 @@ public sealed class EditConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: false));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: null));
 
         var response = await _handler.HandleAsync(
             new EditConversationMessageInput(conversation.Id, MessageId.New(), "updated content"),
@@ -115,7 +115,7 @@ public sealed class EditConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -143,7 +143,7 @@ public sealed class EditConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -171,7 +171,7 @@ public sealed class EditConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -199,7 +199,7 @@ public sealed class EditConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -230,7 +230,7 @@ public sealed class EditConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -272,7 +272,7 @@ public sealed class EditConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))

--- a/tests/Harmonie.Application.Tests/Messages/GetConversationMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetConversationMessagesHandlerTests.cs
@@ -73,7 +73,7 @@ public sealed class GetConversationMessagesHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: false));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: null));
 
         var response = await _handler.HandleAsync(
             new GetConversationMessagesInput(conversation.Id, Limit: 50),
@@ -97,7 +97,7 @@ public sealed class GetConversationMessagesHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetConversationPageAsync(

--- a/tests/Harmonie.Application.Tests/Messages/RemoveConversationReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/RemoveConversationReactionHandlerTests.cs
@@ -76,7 +76,7 @@ public sealed class RemoveConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: false));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: null));
 
         var response = await _handler.HandleAsync(new ConversationRemoveReactionInput(conversation.Id, MessageId.New(), "👍"), outsider, TestContext.Current.CancellationToken);
 
@@ -95,7 +95,7 @@ public sealed class RemoveConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -119,7 +119,7 @@ public sealed class RemoveConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -143,7 +143,7 @@ public sealed class RemoveConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -166,7 +166,7 @@ public sealed class RemoveConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -204,7 +204,7 @@ public sealed class RemoveConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))

--- a/tests/Harmonie.Application.Tests/Messages/SearchConversationMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SearchConversationMessagesHandlerTests.cs
@@ -61,7 +61,7 @@ public sealed class SearchConversationMessagesHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: false));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: null));
 
         var response = await _handler.HandleAsync(
             new SearchConversationMessagesInput(conversation.Id, Q: "deploy"),
@@ -89,7 +89,7 @@ public sealed class SearchConversationMessagesHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, user1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, user1)));
 
         _directMessageRepositoryMock
             .Setup(x => x.SearchConversationMessagesAsync(

--- a/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
@@ -85,7 +85,7 @@ public sealed class SendConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: false));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: null));
 
         var response = await _handler.HandleAsync(
             new SendConversationMessageInput(conversation.Id, "hello"),
@@ -108,7 +108,7 @@ public sealed class SendConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, currentUserId)));
 
         var response = await _handler.HandleAsync(
             new SendConversationMessageInput(conversation.Id, rawContent),
@@ -130,7 +130,7 @@ public sealed class SendConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, currentUserId)));
 
         _directMessageRepositoryMock
             .Setup(x => x.AddAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))
@@ -169,7 +169,7 @@ public sealed class SendConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, currentUserId)));
 
         _uploadedFileRepositoryMock
             .Setup(x => x.GetByIdsAsync(It.IsAny<IReadOnlyCollection<UploadedFileId>>(), It.IsAny<CancellationToken>()))
@@ -203,7 +203,7 @@ public sealed class SendConversationMessageHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, IsParticipant: true));
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, currentUserId)));
 
         _directMessageRepositoryMock
             .Setup(x => x.AddAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))

--- a/tests/Harmonie.Domain.Tests/ConversationParticipantTests.cs
+++ b/tests/Harmonie.Domain.Tests/ConversationParticipantTests.cs
@@ -1,0 +1,96 @@
+using FluentAssertions;
+using Harmonie.Domain.Entities.Conversations;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Users;
+using Xunit;
+
+namespace Harmonie.Domain.Tests;
+
+public sealed class ConversationParticipantTests
+{
+    [Fact]
+    public void Create_WithValidIds_ShouldSucceed()
+    {
+        var conversationId = ConversationId.New();
+        var userId = UserId.New();
+
+        var result = ConversationParticipant.Create(conversationId, userId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.ConversationId.Should().Be(conversationId);
+        result.Value.UserId.Should().Be(userId);
+        result.Value.HiddenAtUtc.Should().BeNull();
+        result.Value.JoinedAtUtc.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public void Create_WithNullConversationId_ShouldFail()
+    {
+        var result = ConversationParticipant.Create(null!, UserId.New());
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Conversation ID is required");
+    }
+
+    [Fact]
+    public void Create_WithNullUserId_ShouldFail()
+    {
+        var result = ConversationParticipant.Create(ConversationId.New(), null!);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("User ID is required");
+    }
+
+    [Fact]
+    public void Hide_ShouldSetHiddenAtUtc()
+    {
+        var participant = ConversationParticipant.Rehydrate(
+            ConversationId.New(), UserId.New(), DateTime.UtcNow, hiddenAtUtc: null);
+
+        participant.Hide();
+
+        participant.HiddenAtUtc.Should().NotBeNull();
+        participant.HiddenAtUtc.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public void Unhide_ShouldClearHiddenAtUtc()
+    {
+        var participant = ConversationParticipant.Rehydrate(
+            ConversationId.New(), UserId.New(), DateTime.UtcNow, hiddenAtUtc: DateTime.UtcNow);
+
+        participant.Unhide();
+
+        participant.HiddenAtUtc.Should().BeNull();
+    }
+
+    [Fact]
+    public void Rehydrate_WithNullConversationId_ShouldThrow()
+    {
+        var act = () => ConversationParticipant.Rehydrate(
+            null!, UserId.New(), DateTime.UtcNow, hiddenAtUtc: null);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Rehydrate_WithNullUserId_ShouldThrow()
+    {
+        var act = () => ConversationParticipant.Rehydrate(
+            ConversationId.New(), null!, DateTime.UtcNow, hiddenAtUtc: null);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Rehydrate_ShouldPreserveHiddenAtUtc()
+    {
+        var hiddenAt = new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        var participant = ConversationParticipant.Rehydrate(
+            ConversationId.New(), UserId.New(), DateTime.UtcNow, hiddenAtUtc: hiddenAt);
+
+        participant.HiddenAtUtc.Should().Be(hiddenAt);
+    }
+}


### PR DESCRIPTION
Closes #344

## Summary

Aligns the Conversations feature with the Guild DDD pattern used by `GuildMember` and `GuildBan`.

## Changes

### New
- **`ConversationParticipant`** domain entity — follows `GuildMember` pattern (no `Entity<TId>`, composite identity by `(ConversationId, UserId)`)
  - `Create()`, `Rehydrate()`, `Hide()`, `Unhide()`
- **`IConversationParticipantRepository`** + implementation
  - `GetAsync`, `UpdateAsync`, `RemoveAsync` — all take the entity, not primitive IDs

### Removed from `IConversationRepository`
- `HideConversationAsync(id, id)` → now `participant.Hide()` + `UpdateAsync(participant)`
- `RemoveParticipantAsync(id, id)` → now `RemoveAsync(participant)`

### Refactored
- `DeleteConversationHandler` — hydrates entity, calls `.Hide()` or `.RemoveAsync()`

## Why

| Before | After |
|---|---|
| `HideConversationAsync(conversationId, userId)` — primitive IDs | `participant.Hide()` + `UpdateAsync(participant)` — domain entity |
| No `ConversationParticipant` entity | Entity with encapsulated behavior |
| Inconsistent with `GuildMember`, `GuildBan` | Aligned with the established DDD pattern |

## Tests
- 8 domain tests for `ConversationParticipant`
- 12 handler tests updated to use `IConversationParticipantRepository`
- 998 tests total, 0 failures