### PR TITLE
[Reaction] Exposer les noms des utilisateurs dans les réactions

### DIFF
--- a/src/Harmonie.API/Endpoints/ChannelEndpoints.cs
+++ b/src/Harmonie.API/Endpoints/ChannelEndpoints.cs
@@ -7,6 +7,7 @@ using ChannelAddReaction = Harmonie.Application.Features.Channels.AddReaction.Ad
 using ChannelDeleteMessage = Harmonie.Application.Features.Channels.DeleteMessage.DeleteMessageEndpoint;
 using ChannelEditMessage = Harmonie.Application.Features.Channels.EditMessage.EditMessageEndpoint;
 using ChannelGetMessages = Harmonie.Application.Features.Channels.GetMessages.GetMessagesEndpoint;
+using ChannelGetReactionUsers = Harmonie.Application.Features.Channels.GetReactionUsers.GetReactionUsersEndpoint;
 using ChannelRemoveReaction = Harmonie.Application.Features.Channels.RemoveReaction.RemoveReactionEndpoint;
 using ChannelSendMessage = Harmonie.Application.Features.Channels.SendMessage.SendMessageEndpoint;
 
@@ -31,5 +32,6 @@ public static class ChannelEndpoints
         // Reactions
         ChannelAddReaction.Map(app);
         ChannelRemoveReaction.Map(app);
+        ChannelGetReactionUsers.Map(app);
     }
 }

--- a/src/Harmonie.API/Endpoints/ConversationEndpoints.cs
+++ b/src/Harmonie.API/Endpoints/ConversationEndpoints.cs
@@ -9,6 +9,7 @@ using ConversationDeleteMessage = Harmonie.Application.Features.Conversations.De
 using ConversationDeleteMessageAttachment = Harmonie.Application.Features.Conversations.DeleteMessageAttachment.DeleteMessageAttachmentEndpoint;
 using ConversationEditMessage = Harmonie.Application.Features.Conversations.EditMessage.EditMessageEndpoint;
 using ConversationGetMessages = Harmonie.Application.Features.Conversations.GetMessages.GetMessagesEndpoint;
+using ConversationGetReactionUsers = Harmonie.Application.Features.Conversations.GetReactionUsers.GetReactionUsersEndpoint;
 using ConversationRemoveReaction = Harmonie.Application.Features.Conversations.RemoveReaction.RemoveReactionEndpoint;
 using ConversationSendMessage = Harmonie.Application.Features.Conversations.SendMessage.SendMessageEndpoint;
 using ConversationUpdateGroup = Harmonie.Application.Features.Conversations.UpdateGroupConversation.UpdateGroupConversationEndpoint;
@@ -37,5 +38,6 @@ public static class ConversationEndpoints
         // Reactions
         ConversationAddReaction.Map(app);
         ConversationRemoveReaction.Map(app);
+        ConversationGetReactionUsers.Map(app);
     }
 }

--- a/src/Harmonie.API/RealTime/Messages/SignalRReactionNotifier.cs
+++ b/src/Harmonie.API/RealTime/Messages/SignalRReactionNotifier.cs
@@ -25,6 +25,8 @@ public sealed class SignalRReactionNotifier : IReactionNotifier
             GuildId: notification.GuildId.Value,
             ConversationId: null,
             UserId: notification.UserId.Value,
+            ReactorUsername: notification.Username,
+            ReactorDisplayName: notification.DisplayName,
             Emoji: notification.Emoji);
 
         await _hubContext.Clients
@@ -44,6 +46,8 @@ public sealed class SignalRReactionNotifier : IReactionNotifier
             GuildId: null,
             ConversationId: notification.ConversationId.Value,
             UserId: notification.UserId.Value,
+            ReactorUsername: notification.Username,
+            ReactorDisplayName: notification.DisplayName,
             Emoji: notification.Emoji);
 
         await _hubContext.Clients
@@ -63,6 +67,8 @@ public sealed class SignalRReactionNotifier : IReactionNotifier
             GuildId: notification.GuildId.Value,
             ConversationId: null,
             UserId: notification.UserId.Value,
+            ReactorUsername: notification.Username,
+            ReactorDisplayName: notification.DisplayName,
             Emoji: notification.Emoji);
 
         await _hubContext.Clients
@@ -82,6 +88,8 @@ public sealed class SignalRReactionNotifier : IReactionNotifier
             GuildId: null,
             ConversationId: notification.ConversationId.Value,
             UserId: notification.UserId.Value,
+            ReactorUsername: notification.Username,
+            ReactorDisplayName: notification.DisplayName,
             Emoji: notification.Emoji);
 
         await _hubContext.Clients
@@ -96,6 +104,8 @@ public sealed record ReactionAddedEvent(
     Guid? GuildId,
     Guid? ConversationId,
     Guid UserId,
+    string ReactorUsername,
+    string? ReactorDisplayName,
     string Emoji);
 
 public sealed record ReactionRemovedEvent(
@@ -104,4 +114,6 @@ public sealed record ReactionRemovedEvent(
     Guid? GuildId,
     Guid? ConversationId,
     Guid UserId,
+    string ReactorUsername,
+    string? ReactorDisplayName,
     string Emoji);

--- a/src/Harmonie.Application/Common/Messages/MessageReactionDto.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageReactionDto.cs
@@ -1,6 +1,12 @@
 namespace Harmonie.Application.Common.Messages;
 
+public sealed record ReactionUserDto(
+    Guid UserId,
+    string Username,
+    string? DisplayName);
+
 public sealed record MessageReactionDto(
     string Emoji,
     int Count,
-    bool ReactedByMe);
+    bool ReactedByMe,
+    IReadOnlyList<ReactionUserDto> Users);

--- a/src/Harmonie.Application/Common/Messages/ReactionUsersCursorCodec.cs
+++ b/src/Harmonie.Application/Common/Messages/ReactionUsersCursorCodec.cs
@@ -1,0 +1,47 @@
+using Harmonie.Application.Interfaces.Messages;
+
+namespace Harmonie.Application.Common.Messages;
+
+public static class ReactionUsersCursorCodec
+{
+    public static string Encode(ReactionUsersCursor cursor)
+    {
+        var utcCreatedAt = cursor.CreatedAtUtc.Kind == DateTimeKind.Utc
+            ? cursor.CreatedAtUtc
+            : DateTime.SpecifyKind(cursor.CreatedAtUtc, DateTimeKind.Utc);
+
+        return $"{utcCreatedAt.Ticks}_{cursor.UserId}";
+    }
+
+    public static bool TryParse(string? encodedCursor, out ReactionUsersCursor? cursor)
+    {
+        cursor = null;
+
+        if (string.IsNullOrWhiteSpace(encodedCursor))
+            return false;
+
+        var separatorIndex = encodedCursor.IndexOf('_');
+        if (separatorIndex <= 0 || separatorIndex >= encodedCursor.Length - 1)
+            return false;
+
+        var ticksPart = encodedCursor[..separatorIndex];
+        var userIdPart = encodedCursor[(separatorIndex + 1)..];
+
+        if (!long.TryParse(ticksPart, out var ticks))
+            return false;
+
+        if (!Guid.TryParse(userIdPart, out var userId))
+            return false;
+
+        try
+        {
+            var createdAtUtc = new DateTime(ticks, DateTimeKind.Utc);
+            cursor = new ReactionUsersCursor(createdAtUtc, userId);
+            return true;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Harmonie.Application/Features/Channels/AddReaction/AddReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/AddReaction/AddReactionHandler.cs
@@ -2,6 +2,7 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
@@ -20,6 +21,7 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ChannelAddReactio
     private readonly IGuildChannelRepository _guildChannelRepository;
     private readonly IMessageRepository _messageRepository;
     private readonly IMessageReactionRepository _reactionRepository;
+    private readonly IUserRepository _userRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IReactionNotifier _reactionNotifier;
     private readonly ILogger<AddReactionHandler> _logger;
@@ -28,6 +30,7 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ChannelAddReactio
         IGuildChannelRepository guildChannelRepository,
         IMessageRepository messageRepository,
         IMessageReactionRepository reactionRepository,
+        IUserRepository userRepository,
         IUnitOfWork unitOfWork,
         IReactionNotifier reactionNotifier,
         ILogger<AddReactionHandler> logger)
@@ -35,6 +38,7 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ChannelAddReactio
         _guildChannelRepository = guildChannelRepository;
         _messageRepository = messageRepository;
         _reactionRepository = reactionRepository;
+        _userRepository = userRepository;
         _unitOfWork = unitOfWork;
         _reactionNotifier = reactionNotifier;
         _logger = logger;
@@ -88,8 +92,12 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ChannelAddReactio
         await _reactionRepository.AddAsync(reaction.Value, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
 
+        var user = await _userRepository.GetByIdAsync(currentUserId, cancellationToken);
+        var username = user?.Username?.Value ?? string.Empty;
+        var displayName = user?.DisplayName;
+
         await NotifyReactionAddedSafelyAsync(
-            new ChannelReactionAddedNotification(request.MessageId, request.ChannelId, ctx.Channel.GuildId, currentUserId, request.Emoji));
+            new ChannelReactionAddedNotification(request.MessageId, request.ChannelId, ctx.Channel.GuildId, currentUserId, username, displayName, request.Emoji));
 
         return ApplicationResponse<bool>.Ok(true);
     }

--- a/src/Harmonie.Application/Features/Channels/AddReaction/AddReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/AddReaction/AddReactionHandler.cs
@@ -2,7 +2,6 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Application.Interfaces.Users;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
@@ -21,7 +20,6 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ChannelAddReactio
     private readonly IGuildChannelRepository _guildChannelRepository;
     private readonly IMessageRepository _messageRepository;
     private readonly IMessageReactionRepository _reactionRepository;
-    private readonly IUserRepository _userRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IReactionNotifier _reactionNotifier;
     private readonly ILogger<AddReactionHandler> _logger;
@@ -30,7 +28,6 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ChannelAddReactio
         IGuildChannelRepository guildChannelRepository,
         IMessageRepository messageRepository,
         IMessageReactionRepository reactionRepository,
-        IUserRepository userRepository,
         IUnitOfWork unitOfWork,
         IReactionNotifier reactionNotifier,
         ILogger<AddReactionHandler> logger)
@@ -38,7 +35,6 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ChannelAddReactio
         _guildChannelRepository = guildChannelRepository;
         _messageRepository = messageRepository;
         _reactionRepository = reactionRepository;
-        _userRepository = userRepository;
         _unitOfWork = unitOfWork;
         _reactionNotifier = reactionNotifier;
         _logger = logger;
@@ -92,12 +88,15 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ChannelAddReactio
         await _reactionRepository.AddAsync(reaction.Value, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
 
-        var user = await _userRepository.GetByIdAsync(currentUserId, cancellationToken);
-        var username = user?.Username?.Value ?? string.Empty;
-        var displayName = user?.DisplayName;
-
         await NotifyReactionAddedSafelyAsync(
-            new ChannelReactionAddedNotification(request.MessageId, request.ChannelId, ctx.Channel.GuildId, currentUserId, username, displayName, request.Emoji));
+            new ChannelReactionAddedNotification(
+                request.MessageId,
+                request.ChannelId,
+                ctx.Channel.GuildId,
+                currentUserId,
+                ctx.CallerUsername ?? string.Empty,
+                ctx.CallerDisplayName,
+                request.Emoji));
 
         return ApplicationResponse<bool>.Ok(true);
     }

--- a/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesHandler.cs
@@ -89,7 +89,8 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetChannelMessage
                     AuthorUserId: x.AuthorUserId.Value,
                     Content: x.Content?.Value,
                     Attachments: x.Attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
-                    Reactions: reactions?.Select(r => new MessageReactionDto(r.Emoji, r.Count, r.ReactedByCaller)).ToArray()
+                    Reactions: reactions?.Select(r => new MessageReactionDto(r.Emoji, r.Count, r.ReactedByCaller,
+                        r.Users.Select(u => new ReactionUserDto(u.UserId, u.Username, u.DisplayName)).ToArray())).ToArray()
                               ?? Array.Empty<MessageReactionDto>(),
                     CreatedAtUtc: x.CreatedAtUtc,
                     UpdatedAtUtc: x.UpdatedAtUtc);

--- a/src/Harmonie.Application/Features/Channels/GetReactionUsers/GetReactionUsersEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/GetReactionUsers/GetReactionUsersEndpoint.cs
@@ -1,0 +1,59 @@
+using FluentValidation;
+using Harmonie.Application.Common;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Messages;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Harmonie.Application.Features.Channels.GetReactionUsers;
+
+public static class GetReactionUsersEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/channels/{channelId}/messages/{messageId}/reactions/{emoji}/users", HandleAsync)
+            .WithName("GetChannelMessageReactionUsers")
+            .WithTags("Channels")
+            .RequireAuthorization()
+            .WithSummary("Get users who reacted with a specific emoji on a channel message")
+            .WithDescription("Returns a paginated list of users who reacted with the given emoji on the specified message.")
+            .Produces<GetReactionUsersResponse>()
+            .ProducesErrors(
+                ApplicationErrorCodes.Common.ValidationFailed,
+                ApplicationErrorCodes.Auth.InvalidCredentials,
+                ApplicationErrorCodes.Channel.NotFound,
+                ApplicationErrorCodes.Channel.NotText,
+                ApplicationErrorCodes.Channel.AccessDenied,
+                ApplicationErrorCodes.Reaction.MessageNotFound);
+    }
+
+    private static async Task<IResult> HandleAsync(
+        GuildChannelId channelId,
+        MessageId messageId,
+        [AsParameters] GetReactionUsersRouteRequest routeRequest,
+        [FromServices] IAuthenticatedHandler<GetChannelReactionUsersInput, GetReactionUsersResponse> handler,
+        [FromServices] IValidator<GetReactionUsersRouteRequest> routeValidator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var routeValidationError = await routeRequest.ValidateAsync(routeValidator, cancellationToken);
+        if (routeValidationError is not null)
+            return ApplicationResponse<GetReactionUsersResponse>.Fail(routeValidationError).ToHttpResult(httpContext);
+
+        if (routeRequest.Emoji is not string emoji)
+            return ApplicationResponse<GetReactionUsersResponse>.Fail(
+                ApplicationErrorCodes.Common.InvalidState,
+                "Route validation succeeded but emoji was null.").ToHttpResult(httpContext);
+
+        var callerId = httpContext.GetRequiredAuthenticatedUserId();
+
+        var response = await handler.HandleAsync(
+            new GetChannelReactionUsersInput(channelId, messageId, emoji, routeRequest.Cursor, routeRequest.Limit),
+            callerId,
+            cancellationToken);
+
+        return response.ToHttpResult(httpContext);
+    }
+}

--- a/src/Harmonie.Application/Features/Channels/GetReactionUsers/GetReactionUsersHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/GetReactionUsers/GetReactionUsersHandler.cs
@@ -1,0 +1,113 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Features.Channels.GetReactionUsers;
+
+public sealed record GetChannelReactionUsersInput(
+    GuildChannelId ChannelId,
+    MessageId MessageId,
+    string Emoji,
+    string? Cursor = null,
+    int? Limit = null);
+
+public sealed class GetReactionUsersHandler : IAuthenticatedHandler<GetChannelReactionUsersInput, GetReactionUsersResponse>
+{
+    private const int DefaultLimit = 50;
+    private const int MaxLimit = 100;
+
+    private readonly IGuildChannelRepository _guildChannelRepository;
+    private readonly IMessageRepository _messageRepository;
+    private readonly IMessageReactionRepository _reactionRepository;
+
+    public GetReactionUsersHandler(
+        IGuildChannelRepository guildChannelRepository,
+        IMessageRepository messageRepository,
+        IMessageReactionRepository reactionRepository)
+    {
+        _guildChannelRepository = guildChannelRepository;
+        _messageRepository = messageRepository;
+        _reactionRepository = reactionRepository;
+    }
+
+    public async Task<ApplicationResponse<GetReactionUsersResponse>> HandleAsync(
+        GetChannelReactionUsersInput request,
+        UserId currentUserId,
+        CancellationToken cancellationToken = default)
+    {
+        ReactionUsersCursor? cursor = null;
+        if (request.Cursor is not null)
+        {
+            if (!ReactionUsersCursorCodec.TryParse(request.Cursor, out var parsedCursor) || parsedCursor is null)
+            {
+                return ApplicationResponse<GetReactionUsersResponse>.Fail(
+                    ApplicationErrorCodes.Common.ValidationFailed,
+                    "Request validation failed",
+                    EndpointExtensions.SingleValidationError(
+                        nameof(request.Cursor),
+                        ApplicationErrorCodes.Validation.InvalidFormat,
+                        "Cursor is invalid"));
+            }
+
+            cursor = parsedCursor;
+        }
+
+        var limit = Math.Clamp(request.Limit ?? DefaultLimit, 1, MaxLimit);
+
+        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(request.ChannelId, currentUserId, cancellationToken);
+        if (ctx is null)
+        {
+            return ApplicationResponse<GetReactionUsersResponse>.Fail(
+                ApplicationErrorCodes.Channel.NotFound,
+                "Channel was not found");
+        }
+
+        if (ctx.Channel.Type != GuildChannelType.Text)
+        {
+            return ApplicationResponse<GetReactionUsersResponse>.Fail(
+                ApplicationErrorCodes.Channel.NotText,
+                "Reactions can only be viewed in text channels");
+        }
+
+        if (ctx.CallerRole is null)
+        {
+            return ApplicationResponse<GetReactionUsersResponse>.Fail(
+                ApplicationErrorCodes.Channel.AccessDenied,
+                "You do not have access to this channel");
+        }
+
+        var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
+        var messageChannelId = message?.ChannelId;
+        if (message is null || messageChannelId is null || messageChannelId != request.ChannelId)
+        {
+            return ApplicationResponse<GetReactionUsersResponse>.Fail(
+                ApplicationErrorCodes.Reaction.MessageNotFound,
+                "Message was not found");
+        }
+
+        var page = await _reactionRepository.GetReactionUsersAsync(
+            request.MessageId,
+            request.Emoji,
+            limit,
+            cursor,
+            cancellationToken);
+
+        var users = page.Users
+            .Select(u => new ReactionUserDto(u.UserId, u.Username, u.DisplayName))
+            .ToArray();
+
+        var payload = new GetReactionUsersResponse(
+            MessageId: request.MessageId.Value,
+            Emoji: request.Emoji,
+            TotalCount: page.TotalCount,
+            Users: users,
+            NextCursor: page.NextCursor is null ? null : ReactionUsersCursorCodec.Encode(page.NextCursor));
+
+        return ApplicationResponse<GetReactionUsersResponse>.Ok(payload);
+    }
+}

--- a/src/Harmonie.Application/Features/Channels/GetReactionUsers/GetReactionUsersResponse.cs
+++ b/src/Harmonie.Application/Features/Channels/GetReactionUsers/GetReactionUsersResponse.cs
@@ -1,0 +1,10 @@
+using Harmonie.Application.Common.Messages;
+
+namespace Harmonie.Application.Features.Channels.GetReactionUsers;
+
+public sealed record GetReactionUsersResponse(
+    Guid MessageId,
+    string Emoji,
+    int TotalCount,
+    IReadOnlyList<ReactionUserDto> Users,
+    string? NextCursor);

--- a/src/Harmonie.Application/Features/Channels/GetReactionUsers/GetReactionUsersRouteRequest.cs
+++ b/src/Harmonie.Application/Features/Channels/GetReactionUsers/GetReactionUsersRouteRequest.cs
@@ -1,0 +1,8 @@
+namespace Harmonie.Application.Features.Channels.GetReactionUsers;
+
+public sealed class GetReactionUsersRouteRequest
+{
+    public string? Emoji { get; init; }
+    public string? Cursor { get; init; }
+    public int? Limit { get; init; }
+}

--- a/src/Harmonie.Application/Features/Channels/GetReactionUsers/GetReactionUsersRouteValidator.cs
+++ b/src/Harmonie.Application/Features/Channels/GetReactionUsers/GetReactionUsersRouteValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace Harmonie.Application.Features.Channels.GetReactionUsers;
+
+public sealed class GetReactionUsersRouteValidator : AbstractValidator<GetReactionUsersRouteRequest>
+{
+    public GetReactionUsersRouteValidator()
+    {
+        RuleFor(x => x.Emoji)
+            .NotEmpty()
+            .MaximumLength(64);
+    }
+}

--- a/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionHandler.cs
@@ -2,6 +2,7 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Messages;
@@ -19,6 +20,7 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ChannelRemoveR
     private readonly IGuildChannelRepository _guildChannelRepository;
     private readonly IMessageRepository _messageRepository;
     private readonly IMessageReactionRepository _reactionRepository;
+    private readonly IUserRepository _userRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IReactionNotifier _reactionNotifier;
     private readonly ILogger<RemoveReactionHandler> _logger;
@@ -27,6 +29,7 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ChannelRemoveR
         IGuildChannelRepository guildChannelRepository,
         IMessageRepository messageRepository,
         IMessageReactionRepository reactionRepository,
+        IUserRepository userRepository,
         IUnitOfWork unitOfWork,
         IReactionNotifier reactionNotifier,
         ILogger<RemoveReactionHandler> logger)
@@ -34,6 +37,7 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ChannelRemoveR
         _guildChannelRepository = guildChannelRepository;
         _messageRepository = messageRepository;
         _reactionRepository = reactionRepository;
+        _userRepository = userRepository;
         _unitOfWork = unitOfWork;
         _reactionNotifier = reactionNotifier;
         _logger = logger;
@@ -79,8 +83,12 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ChannelRemoveR
         await _reactionRepository.RemoveAsync(request.MessageId, currentUserId, request.Emoji, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
 
+        var user = await _userRepository.GetByIdAsync(currentUserId, cancellationToken);
+        var username = user?.Username?.Value ?? string.Empty;
+        var displayName = user?.DisplayName;
+
         await NotifyReactionRemovedSafelyAsync(
-            new ChannelReactionRemovedNotification(request.MessageId, request.ChannelId, ctx.Channel.GuildId, currentUserId, request.Emoji));
+            new ChannelReactionRemovedNotification(request.MessageId, request.ChannelId, ctx.Channel.GuildId, currentUserId, username, displayName, request.Emoji));
 
         return ApplicationResponse<bool>.Ok(true);
     }

--- a/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionHandler.cs
@@ -2,7 +2,6 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Application.Interfaces.Users;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Messages;
@@ -20,7 +19,6 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ChannelRemoveR
     private readonly IGuildChannelRepository _guildChannelRepository;
     private readonly IMessageRepository _messageRepository;
     private readonly IMessageReactionRepository _reactionRepository;
-    private readonly IUserRepository _userRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IReactionNotifier _reactionNotifier;
     private readonly ILogger<RemoveReactionHandler> _logger;
@@ -29,7 +27,6 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ChannelRemoveR
         IGuildChannelRepository guildChannelRepository,
         IMessageRepository messageRepository,
         IMessageReactionRepository reactionRepository,
-        IUserRepository userRepository,
         IUnitOfWork unitOfWork,
         IReactionNotifier reactionNotifier,
         ILogger<RemoveReactionHandler> logger)
@@ -37,7 +34,6 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ChannelRemoveR
         _guildChannelRepository = guildChannelRepository;
         _messageRepository = messageRepository;
         _reactionRepository = reactionRepository;
-        _userRepository = userRepository;
         _unitOfWork = unitOfWork;
         _reactionNotifier = reactionNotifier;
         _logger = logger;
@@ -83,12 +79,15 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ChannelRemoveR
         await _reactionRepository.RemoveAsync(request.MessageId, currentUserId, request.Emoji, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
 
-        var user = await _userRepository.GetByIdAsync(currentUserId, cancellationToken);
-        var username = user?.Username?.Value ?? string.Empty;
-        var displayName = user?.DisplayName;
-
         await NotifyReactionRemovedSafelyAsync(
-            new ChannelReactionRemovedNotification(request.MessageId, request.ChannelId, ctx.Channel.GuildId, currentUserId, username, displayName, request.Emoji));
+            new ChannelReactionRemovedNotification(
+                request.MessageId,
+                request.ChannelId,
+                ctx.Channel.GuildId,
+                currentUserId,
+                ctx.CallerUsername ?? string.Empty,
+                ctx.CallerDisplayName,
+                request.Emoji));
 
         return ApplicationResponse<bool>.Ok(true);
     }

--- a/src/Harmonie.Application/Features/Conversations/AddReaction/AddReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/AddReaction/AddReactionHandler.cs
@@ -2,7 +2,6 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Application.Interfaces.Users;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
@@ -20,7 +19,6 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ConversationAddRe
     private readonly IConversationRepository _conversationRepository;
     private readonly IMessageRepository _messageRepository;
     private readonly IMessageReactionRepository _reactionRepository;
-    private readonly IUserRepository _userRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IReactionNotifier _reactionNotifier;
     private readonly ILogger<AddReactionHandler> _logger;
@@ -29,7 +27,6 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ConversationAddRe
         IConversationRepository conversationRepository,
         IMessageRepository messageRepository,
         IMessageReactionRepository reactionRepository,
-        IUserRepository userRepository,
         IUnitOfWork unitOfWork,
         IReactionNotifier reactionNotifier,
         ILogger<AddReactionHandler> logger)
@@ -37,7 +34,6 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ConversationAddRe
         _conversationRepository = conversationRepository;
         _messageRepository = messageRepository;
         _reactionRepository = reactionRepository;
-        _userRepository = userRepository;
         _unitOfWork = unitOfWork;
         _reactionNotifier = reactionNotifier;
         _logger = logger;
@@ -83,12 +79,14 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ConversationAddRe
         await _reactionRepository.AddAsync(reaction.Value, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
 
-        var user = await _userRepository.GetByIdAsync(currentUserId, cancellationToken);
-        var username = user?.Username?.Value ?? string.Empty;
-        var displayName = user?.DisplayName;
-
         await NotifyReactionAddedSafelyAsync(
-            new ConversationReactionAddedNotification(request.MessageId, request.ConversationId, currentUserId, username, displayName, request.Emoji));
+            new ConversationReactionAddedNotification(
+                request.MessageId,
+                request.ConversationId,
+                currentUserId,
+                access.CallerUsername ?? string.Empty,
+                access.CallerDisplayName,
+                request.Emoji));
 
         return ApplicationResponse<bool>.Ok(true);
     }

--- a/src/Harmonie.Application/Features/Conversations/AddReaction/AddReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/AddReaction/AddReactionHandler.cs
@@ -2,6 +2,7 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
@@ -19,6 +20,7 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ConversationAddRe
     private readonly IConversationRepository _conversationRepository;
     private readonly IMessageRepository _messageRepository;
     private readonly IMessageReactionRepository _reactionRepository;
+    private readonly IUserRepository _userRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IReactionNotifier _reactionNotifier;
     private readonly ILogger<AddReactionHandler> _logger;
@@ -27,6 +29,7 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ConversationAddRe
         IConversationRepository conversationRepository,
         IMessageRepository messageRepository,
         IMessageReactionRepository reactionRepository,
+        IUserRepository userRepository,
         IUnitOfWork unitOfWork,
         IReactionNotifier reactionNotifier,
         ILogger<AddReactionHandler> logger)
@@ -34,6 +37,7 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ConversationAddRe
         _conversationRepository = conversationRepository;
         _messageRepository = messageRepository;
         _reactionRepository = reactionRepository;
+        _userRepository = userRepository;
         _unitOfWork = unitOfWork;
         _reactionNotifier = reactionNotifier;
         _logger = logger;
@@ -79,8 +83,12 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ConversationAddRe
         await _reactionRepository.AddAsync(reaction.Value, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
 
+        var user = await _userRepository.GetByIdAsync(currentUserId, cancellationToken);
+        var username = user?.Username?.Value ?? string.Empty;
+        var displayName = user?.DisplayName;
+
         await NotifyReactionAddedSafelyAsync(
-            new ConversationReactionAddedNotification(request.MessageId, request.ConversationId, currentUserId, request.Emoji));
+            new ConversationReactionAddedNotification(request.MessageId, request.ConversationId, currentUserId, username, displayName, request.Emoji));
 
         return ApplicationResponse<bool>.Ok(true);
     }

--- a/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesHandler.cs
@@ -80,7 +80,8 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetConversationMe
                     AuthorUserId: x.AuthorUserId.Value,
                     Content: x.Content?.Value,
                     Attachments: x.Attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
-                    Reactions: reactions?.Select(r => new MessageReactionDto(r.Emoji, r.Count, r.ReactedByCaller)).ToArray()
+                    Reactions: reactions?.Select(r => new MessageReactionDto(r.Emoji, r.Count, r.ReactedByCaller,
+                        r.Users.Select(u => new ReactionUserDto(u.UserId, u.Username, u.DisplayName)).ToArray())).ToArray()
                               ?? Array.Empty<MessageReactionDto>(),
                     CreatedAtUtc: x.CreatedAtUtc,
                     UpdatedAtUtc: x.UpdatedAtUtc);

--- a/src/Harmonie.Application/Features/Conversations/GetReactionUsers/GetReactionUsersEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetReactionUsers/GetReactionUsersEndpoint.cs
@@ -1,0 +1,58 @@
+using FluentValidation;
+using Harmonie.Application.Common;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Messages;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Harmonie.Application.Features.Conversations.GetReactionUsers;
+
+public static class GetReactionUsersEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/conversations/{conversationId}/messages/{messageId}/reactions/{emoji}/users", HandleAsync)
+            .WithName("GetConversationMessageReactionUsers")
+            .WithTags("Conversations")
+            .RequireAuthorization()
+            .WithSummary("Get users who reacted with a specific emoji on a conversation message")
+            .WithDescription("Returns a paginated list of users who reacted with the given emoji on the specified message.")
+            .Produces<GetReactionUsersResponse>()
+            .ProducesErrors(
+                ApplicationErrorCodes.Common.ValidationFailed,
+                ApplicationErrorCodes.Auth.InvalidCredentials,
+                ApplicationErrorCodes.Conversation.NotFound,
+                ApplicationErrorCodes.Conversation.AccessDenied,
+                ApplicationErrorCodes.Reaction.MessageNotFound);
+    }
+
+    private static async Task<IResult> HandleAsync(
+        ConversationId conversationId,
+        MessageId messageId,
+        [AsParameters] GetReactionUsersRouteRequest routeRequest,
+        [FromServices] IAuthenticatedHandler<GetConversationReactionUsersInput, GetReactionUsersResponse> handler,
+        [FromServices] IValidator<GetReactionUsersRouteRequest> routeValidator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var routeValidationError = await routeRequest.ValidateAsync(routeValidator, cancellationToken);
+        if (routeValidationError is not null)
+            return ApplicationResponse<GetReactionUsersResponse>.Fail(routeValidationError).ToHttpResult(httpContext);
+
+        if (routeRequest.Emoji is not string emoji)
+            return ApplicationResponse<GetReactionUsersResponse>.Fail(
+                ApplicationErrorCodes.Common.InvalidState,
+                "Route validation succeeded but emoji was null.").ToHttpResult(httpContext);
+
+        var callerId = httpContext.GetRequiredAuthenticatedUserId();
+
+        var response = await handler.HandleAsync(
+            new GetConversationReactionUsersInput(conversationId, messageId, emoji, routeRequest.Cursor, routeRequest.Limit),
+            callerId,
+            cancellationToken);
+
+        return response.ToHttpResult(httpContext);
+    }
+}

--- a/src/Harmonie.Application/Features/Conversations/GetReactionUsers/GetReactionUsersHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetReactionUsers/GetReactionUsersHandler.cs
@@ -1,0 +1,104 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Features.Conversations.GetReactionUsers;
+
+public sealed record GetConversationReactionUsersInput(
+    ConversationId ConversationId,
+    MessageId MessageId,
+    string Emoji,
+    string? Cursor = null,
+    int? Limit = null);
+
+public sealed class GetReactionUsersHandler : IAuthenticatedHandler<GetConversationReactionUsersInput, GetReactionUsersResponse>
+{
+    private const int DefaultLimit = 50;
+    private const int MaxLimit = 100;
+
+    private readonly IConversationRepository _conversationRepository;
+    private readonly IMessageRepository _messageRepository;
+    private readonly IMessageReactionRepository _reactionRepository;
+
+    public GetReactionUsersHandler(
+        IConversationRepository conversationRepository,
+        IMessageRepository messageRepository,
+        IMessageReactionRepository reactionRepository)
+    {
+        _conversationRepository = conversationRepository;
+        _messageRepository = messageRepository;
+        _reactionRepository = reactionRepository;
+    }
+
+    public async Task<ApplicationResponse<GetReactionUsersResponse>> HandleAsync(
+        GetConversationReactionUsersInput request,
+        UserId currentUserId,
+        CancellationToken cancellationToken = default)
+    {
+        ReactionUsersCursor? cursor = null;
+        if (request.Cursor is not null)
+        {
+            if (!ReactionUsersCursorCodec.TryParse(request.Cursor, out var parsedCursor) || parsedCursor is null)
+            {
+                return ApplicationResponse<GetReactionUsersResponse>.Fail(
+                    ApplicationErrorCodes.Common.ValidationFailed,
+                    "Request validation failed",
+                    EndpointExtensions.SingleValidationError(
+                        nameof(request.Cursor),
+                        ApplicationErrorCodes.Validation.InvalidFormat,
+                        "Cursor is invalid"));
+            }
+
+            cursor = parsedCursor;
+        }
+
+        var limit = Math.Clamp(request.Limit ?? DefaultLimit, 1, MaxLimit);
+
+        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(request.ConversationId, currentUserId, cancellationToken);
+        if (access is null)
+        {
+            return ApplicationResponse<GetReactionUsersResponse>.Fail(
+                ApplicationErrorCodes.Conversation.NotFound,
+                "Conversation was not found");
+        }
+        if (access.Participant is null)
+        {
+            return ApplicationResponse<GetReactionUsersResponse>.Fail(
+                ApplicationErrorCodes.Conversation.AccessDenied,
+                "You do not have access to this conversation");
+        }
+
+        var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
+        var messageConversationId = message?.ConversationId;
+        if (message is null || messageConversationId is null || messageConversationId != request.ConversationId)
+        {
+            return ApplicationResponse<GetReactionUsersResponse>.Fail(
+                ApplicationErrorCodes.Reaction.MessageNotFound,
+                "Message was not found");
+        }
+
+        var page = await _reactionRepository.GetReactionUsersAsync(
+            request.MessageId,
+            request.Emoji,
+            limit,
+            cursor,
+            cancellationToken);
+
+        var users = page.Users
+            .Select(u => new ReactionUserDto(u.UserId, u.Username, u.DisplayName))
+            .ToArray();
+
+        var payload = new GetReactionUsersResponse(
+            MessageId: request.MessageId.Value,
+            Emoji: request.Emoji,
+            TotalCount: page.TotalCount,
+            Users: users,
+            NextCursor: page.NextCursor is null ? null : ReactionUsersCursorCodec.Encode(page.NextCursor));
+
+        return ApplicationResponse<GetReactionUsersResponse>.Ok(payload);
+    }
+}

--- a/src/Harmonie.Application/Features/Conversations/GetReactionUsers/GetReactionUsersResponse.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetReactionUsers/GetReactionUsersResponse.cs
@@ -1,0 +1,10 @@
+using Harmonie.Application.Common.Messages;
+
+namespace Harmonie.Application.Features.Conversations.GetReactionUsers;
+
+public sealed record GetReactionUsersResponse(
+    Guid MessageId,
+    string Emoji,
+    int TotalCount,
+    IReadOnlyList<ReactionUserDto> Users,
+    string? NextCursor);

--- a/src/Harmonie.Application/Features/Conversations/GetReactionUsers/GetReactionUsersRouteRequest.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetReactionUsers/GetReactionUsersRouteRequest.cs
@@ -1,0 +1,8 @@
+namespace Harmonie.Application.Features.Conversations.GetReactionUsers;
+
+public sealed class GetReactionUsersRouteRequest
+{
+    public string? Emoji { get; init; }
+    public string? Cursor { get; init; }
+    public int? Limit { get; init; }
+}

--- a/src/Harmonie.Application/Features/Conversations/GetReactionUsers/GetReactionUsersRouteValidator.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetReactionUsers/GetReactionUsersRouteValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace Harmonie.Application.Features.Conversations.GetReactionUsers;
+
+public sealed class GetReactionUsersRouteValidator : AbstractValidator<GetReactionUsersRouteRequest>
+{
+    public GetReactionUsersRouteValidator()
+    {
+        RuleFor(x => x.Emoji)
+            .NotEmpty()
+            .MaximumLength(64);
+    }
+}

--- a/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionHandler.cs
@@ -2,6 +2,7 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -18,6 +19,7 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ConversationRe
     private readonly IConversationRepository _conversationRepository;
     private readonly IMessageRepository _messageRepository;
     private readonly IMessageReactionRepository _reactionRepository;
+    private readonly IUserRepository _userRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IReactionNotifier _reactionNotifier;
     private readonly ILogger<RemoveReactionHandler> _logger;
@@ -26,6 +28,7 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ConversationRe
         IConversationRepository conversationRepository,
         IMessageRepository messageRepository,
         IMessageReactionRepository reactionRepository,
+        IUserRepository userRepository,
         IUnitOfWork unitOfWork,
         IReactionNotifier reactionNotifier,
         ILogger<RemoveReactionHandler> logger)
@@ -33,6 +36,7 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ConversationRe
         _conversationRepository = conversationRepository;
         _messageRepository = messageRepository;
         _reactionRepository = reactionRepository;
+        _userRepository = userRepository;
         _unitOfWork = unitOfWork;
         _reactionNotifier = reactionNotifier;
         _logger = logger;
@@ -70,8 +74,12 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ConversationRe
         await _reactionRepository.RemoveAsync(request.MessageId, currentUserId, request.Emoji, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
 
+        var user = await _userRepository.GetByIdAsync(currentUserId, cancellationToken);
+        var username = user?.Username?.Value ?? string.Empty;
+        var displayName = user?.DisplayName;
+
         await NotifyReactionRemovedSafelyAsync(
-            new ConversationReactionRemovedNotification(request.MessageId, request.ConversationId, currentUserId, request.Emoji));
+            new ConversationReactionRemovedNotification(request.MessageId, request.ConversationId, currentUserId, username, displayName, request.Emoji));
 
         return ApplicationResponse<bool>.Ok(true);
     }

--- a/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionHandler.cs
@@ -2,7 +2,6 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Application.Interfaces.Users;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -19,7 +18,6 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ConversationRe
     private readonly IConversationRepository _conversationRepository;
     private readonly IMessageRepository _messageRepository;
     private readonly IMessageReactionRepository _reactionRepository;
-    private readonly IUserRepository _userRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IReactionNotifier _reactionNotifier;
     private readonly ILogger<RemoveReactionHandler> _logger;
@@ -28,7 +26,6 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ConversationRe
         IConversationRepository conversationRepository,
         IMessageRepository messageRepository,
         IMessageReactionRepository reactionRepository,
-        IUserRepository userRepository,
         IUnitOfWork unitOfWork,
         IReactionNotifier reactionNotifier,
         ILogger<RemoveReactionHandler> logger)
@@ -36,7 +33,6 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ConversationRe
         _conversationRepository = conversationRepository;
         _messageRepository = messageRepository;
         _reactionRepository = reactionRepository;
-        _userRepository = userRepository;
         _unitOfWork = unitOfWork;
         _reactionNotifier = reactionNotifier;
         _logger = logger;
@@ -74,12 +70,14 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ConversationRe
         await _reactionRepository.RemoveAsync(request.MessageId, currentUserId, request.Emoji, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
 
-        var user = await _userRepository.GetByIdAsync(currentUserId, cancellationToken);
-        var username = user?.Username?.Value ?? string.Empty;
-        var displayName = user?.DisplayName;
-
         await NotifyReactionRemovedSafelyAsync(
-            new ConversationReactionRemovedNotification(request.MessageId, request.ConversationId, currentUserId, username, displayName, request.Emoji));
+            new ConversationReactionRemovedNotification(
+                request.MessageId,
+                request.ConversationId,
+                currentUserId,
+                access.CallerUsername ?? string.Empty,
+                access.CallerDisplayName,
+                request.Emoji));
 
         return ApplicationResponse<bool>.Ok(true);
     }

--- a/src/Harmonie.Application/Interfaces/Channels/IGuildChannelRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Channels/IGuildChannelRepository.cs
@@ -9,7 +9,9 @@ namespace Harmonie.Application.Interfaces.Channels;
 
 public sealed record ChannelAccessContext(
     GuildChannel Channel,
-    GuildRole? CallerRole);
+    GuildRole? CallerRole,
+    string? CallerUsername = null,
+    string? CallerDisplayName = null);
 
 public sealed record ChannelParticipantProfile(
     Username Username,

--- a/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
@@ -15,7 +15,11 @@ public sealed record ConversationParticipantSummary(
 
 public sealed record ConversationGetOrCreateResult(Conversation Conversation, bool WasCreated);
 
-public sealed record ConversationAccess(Conversation Conversation, ConversationParticipant? Participant);
+public sealed record ConversationAccess(
+    Conversation Conversation,
+    ConversationParticipant? Participant,
+    string? CallerUsername = null,
+    string? CallerDisplayName = null);
 
 public sealed record UserConversationSummary(
     ConversationId ConversationId,

--- a/src/Harmonie.Application/Interfaces/Messages/IMessageReactionRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Messages/IMessageReactionRepository.cs
@@ -21,9 +21,31 @@ public interface IMessageReactionRepository
         UserId userId,
         string emoji,
         CancellationToken cancellationToken = default);
+
+    Task<ReactionUsersPage> GetReactionUsersAsync(
+        MessageId messageId,
+        string emoji,
+        int limit,
+        ReactionUsersCursor? cursor,
+        CancellationToken cancellationToken = default);
 }
+
+public sealed record ReactionUser(
+    Guid UserId,
+    string Username,
+    string? DisplayName);
+
+public sealed record ReactionUsersCursor(
+    DateTime CreatedAtUtc,
+    Guid UserId);
+
+public sealed record ReactionUsersPage(
+    IReadOnlyList<ReactionUser> Users,
+    int TotalCount,
+    ReactionUsersCursor? NextCursor);
 
 public sealed record MessageReactionSummary(
     string Emoji,
     int Count,
-    bool ReactedByCaller);
+    bool ReactedByCaller,
+    IReadOnlyList<ReactionUser> Users);

--- a/src/Harmonie.Application/Interfaces/Messages/IReactionNotifier.cs
+++ b/src/Harmonie.Application/Interfaces/Messages/IReactionNotifier.cs
@@ -30,12 +30,16 @@ public sealed record ChannelReactionAddedNotification(
     GuildChannelId ChannelId,
     GuildId GuildId,
     UserId UserId,
+    string Username,
+    string? DisplayName,
     string Emoji);
 
 public sealed record ConversationReactionAddedNotification(
     MessageId MessageId,
     ConversationId ConversationId,
     UserId UserId,
+    string Username,
+    string? DisplayName,
     string Emoji);
 
 public sealed record ChannelReactionRemovedNotification(
@@ -43,10 +47,14 @@ public sealed record ChannelReactionRemovedNotification(
     GuildChannelId ChannelId,
     GuildId GuildId,
     UserId UserId,
+    string Username,
+    string? DisplayName,
     string Emoji);
 
 public sealed record ConversationReactionRemovedNotification(
     MessageId MessageId,
     ConversationId ConversationId,
     UserId UserId,
+    string Username,
+    string? DisplayName,
     string Emoji);

--- a/src/Harmonie.Application/Registration/ChannelRegistration.cs
+++ b/src/Harmonie.Application/Registration/ChannelRegistration.cs
@@ -7,6 +7,7 @@ using Harmonie.Application.Features.Channels.DeleteMessageAttachment;
 using Harmonie.Application.Features.Channels.EditMessage;
 using Harmonie.Application.Features.Channels.GetMessages;
 using Harmonie.Application.Features.Channels.JoinVoiceChannel;
+using Harmonie.Application.Features.Channels.GetReactionUsers;
 using Harmonie.Application.Features.Channels.RemoveReaction;
 using Harmonie.Application.Features.Channels.SendMessage;
 using Harmonie.Application.Features.Channels.UpdateChannel;
@@ -34,6 +35,7 @@ public static class ChannelRegistration
         // Reactions
         services.AddAuthenticatedHandler<ChannelAddReactionInput, bool, AddReactionHandler>();
         services.AddAuthenticatedHandler<ChannelRemoveReactionInput, bool, RemoveReactionHandler>();
+        services.AddAuthenticatedHandler<GetChannelReactionUsersInput, GetReactionUsersResponse, GetReactionUsersHandler>();
 
         return services;
     }

--- a/src/Harmonie.Application/Registration/ConversationRegistration.cs
+++ b/src/Harmonie.Application/Registration/ConversationRegistration.cs
@@ -9,6 +9,7 @@ using Harmonie.Application.Features.Conversations.EditMessage;
 using Harmonie.Application.Features.Conversations.GetMessages;
 using Harmonie.Application.Features.Conversations.ListConversations;
 using Harmonie.Application.Features.Conversations.OpenConversation;
+using Harmonie.Application.Features.Conversations.GetReactionUsers;
 using Harmonie.Application.Features.Conversations.RemoveReaction;
 using Harmonie.Application.Features.Conversations.SearchConversationMessages;
 using Harmonie.Application.Features.Conversations.SendMessage;
@@ -39,6 +40,7 @@ public static class ConversationRegistration
         // Reactions
         services.AddAuthenticatedHandler<ConversationAddReactionInput, bool, AddReactionHandler>();
         services.AddAuthenticatedHandler<ConversationRemoveReactionInput, bool, RemoveReactionHandler>();
+        services.AddAuthenticatedHandler<GetConversationReactionUsersInput, GetReactionUsersResponse, GetReactionUsersHandler>();
 
         return services;
     }

--- a/src/Harmonie.Infrastructure/Persistence/Channels/GuildChannelRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Channels/GuildChannelRepository.cs
@@ -263,11 +263,16 @@ public sealed class GuildChannelRepository : IGuildChannelRepository
                                   gc.is_default     AS "IsDefault",
                                   gc.position       AS "Position",
                                   gc.created_at_utc AS "CreatedAtUtc",
-                                  gm.role           AS "Role"
+                                  gm.role           AS "Role",
+                                  u.username        AS "Username",
+                                  u.display_name    AS "DisplayName"
                            FROM guild_channels gc
                            LEFT JOIN guild_members gm
                                   ON gm.guild_id = gc.guild_id
                                  AND gm.user_id = @CallerId
+                           LEFT JOIN users u
+                                  ON u.id = @CallerId
+                                 AND u.deleted_at IS NULL
                            WHERE gc.id = @ChannelId
                            LIMIT 1
                            """;
@@ -284,7 +289,9 @@ public sealed class GuildChannelRepository : IGuildChannelRepository
             ? null
             : new ChannelAccessContext(
                 MapToGuildChannel(row),
-                row.Role.HasValue ? (GuildRole)row.Role.Value : null);
+                row.Role.HasValue ? (GuildRole)row.Role.Value : null,
+                row.Username,
+                row.DisplayName);
     }
 
     private static GuildChannel MapToGuildChannel(GuildChannelRow row)
@@ -342,6 +349,8 @@ public sealed class GuildChannelRepository : IGuildChannelRepository
         public int Position { get; init; }
         public DateTime CreatedAtUtc { get; init; }
         public short? Role { get; init; }
+        public string? Username { get; init; }
+        public string? DisplayName { get; init; }
     }
 
     private sealed class ChannelWithParticipantDto

--- a/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
@@ -237,10 +237,15 @@ public sealed class ConversationRepository : IConversationRepository
                                   c.created_at_utc  AS "CreatedAtUtc",
                                   cp.user_id        AS "ParticipantUserId",
                                   cp.joined_at_utc  AS "JoinedAtUtc",
-                                  cp.hidden_at_utc  AS "HiddenAtUtc"
+                                  cp.hidden_at_utc  AS "HiddenAtUtc",
+                                  u.username        AS "Username",
+                                  u.display_name    AS "DisplayName"
                            FROM conversations c
                            LEFT JOIN conversation_participants cp
                              ON cp.conversation_id = c.id AND cp.user_id = @UserId
+                           LEFT JOIN users u
+                             ON u.id = @UserId
+                            AND u.deleted_at IS NULL
                            WHERE c.id = @ConversationId
                            """;
 
@@ -264,7 +269,7 @@ public sealed class ConversationRepository : IConversationRepository
                 row.HiddenAtUtc)
             : null;
 
-        return new ConversationAccess(conversation, participant);
+        return new ConversationAccess(conversation, participant, row.Username, row.DisplayName);
     }
 
     public async Task DeleteAsync(
@@ -349,6 +354,10 @@ public sealed class ConversationRepository : IConversationRepository
         public DateTime? JoinedAtUtc { get; init; }
 
         public DateTime? HiddenAtUtc { get; init; }
+
+        public string? Username { get; init; }
+
+        public string? DisplayName { get; init; }
     }
 
 }

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessagePaginationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessagePaginationRepository.cs
@@ -85,6 +85,27 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
                    GROUP BY message_id, emoji
                    ORDER BY message_id, MIN(created_at_utc);
 
+                   SELECT sub.message_id AS "MessageId",
+                          sub.emoji AS "Emoji",
+                          sub.user_id AS "UserId",
+                          u.username AS "Username",
+                          u.display_name AS "DisplayName"
+                   FROM (
+                       SELECT mr.message_id, mr.emoji, mr.user_id, mr.created_at_utc,
+                              ROW_NUMBER() OVER (PARTITION BY mr.message_id, mr.emoji ORDER BY mr.created_at_utc) AS rn
+                       FROM message_reactions mr
+                       WHERE mr.message_id IN (
+                           SELECT id FROM messages
+                           WHERE channel_id = @ChannelId
+                             AND deleted_at_utc IS NULL
+                             {cursorFilter}
+                           ORDER BY created_at_utc DESC, id DESC
+                           LIMIT @Take)
+                   ) sub
+                   JOIN users u ON u.id = sub.user_id
+                   WHERE sub.rn <= 5
+                   ORDER BY sub.message_id, sub.emoji, sub.created_at_utc;
+
                    SELECT last_read_message_id AS "LastReadMessageId",
                           read_at_utc          AS "ReadAtUtc"
                    FROM channel_read_states
@@ -112,6 +133,7 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
         var rows = (await multi.ReadAsync<MessageRow>()).ToArray();
         var attachmentRows = (await multi.ReadAsync<MessageAttachmentRow>()).ToArray();
         var reactionRows = (await multi.ReadAsync<ReactionSummaryRow>()).ToArray();
+        var reactionUserRows = (await multi.ReadAsync<ReactionUserRow>()).ToArray();
         var readStateRow = await multi.ReadFirstOrDefaultAsync<ReadStateRow?>();
 
         var hasMore = rows.Length > limit;
@@ -121,7 +143,8 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
         var attachmentsByMessageId = MessageRepositoryHelpers.BuildAttachmentsDictionary(
             attachmentRows.Where(r => pageMessageIds.Contains(r.MessageId)));
         var reactionsByMessageId = MessageRepositoryHelpers.BuildReactionsDictionary(
-            reactionRows.Where(r => pageMessageIds.Contains(r.MessageId)));
+            reactionRows.Where(r => pageMessageIds.Contains(r.MessageId)),
+            reactionUserRows.Where(r => pageMessageIds.Contains(r.MessageId)));
 
         var items = pageRows
             .Select(row => MessageRepositoryHelpers.MapToMessage(row, attachmentsByMessageId))
@@ -215,6 +238,27 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
                    GROUP BY message_id, emoji
                    ORDER BY message_id, MIN(created_at_utc);
 
+                   SELECT sub.message_id AS "MessageId",
+                          sub.emoji AS "Emoji",
+                          sub.user_id AS "UserId",
+                          u.username AS "Username",
+                          u.display_name AS "DisplayName"
+                   FROM (
+                       SELECT mr.message_id, mr.emoji, mr.user_id, mr.created_at_utc,
+                              ROW_NUMBER() OVER (PARTITION BY mr.message_id, mr.emoji ORDER BY mr.created_at_utc) AS rn
+                       FROM message_reactions mr
+                       WHERE mr.message_id IN (
+                           SELECT id FROM messages
+                           WHERE conversation_id = @ConversationId
+                             AND deleted_at_utc IS NULL
+                             {cursorFilter}
+                           ORDER BY created_at_utc DESC, id DESC
+                           LIMIT @Take)
+                   ) sub
+                   JOIN users u ON u.id = sub.user_id
+                   WHERE sub.rn <= 5
+                   ORDER BY sub.message_id, sub.emoji, sub.created_at_utc;
+
                    SELECT last_read_message_id AS "LastReadMessageId",
                           read_at_utc          AS "ReadAtUtc"
                    FROM conversation_read_states
@@ -242,6 +286,7 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
         var rows = (await multi.ReadAsync<MessageRow>()).ToArray();
         var attachmentRows = (await multi.ReadAsync<MessageAttachmentRow>()).ToArray();
         var reactionRows = (await multi.ReadAsync<ReactionSummaryRow>()).ToArray();
+        var reactionUserRows = (await multi.ReadAsync<ReactionUserRow>()).ToArray();
         var readStateRow = await multi.ReadFirstOrDefaultAsync<ReadStateRow?>();
 
         var hasMore = rows.Length > limit;
@@ -251,7 +296,8 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
         var attachmentsByMessageId = MessageRepositoryHelpers.BuildAttachmentsDictionary(
             attachmentRows.Where(r => pageMessageIds.Contains(r.MessageId)));
         var reactionsByMessageId = MessageRepositoryHelpers.BuildReactionsDictionary(
-            reactionRows.Where(r => pageMessageIds.Contains(r.MessageId)));
+            reactionRows.Where(r => pageMessageIds.Contains(r.MessageId)),
+            reactionUserRows.Where(r => pageMessageIds.Contains(r.MessageId)));
 
         var items = pageRows
             .Select(row => MessageRepositoryHelpers.MapToMessage(row, attachmentsByMessageId))

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessageReactionRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessageReactionRepository.cs
@@ -4,6 +4,7 @@ using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
 using Harmonie.Infrastructure.Persistence.Common;
+using Harmonie.Infrastructure.Rows.Messages;
 
 namespace Harmonie.Infrastructure.Persistence.Messages;
 
@@ -99,5 +100,78 @@ public sealed class MessageReactionRepository : IMessageReactionRepository
             cancellationToken: cancellationToken);
 
         await connection.ExecuteAsync(command);
+    }
+
+    public async Task<ReactionUsersPage> GetReactionUsersAsync(
+        MessageId messageId,
+        string emoji,
+        int limit,
+        ReactionUsersCursor? cursor,
+        CancellationToken cancellationToken = default)
+    {
+        if (limit <= 0)
+            throw new ArgumentOutOfRangeException(nameof(limit), "Limit must be positive.");
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var take = limit + 1;
+
+        var cursorFilter = cursor is not null
+            ? "AND (mr.created_at_utc, mr.user_id) > (@CursorCreatedAtUtc, @CursorUserId)"
+            : "";
+
+        var sql = $@"""
+                   SELECT mr.user_id AS ""UserId"",
+                          u.username AS ""Username"",
+                          u.display_name AS ""DisplayName"",
+                          mr.created_at_utc AS ""CreatedAtUtc""
+                   FROM message_reactions mr
+                   JOIN users u ON u.id = mr.user_id
+                   WHERE mr.message_id = @MessageId
+                     AND mr.emoji = @Emoji
+                     {cursorFilter}
+                   ORDER BY mr.created_at_utc, mr.user_id
+                   LIMIT @Take;
+
+                   SELECT COUNT(*)
+                   FROM message_reactions
+                   WHERE message_id = @MessageId
+                     AND emoji = @Emoji;
+                   """;
+
+        var parameters = new DynamicParameters();
+        parameters.Add("MessageId", messageId.Value);
+        parameters.Add("Emoji", emoji);
+        parameters.Add("Take", take);
+        if (cursor is not null)
+        {
+            parameters.Add("CursorCreatedAtUtc", cursor.CreatedAtUtc);
+            parameters.Add("CursorUserId", cursor.UserId);
+        }
+
+        var command = new CommandDefinition(
+            sql,
+            parameters,
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        using var multi = await connection.QueryMultipleAsync(command);
+        var rows = (await multi.ReadAsync<ReactionUserDetailRow>()).ToArray();
+        var totalCount = await multi.ReadSingleAsync<int>();
+
+        var hasMore = rows.Length > limit;
+        var pageRows = hasMore ? rows.Take(limit).ToArray() : rows;
+
+        ReactionUsersCursor? nextCursor = null;
+        if (hasMore && pageRows.Length > 0)
+        {
+            var lastPageRow = pageRows[pageRows.Length - 1];
+            nextCursor = new ReactionUsersCursor(lastPageRow.CreatedAtUtc, lastPageRow.UserId);
+        }
+
+        var users = pageRows
+            .Select(row => new ReactionUser(row.UserId, row.Username, row.DisplayName))
+            .ToArray();
+
+        return new ReactionUsersPage(users, totalCount, nextCursor);
     }
 }

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessageReactionRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessageReactionRepository.cs
@@ -115,11 +115,11 @@ public sealed class MessageReactionRepository : IMessageReactionRepository
         var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
         var take = limit + 1;
 
-        var cursorFilter = cursor is not null
+        var cursorCondition = cursor is not null
             ? "AND (mr.created_at_utc, mr.user_id) > (@CursorCreatedAtUtc, @CursorUserId)"
-            : "";
+            : "1=1";
 
-        var sql = $@"""
+        var sql = $@"
                    SELECT mr.user_id AS ""UserId"",
                           u.username AS ""Username"",
                           u.display_name AS ""DisplayName"",
@@ -128,7 +128,7 @@ public sealed class MessageReactionRepository : IMessageReactionRepository
                    JOIN users u ON u.id = mr.user_id
                    WHERE mr.message_id = @MessageId
                      AND mr.emoji = @Emoji
-                     {cursorFilter}
+                     AND {cursorCondition}
                    ORDER BY mr.created_at_utc, mr.user_id
                    LIMIT @Take;
 
@@ -136,7 +136,7 @@ public sealed class MessageReactionRepository : IMessageReactionRepository
                    FROM message_reactions
                    WHERE message_id = @MessageId
                      AND emoji = @Emoji;
-                   """;
+                   ";
 
         var parameters = new DynamicParameters();
         parameters.Add("MessageId", messageId.Value);
@@ -156,7 +156,7 @@ public sealed class MessageReactionRepository : IMessageReactionRepository
 
         using var multi = await connection.QueryMultipleAsync(command);
         var rows = (await multi.ReadAsync<ReactionUserDetailRow>()).ToArray();
-        var totalCount = await multi.ReadSingleAsync<int>();
+        var totalCount = (await multi.ReadAsync<int>()).Single();
 
         var hasMore = rows.Length > limit;
         var pageRows = hasMore ? rows.Take(limit).ToArray() : rows;

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepositoryHelpers.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepositoryHelpers.cs
@@ -75,17 +75,34 @@ internal static class MessageRepositoryHelpers
     }
 
     internal static IReadOnlyDictionary<Guid, IReadOnlyList<MessageReactionSummary>> BuildReactionsDictionary(
-        IEnumerable<ReactionSummaryRow> rows)
+        IEnumerable<ReactionSummaryRow> summaryRows,
+        IEnumerable<ReactionUserRow> userRows)
     {
-        return rows
+        var usersByKey = userRows
+            .GroupBy(row => (row.MessageId, row.Emoji))
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyList<ReactionUser>)group
+                    .Select(row => new ReactionUser(
+                        row.UserId,
+                        row.Username,
+                        row.DisplayName))
+                    .ToArray());
+
+        return summaryRows
             .GroupBy(row => row.MessageId)
             .ToDictionary(
                 group => group.Key,
                 group => (IReadOnlyList<MessageReactionSummary>)group
-                    .Select(row => new MessageReactionSummary(
-                        row.Emoji,
-                        row.Count,
-                        row.ReactedByCaller))
+                    .Select(row =>
+                    {
+                        usersByKey.TryGetValue((row.MessageId, row.Emoji), out var users);
+                        return new MessageReactionSummary(
+                            row.Emoji,
+                            row.Count,
+                            row.ReactedByCaller,
+                            users ?? Array.Empty<ReactionUser>());
+                    })
                     .ToArray());
     }
 

--- a/src/Harmonie.Infrastructure/Rows/Messages/ReactionUserDetailRow.cs
+++ b/src/Harmonie.Infrastructure/Rows/Messages/ReactionUserDetailRow.cs
@@ -1,0 +1,9 @@
+namespace Harmonie.Infrastructure.Rows.Messages;
+
+internal sealed class ReactionUserDetailRow
+{
+    public Guid UserId { get; init; }
+    public string Username { get; init; } = string.Empty;
+    public string? DisplayName { get; init; }
+    public DateTime CreatedAtUtc { get; init; }
+}

--- a/src/Harmonie.Infrastructure/Rows/Messages/ReactionUserRow.cs
+++ b/src/Harmonie.Infrastructure/Rows/Messages/ReactionUserRow.cs
@@ -1,0 +1,10 @@
+namespace Harmonie.Infrastructure.Rows.Messages;
+
+internal sealed class ReactionUserRow
+{
+    public Guid MessageId { get; init; }
+    public string Emoji { get; init; } = string.Empty;
+    public Guid UserId { get; init; }
+    public string Username { get; init; } = string.Empty;
+    public string? DisplayName { get; init; }
+}

--- a/tests/Harmonie.API.IntegrationTests/Channels/GetMessagesReactionsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Channels/GetMessagesReactionsTests.cs
@@ -68,6 +68,8 @@ public sealed class GetMessagesReactionsTests : IClassFixture<HarmonieWebApplica
         reactions[0].Emoji.Should().Be("\U0001f44d");
         reactions[0].Count.Should().Be(1);
         reactions[0].ReactedByMe.Should().BeTrue();
+        reactions[0].Users.Should().HaveCount(1);
+        reactions[0].Users[0].UserId.Should().Be(owner.UserId);
     }
 
     [Fact]
@@ -150,6 +152,8 @@ public sealed class GetMessagesReactionsTests : IClassFixture<HarmonieWebApplica
         reactions[0].Emoji.Should().Be("\u2764");
         reactions[0].Count.Should().Be(1);
         reactions[0].ReactedByMe.Should().BeTrue();
+        reactions[0].Users.Should().HaveCount(1);
+        reactions[0].Users[0].UserId.Should().Be(caller.UserId);
     }
 
     [Fact]

--- a/tests/Harmonie.API.IntegrationTests/Channels/GetReactionUsersEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Channels/GetReactionUsersEndpointTests.cs
@@ -1,0 +1,147 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Harmonie.API.IntegrationTests.Common;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+using ChannelGetReactionUsersResponse = Harmonie.Application.Features.Channels.GetReactionUsers.GetReactionUsersResponse;
+using ConversationGetReactionUsersResponse = Harmonie.Application.Features.Conversations.GetReactionUsers.GetReactionUsersResponse;
+
+namespace Harmonie.API.IntegrationTests;
+
+public sealed class GetReactionUsersEndpointTests : IClassFixture<HarmonieWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public GetReactionUsersEndpointTests(HarmonieWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    // ─── Channel tests ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetChannelReactionUsers_WhenNoReactions_ShouldReturnEmptyUsers()
+    {
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var (_, channelId) = await ChannelTestHelper.CreateGuildAndChannelAsync(_client, owner.AccessToken);
+        var message = await ChannelTestHelper.SendChannelMessageAsync(_client, channelId, "no reactions", owner.AccessToken);
+
+        var response = await _client.SendAuthorizedGetAsync(
+            $"/api/channels/{channelId}/messages/{message.MessageId}/reactions/thumbsup/users",
+            owner.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ChannelGetReactionUsersResponse>(TestContext.Current.CancellationToken);
+        payload.Should().NotBeNull();
+        payload!.Users.Should().BeEmpty();
+        payload.TotalCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetChannelReactionUsers_WithReactions_ShouldReturnPaginatedUsers()
+    {
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var (_, channelId) = await ChannelTestHelper.CreateGuildAndChannelAsync(_client, owner.AccessToken);
+        var message = await ChannelTestHelper.SendChannelMessageAsync(_client, channelId, "react to this", owner.AccessToken);
+
+        await ChannelTestHelper.AddReactionAsync(_client, channelId, message.MessageId, "thumbsup", owner.AccessToken);
+
+        var response = await _client.SendAuthorizedGetAsync(
+            $"/api/channels/{channelId}/messages/{message.MessageId}/reactions/thumbsup/users",
+            owner.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ChannelGetReactionUsersResponse>(TestContext.Current.CancellationToken);
+        payload.Should().NotBeNull();
+        payload!.Users.Should().HaveCount(1);
+        payload.TotalCount.Should().Be(1);
+        payload.Users[0].UserId.Should().Be(owner.UserId);
+    }
+
+    [Fact]
+    public async Task GetChannelReactionUsers_WhenChannelDoesNotExist_ShouldReturnNotFound()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+
+        var response = await _client.SendAuthorizedGetAsync(
+            $"/api/channels/{Guid.NewGuid()}/messages/{Guid.NewGuid()}/reactions/thumbsup/users",
+            caller.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetChannelReactionUsers_WhenCallerIsNotMember_ShouldReturnForbidden()
+    {
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var outsider = await AuthTestHelper.RegisterAsync(_client);
+        var (_, channelId) = await ChannelTestHelper.CreateGuildAndChannelAsync(_client, owner.AccessToken);
+        var message = await ChannelTestHelper.SendChannelMessageAsync(_client, channelId, "can't access", owner.AccessToken);
+
+        var response = await _client.SendAuthorizedGetAsync(
+            $"/api/channels/{channelId}/messages/{message.MessageId}/reactions/thumbsup/users",
+            outsider.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // ─── Conversation tests ─────────────────────────────────────────
+
+    [Fact]
+    public async Task GetConversationReactionUsers_WhenNoReactions_ShouldReturnEmptyUsers()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var target = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, target.UserId);
+        var message = await ConversationTestHelper.SendConversationMessageAsync(_client, conversationId, "no reactions dm", caller.AccessToken);
+
+        var response = await _client.SendAuthorizedGetAsync(
+            $"/api/conversations/{conversationId}/messages/{message.MessageId}/reactions/heart/users",
+            caller.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ConversationGetReactionUsersResponse>(TestContext.Current.CancellationToken);
+        payload.Should().NotBeNull();
+        payload!.Users.Should().BeEmpty();
+        payload.TotalCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetConversationReactionUsers_WithReactions_ShouldReturnPaginatedUsers()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var target = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, target.UserId);
+        var message = await ConversationTestHelper.SendConversationMessageAsync(_client, conversationId, "react dm", caller.AccessToken);
+
+        await ConversationTestHelper.AddReactionAsync(_client, conversationId, message.MessageId, "heart", caller.AccessToken);
+
+        var response = await _client.SendAuthorizedGetAsync(
+            $"/api/conversations/{conversationId}/messages/{message.MessageId}/reactions/heart/users",
+            caller.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ConversationGetReactionUsersResponse>(TestContext.Current.CancellationToken);
+        payload.Should().NotBeNull();
+        payload!.Users.Should().HaveCount(1);
+        payload.TotalCount.Should().Be(1);
+        payload.Users[0].UserId.Should().Be(caller.UserId);
+    }
+
+    [Fact]
+    public async Task GetConversationReactionUsers_WhenCallerIsNotParticipant_ShouldReturnForbidden()
+    {
+        var participantOne = await AuthTestHelper.RegisterAsync(_client);
+        var participantTwo = await AuthTestHelper.RegisterAsync(_client);
+        var outsider = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, participantOne.AccessToken, participantTwo.UserId);
+        var message = await ConversationTestHelper.SendConversationMessageAsync(_client, conversationId, "private dm", participantOne.AccessToken);
+
+        var response = await _client.SendAuthorizedGetAsync(
+            $"/api/conversations/{conversationId}/messages/{message.MessageId}/reactions/heart/users",
+            outsider.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+}

--- a/tests/Harmonie.API.IntegrationTests/Common/ChannelTestHelper.cs
+++ b/tests/Harmonie.API.IntegrationTests/Common/ChannelTestHelper.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using FluentAssertions;
 using Harmonie.Application.Features.Channels.SendMessage;
@@ -81,5 +82,19 @@ public static class ChannelTestHelper
         payload.Should().NotBeNull();
 
         return payload!.MessageId;
+    }
+
+    public static async Task AddReactionAsync(
+        HttpClient client,
+        Guid channelId,
+        Guid messageId,
+        string urlEncodedEmoji,
+        string accessToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Put,
+            $"/api/channels/{channelId}/messages/{messageId}/reactions/{urlEncodedEmoji}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        var response = await client.SendAsync(request);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
 }

--- a/tests/Harmonie.API.IntegrationTests/Common/ConversationTestHelper.cs
+++ b/tests/Harmonie.API.IntegrationTests/Common/ConversationTestHelper.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using FluentAssertions;
 using Harmonie.Application.Features.Channels.SendMessage;
@@ -57,5 +58,19 @@ public static class ConversationTestHelper
         var payload = await response.Content.ReadFromJsonAsync<SendMessageResponse>();
         payload.Should().NotBeNull();
         return payload!;
+    }
+
+    public static async Task AddReactionAsync(
+        HttpClient client,
+        Guid conversationId,
+        Guid messageId,
+        string urlEncodedEmoji,
+        string accessToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Put,
+            $"/api/conversations/{conversationId}/messages/{messageId}/reactions/{urlEncodedEmoji}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        var response = await client.SendAsync(request);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
 }

--- a/tests/Harmonie.Application.Tests/Messages/AddChannelReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/AddChannelReactionHandlerTests.cs
@@ -4,7 +4,6 @@ using Harmonie.Application.Features.Channels.AddReaction;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Guilds;
 using Harmonie.Domain.Entities.Messages;
@@ -24,7 +23,6 @@ public sealed class AddChannelReactionHandlerTests
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IMessageRepository> _messageRepositoryMock;
     private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
-    private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IReactionNotifier> _reactionNotifierMock;
@@ -35,7 +33,6 @@ public sealed class AddChannelReactionHandlerTests
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
         _messageRepositoryMock = new Mock<IMessageRepository>();
         _reactionRepositoryMock = new Mock<IMessageReactionRepository>();
-        _userRepositoryMock = new Mock<IUserRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
         _reactionNotifierMock = new Mock<IReactionNotifier>();
@@ -46,15 +43,10 @@ public sealed class AddChannelReactionHandlerTests
             .Setup(x => x.NotifyReactionAddedToChannelAsync(It.IsAny<ChannelReactionAddedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        _userRepositoryMock
-            .Setup(x => x.GetByIdAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((UserId userId, CancellationToken _) => ApplicationTestBuilders.CreateUser(userId));
-
         _handler = new AddReactionHandler(
             _guildChannelRepositoryMock.Object,
             _messageRepositoryMock.Object,
             _reactionRepositoryMock.Object,
-            _userRepositoryMock.Object,
             _unitOfWorkMock.Object,
             _reactionNotifierMock.Object,
             NullLogger<AddReactionHandler>.Instance);

--- a/tests/Harmonie.Application.Tests/Messages/AddChannelReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/AddChannelReactionHandlerTests.cs
@@ -4,6 +4,7 @@ using Harmonie.Application.Features.Channels.AddReaction;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Guilds;
 using Harmonie.Domain.Entities.Messages;
@@ -23,6 +24,7 @@ public sealed class AddChannelReactionHandlerTests
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IMessageRepository> _messageRepositoryMock;
     private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
+    private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IReactionNotifier> _reactionNotifierMock;
@@ -33,6 +35,7 @@ public sealed class AddChannelReactionHandlerTests
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
         _messageRepositoryMock = new Mock<IMessageRepository>();
         _reactionRepositoryMock = new Mock<IMessageReactionRepository>();
+        _userRepositoryMock = new Mock<IUserRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
         _reactionNotifierMock = new Mock<IReactionNotifier>();
@@ -43,10 +46,15 @@ public sealed class AddChannelReactionHandlerTests
             .Setup(x => x.NotifyReactionAddedToChannelAsync(It.IsAny<ChannelReactionAddedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserId userId, CancellationToken _) => ApplicationTestBuilders.CreateUser(userId));
+
         _handler = new AddReactionHandler(
             _guildChannelRepositoryMock.Object,
             _messageRepositoryMock.Object,
             _reactionRepositoryMock.Object,
+            _userRepositoryMock.Object,
             _unitOfWorkMock.Object,
             _reactionNotifierMock.Object,
             NullLogger<AddReactionHandler>.Instance);

--- a/tests/Harmonie.Application.Tests/Messages/AddChannelReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/AddChannelReactionHandlerTests.cs
@@ -20,6 +20,9 @@ namespace Harmonie.Application.Tests.Messages;
 
 public sealed class AddChannelReactionHandlerTests
 {
+    private const string TestUsername = "testuser";
+    private const string TestDisplayName = "Test User";
+
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IMessageRepository> _messageRepositoryMock;
     private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
@@ -158,7 +161,7 @@ public sealed class AddChannelReactionHandlerTests
 
         _guildChannelRepositoryMock
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
+            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member, TestUsername, TestDisplayName));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -180,7 +183,7 @@ public sealed class AddChannelReactionHandlerTests
 
         _guildChannelRepositoryMock
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
+            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member, TestUsername, TestDisplayName));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -203,6 +206,8 @@ public sealed class AddChannelReactionHandlerTests
                     n.GuildId == channel.GuildId &&
                     n.MessageId == messageId &&
                     n.UserId == callerId &&
+                    n.Username == TestUsername &&
+                    n.DisplayName == TestDisplayName &&
                     n.Emoji == "👍"),
                 It.IsAny<CancellationToken>()),
             Times.Once);
@@ -219,7 +224,7 @@ public sealed class AddChannelReactionHandlerTests
 
         _guildChannelRepositoryMock
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
+            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member, TestUsername, TestDisplayName));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -240,7 +245,7 @@ public sealed class AddChannelReactionHandlerTests
 
         _guildChannelRepositoryMock
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
+            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member, TestUsername, TestDisplayName));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))

--- a/tests/Harmonie.Application.Tests/Messages/AddConversationReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/AddConversationReactionHandlerTests.cs
@@ -4,7 +4,6 @@ using Harmonie.Application.Features.Conversations.AddReaction;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
@@ -22,7 +21,6 @@ public sealed class AddConversationReactionHandlerTests
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IMessageRepository> _messageRepositoryMock;
     private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
-    private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IReactionNotifier> _reactionNotifierMock;
@@ -33,7 +31,6 @@ public sealed class AddConversationReactionHandlerTests
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _messageRepositoryMock = new Mock<IMessageRepository>();
         _reactionRepositoryMock = new Mock<IMessageReactionRepository>();
-        _userRepositoryMock = new Mock<IUserRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
         _reactionNotifierMock = new Mock<IReactionNotifier>();
@@ -44,15 +41,10 @@ public sealed class AddConversationReactionHandlerTests
             .Setup(x => x.NotifyReactionAddedToConversationAsync(It.IsAny<ConversationReactionAddedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        _userRepositoryMock
-            .Setup(x => x.GetByIdAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((UserId userId, CancellationToken _) => ApplicationTestBuilders.CreateUser(userId));
-
         _handler = new AddReactionHandler(
             _conversationRepositoryMock.Object,
             _messageRepositoryMock.Object,
             _reactionRepositoryMock.Object,
-            _userRepositoryMock.Object,
             _unitOfWorkMock.Object,
             _reactionNotifierMock.Object,
             NullLogger<AddReactionHandler>.Instance);

--- a/tests/Harmonie.Application.Tests/Messages/AddConversationReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/AddConversationReactionHandlerTests.cs
@@ -4,6 +4,7 @@ using Harmonie.Application.Features.Conversations.AddReaction;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
@@ -21,6 +22,7 @@ public sealed class AddConversationReactionHandlerTests
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IMessageRepository> _messageRepositoryMock;
     private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
+    private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IReactionNotifier> _reactionNotifierMock;
@@ -31,6 +33,7 @@ public sealed class AddConversationReactionHandlerTests
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _messageRepositoryMock = new Mock<IMessageRepository>();
         _reactionRepositoryMock = new Mock<IMessageReactionRepository>();
+        _userRepositoryMock = new Mock<IUserRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
         _reactionNotifierMock = new Mock<IReactionNotifier>();
@@ -41,10 +44,15 @@ public sealed class AddConversationReactionHandlerTests
             .Setup(x => x.NotifyReactionAddedToConversationAsync(It.IsAny<ConversationReactionAddedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserId userId, CancellationToken _) => ApplicationTestBuilders.CreateUser(userId));
+
         _handler = new AddReactionHandler(
             _conversationRepositoryMock.Object,
             _messageRepositoryMock.Object,
             _reactionRepositoryMock.Object,
+            _userRepositoryMock.Object,
             _unitOfWorkMock.Object,
             _reactionNotifierMock.Object,
             NullLogger<AddReactionHandler>.Instance);

--- a/tests/Harmonie.Application.Tests/Messages/AddConversationReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/AddConversationReactionHandlerTests.cs
@@ -18,6 +18,9 @@ namespace Harmonie.Application.Tests.Messages;
 
 public sealed class AddConversationReactionHandlerTests
 {
+    private const string TestUsername = "testuser";
+    private const string TestDisplayName = "Test User";
+
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IMessageRepository> _messageRepositoryMock;
     private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
@@ -144,7 +147,10 @@ public sealed class AddConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .ReturnsAsync(new ConversationAccess(conversation,
+                Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne),
+                CallerUsername: TestUsername,
+                CallerDisplayName: TestDisplayName));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -167,7 +173,10 @@ public sealed class AddConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .ReturnsAsync(new ConversationAccess(conversation,
+                Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne),
+                CallerUsername: TestUsername,
+                CallerDisplayName: TestDisplayName));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -189,6 +198,8 @@ public sealed class AddConversationReactionHandlerTests
                     n.ConversationId == conversation.Id &&
                     n.MessageId == messageId &&
                     n.UserId == participantOne &&
+                    n.Username == TestUsername &&
+                    n.DisplayName == TestDisplayName &&
                     n.Emoji == "❤"),
                 It.IsAny<CancellationToken>()),
             Times.Once);
@@ -205,7 +216,10 @@ public sealed class AddConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantTwo, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantTwo)));
+            .ReturnsAsync(new ConversationAccess(conversation,
+                Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantTwo),
+                CallerUsername: TestUsername,
+                CallerDisplayName: TestDisplayName));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -227,7 +241,10 @@ public sealed class AddConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .ReturnsAsync(new ConversationAccess(conversation,
+                Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne),
+                CallerUsername: TestUsername,
+                CallerDisplayName: TestDisplayName));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))

--- a/tests/Harmonie.Application.Tests/Messages/GetChannelReactionUsersHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetChannelReactionUsersHandlerTests.cs
@@ -1,0 +1,103 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Channels.GetReactionUsers;
+using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Messages;
+
+public sealed class GetChannelReactionUsersHandlerTests
+{
+    private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
+    private readonly Mock<IMessageRepository> _messageRepositoryMock;
+    private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
+    private readonly GetReactionUsersHandler _handler;
+
+    public GetChannelReactionUsersHandlerTests()
+    {
+        _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
+        _messageRepositoryMock = new Mock<IMessageRepository>();
+        _reactionRepositoryMock = new Mock<IMessageReactionRepository>();
+
+        _handler = new GetReactionUsersHandler(
+            _guildChannelRepositoryMock.Object,
+            _messageRepositoryMock.Object,
+            _reactionRepositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenNoReactions_ShouldReturnEmptyUsers()
+    {
+        var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Text);
+        var callerId = UserId.New();
+        var messageId = MessageId.New();
+        var message = ApplicationTestBuilders.CreateChannelMessage(channel.Id, callerId, content: "test");
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
+
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        _reactionRepositoryMock
+            .Setup(x => x.GetReactionUsersAsync(messageId, "👍", It.IsAny<int>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReactionUsersPage(Array.Empty<ReactionUser>(), 0, null));
+
+        var response = await _handler.HandleAsync(
+            new GetChannelReactionUsersInput(channel.Id, messageId, "👍"),
+            callerId,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data.Should().NotBeNull();
+        response.Data!.Users.Should().BeEmpty();
+        response.Data.TotalCount.Should().Be(0);
+        response.Data.Emoji.Should().Be("👍");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithReactions_ShouldReturnUsers()
+    {
+        var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Text);
+        var callerId = UserId.New();
+        var messageId = MessageId.New();
+        var message = ApplicationTestBuilders.CreateChannelMessage(channel.Id, callerId, content: "test");
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
+
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        _reactionRepositoryMock
+            .Setup(x => x.GetReactionUsersAsync(messageId, "👍", It.IsAny<int>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReactionUsersPage(
+                new[] { new ReactionUser(callerId.Value, "testuser", "Test User") },
+                1,
+                null));
+
+        var response = await _handler.HandleAsync(
+            new GetChannelReactionUsersInput(channel.Id, messageId, "👍"),
+            callerId,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data.Should().NotBeNull();
+        response.Data!.Users.Should().HaveCount(1);
+        response.Data.TotalCount.Should().Be(1);
+        response.Data.Users[0].UserId.Should().Be(callerId.Value);
+        response.Data.Users[0].Username.Should().Be("testuser");
+        response.Data.Users[0].DisplayName.Should().Be("Test User");
+    }
+}

--- a/tests/Harmonie.Application.Tests/Messages/GetConversationReactionUsersHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetConversationReactionUsersHandlerTests.cs
@@ -1,0 +1,146 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Conversations.GetReactionUsers;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Messages;
+
+public sealed class GetConversationReactionUsersHandlerTests
+{
+    private readonly Mock<IConversationRepository> _conversationRepositoryMock;
+    private readonly Mock<IMessageRepository> _messageRepositoryMock;
+    private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
+    private readonly GetReactionUsersHandler _handler;
+
+    public GetConversationReactionUsersHandlerTests()
+    {
+        _conversationRepositoryMock = new Mock<IConversationRepository>();
+        _messageRepositoryMock = new Mock<IMessageRepository>();
+        _reactionRepositoryMock = new Mock<IMessageReactionRepository>();
+
+        _handler = new GetReactionUsersHandler(
+            _conversationRepositoryMock.Object,
+            _messageRepositoryMock.Object,
+            _reactionRepositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenNoReactions_ShouldReturnEmptyUsers()
+    {
+        var participantOne = UserId.New();
+        var participantTwo = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(participantOne, participantTwo);
+        var messageId = MessageId.New();
+        var message = ApplicationTestBuilders.CreateConversationMessage(conversation.Id, participantOne);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation,
+                Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        _reactionRepositoryMock
+            .Setup(x => x.GetReactionUsersAsync(messageId, "❤️", It.IsAny<int>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReactionUsersPage(Array.Empty<ReactionUser>(), 0, null));
+
+        var response = await _handler.HandleAsync(
+            new GetConversationReactionUsersInput(conversation.Id, messageId, "❤️"),
+            participantOne,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data.Should().NotBeNull();
+        response.Data!.Users.Should().BeEmpty();
+        response.Data.TotalCount.Should().Be(0);
+        response.Data.Emoji.Should().Be("❤️");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithReactions_ShouldReturnUsers()
+    {
+        var participantOne = UserId.New();
+        var participantTwo = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(participantOne, participantTwo);
+        var messageId = MessageId.New();
+        var message = ApplicationTestBuilders.CreateConversationMessage(conversation.Id, participantOne);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation,
+                Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        _reactionRepositoryMock
+            .Setup(x => x.GetReactionUsersAsync(messageId, "❤️", It.IsAny<int>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReactionUsersPage(
+                new[] { new ReactionUser(participantOne.Value, "user1", "User One") },
+                1,
+                null));
+
+        var response = await _handler.HandleAsync(
+            new GetConversationReactionUsersInput(conversation.Id, messageId, "❤️"),
+            participantOne,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data.Should().NotBeNull();
+        response.Data!.Users.Should().HaveCount(1);
+        response.Data.TotalCount.Should().Be(1);
+        response.Data.Users[0].UserId.Should().Be(participantOne.Value);
+        response.Data.Users[0].Username.Should().Be("user1");
+        response.Data.Users[0].DisplayName.Should().Be("User One");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenConversationDoesNotExist_ShouldReturnNotFound()
+    {
+        var conversationId = ConversationId.New();
+        var callerId = UserId.New();
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversationId, callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConversationAccess?)null);
+
+        var response = await _handler.HandleAsync(
+            new GetConversationReactionUsersInput(conversationId, MessageId.New(), "👍"),
+            callerId,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCallerIsNotParticipant_ShouldReturnAccessDenied()
+    {
+        var participantOne = UserId.New();
+        var participantTwo = UserId.New();
+        var outsider = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(participantOne, participantTwo);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: null));
+
+        var response = await _handler.HandleAsync(
+            new GetConversationReactionUsersInput(conversation.Id, MessageId.New(), "👍"),
+            outsider,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.AccessDenied);
+    }
+}

--- a/tests/Harmonie.Application.Tests/Messages/RemoveChannelReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/RemoveChannelReactionHandlerTests.cs
@@ -4,7 +4,6 @@ using Harmonie.Application.Features.Channels.RemoveReaction;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Guilds;
 using Harmonie.Domain.Entities.Messages;
@@ -25,7 +24,6 @@ public sealed class RemoveChannelReactionHandlerTests
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IMessageRepository> _messageRepositoryMock;
     private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
-    private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IReactionNotifier> _reactionNotifierMock;
@@ -36,7 +34,6 @@ public sealed class RemoveChannelReactionHandlerTests
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
         _messageRepositoryMock = new Mock<IMessageRepository>();
         _reactionRepositoryMock = new Mock<IMessageReactionRepository>();
-        _userRepositoryMock = new Mock<IUserRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
         _reactionNotifierMock = new Mock<IReactionNotifier>();
@@ -47,15 +44,10 @@ public sealed class RemoveChannelReactionHandlerTests
             .Setup(x => x.NotifyReactionRemovedFromChannelAsync(It.IsAny<ChannelReactionRemovedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        _userRepositoryMock
-            .Setup(x => x.GetByIdAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((UserId userId, CancellationToken _) => ApplicationTestBuilders.CreateUser(userId));
-
         _handler = new RemoveReactionHandler(
             _guildChannelRepositoryMock.Object,
             _messageRepositoryMock.Object,
             _reactionRepositoryMock.Object,
-            _userRepositoryMock.Object,
             _unitOfWorkMock.Object,
             _reactionNotifierMock.Object,
             NullLogger<RemoveReactionHandler>.Instance);

--- a/tests/Harmonie.Application.Tests/Messages/RemoveChannelReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/RemoveChannelReactionHandlerTests.cs
@@ -21,6 +21,9 @@ namespace Harmonie.Application.Tests.Messages;
 
 public sealed class RemoveChannelReactionHandlerTests
 {
+    private const string TestUsername = "testuser";
+    private const string TestDisplayName = "Test User";
+
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IMessageRepository> _messageRepositoryMock;
     private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
@@ -159,7 +162,7 @@ public sealed class RemoveChannelReactionHandlerTests
 
         _guildChannelRepositoryMock
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
+            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member, TestUsername, TestDisplayName));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -181,7 +184,7 @@ public sealed class RemoveChannelReactionHandlerTests
 
         _guildChannelRepositoryMock
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
+            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member, TestUsername, TestDisplayName));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -204,6 +207,8 @@ public sealed class RemoveChannelReactionHandlerTests
                     n.GuildId == channel.GuildId &&
                     n.MessageId == messageId &&
                     n.UserId == callerId &&
+                    n.Username == TestUsername &&
+                    n.DisplayName == TestDisplayName &&
                     n.Emoji == "👍"),
                 It.IsAny<CancellationToken>()),
             Times.Once);
@@ -219,7 +224,7 @@ public sealed class RemoveChannelReactionHandlerTests
 
         _guildChannelRepositoryMock
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
+            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member, TestUsername, TestDisplayName));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))

--- a/tests/Harmonie.Application.Tests/Messages/RemoveChannelReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/RemoveChannelReactionHandlerTests.cs
@@ -4,6 +4,7 @@ using Harmonie.Application.Features.Channels.RemoveReaction;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Guilds;
 using Harmonie.Domain.Entities.Messages;
@@ -24,6 +25,7 @@ public sealed class RemoveChannelReactionHandlerTests
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IMessageRepository> _messageRepositoryMock;
     private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
+    private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IReactionNotifier> _reactionNotifierMock;
@@ -34,6 +36,7 @@ public sealed class RemoveChannelReactionHandlerTests
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
         _messageRepositoryMock = new Mock<IMessageRepository>();
         _reactionRepositoryMock = new Mock<IMessageReactionRepository>();
+        _userRepositoryMock = new Mock<IUserRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
         _reactionNotifierMock = new Mock<IReactionNotifier>();
@@ -44,10 +47,15 @@ public sealed class RemoveChannelReactionHandlerTests
             .Setup(x => x.NotifyReactionRemovedFromChannelAsync(It.IsAny<ChannelReactionRemovedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserId userId, CancellationToken _) => ApplicationTestBuilders.CreateUser(userId));
+
         _handler = new RemoveReactionHandler(
             _guildChannelRepositoryMock.Object,
             _messageRepositoryMock.Object,
             _reactionRepositoryMock.Object,
+            _userRepositoryMock.Object,
             _unitOfWorkMock.Object,
             _reactionNotifierMock.Object,
             NullLogger<RemoveReactionHandler>.Instance);

--- a/tests/Harmonie.Application.Tests/Messages/RemoveConversationReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/RemoveConversationReactionHandlerTests.cs
@@ -4,6 +4,7 @@ using Harmonie.Application.Features.Conversations.RemoveReaction;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
@@ -20,6 +21,7 @@ public sealed class RemoveConversationReactionHandlerTests
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IMessageRepository> _messageRepositoryMock;
     private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
+    private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IReactionNotifier> _reactionNotifierMock;
@@ -30,6 +32,7 @@ public sealed class RemoveConversationReactionHandlerTests
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _messageRepositoryMock = new Mock<IMessageRepository>();
         _reactionRepositoryMock = new Mock<IMessageReactionRepository>();
+        _userRepositoryMock = new Mock<IUserRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
         _reactionNotifierMock = new Mock<IReactionNotifier>();
@@ -40,10 +43,15 @@ public sealed class RemoveConversationReactionHandlerTests
             .Setup(x => x.NotifyReactionRemovedFromConversationAsync(It.IsAny<ConversationReactionRemovedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserId userId, CancellationToken _) => ApplicationTestBuilders.CreateUser(userId));
+
         _handler = new RemoveReactionHandler(
             _conversationRepositoryMock.Object,
             _messageRepositoryMock.Object,
             _reactionRepositoryMock.Object,
+            _userRepositoryMock.Object,
             _unitOfWorkMock.Object,
             _reactionNotifierMock.Object,
             NullLogger<RemoveReactionHandler>.Instance);

--- a/tests/Harmonie.Application.Tests/Messages/RemoveConversationReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/RemoveConversationReactionHandlerTests.cs
@@ -4,7 +4,6 @@ using Harmonie.Application.Features.Conversations.RemoveReaction;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
@@ -21,7 +20,6 @@ public sealed class RemoveConversationReactionHandlerTests
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IMessageRepository> _messageRepositoryMock;
     private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
-    private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IReactionNotifier> _reactionNotifierMock;
@@ -32,7 +30,6 @@ public sealed class RemoveConversationReactionHandlerTests
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _messageRepositoryMock = new Mock<IMessageRepository>();
         _reactionRepositoryMock = new Mock<IMessageReactionRepository>();
-        _userRepositoryMock = new Mock<IUserRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
         _reactionNotifierMock = new Mock<IReactionNotifier>();
@@ -43,15 +40,10 @@ public sealed class RemoveConversationReactionHandlerTests
             .Setup(x => x.NotifyReactionRemovedFromConversationAsync(It.IsAny<ConversationReactionRemovedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        _userRepositoryMock
-            .Setup(x => x.GetByIdAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((UserId userId, CancellationToken _) => ApplicationTestBuilders.CreateUser(userId));
-
         _handler = new RemoveReactionHandler(
             _conversationRepositoryMock.Object,
             _messageRepositoryMock.Object,
             _reactionRepositoryMock.Object,
-            _userRepositoryMock.Object,
             _unitOfWorkMock.Object,
             _reactionNotifierMock.Object,
             NullLogger<RemoveReactionHandler>.Instance);

--- a/tests/Harmonie.Application.Tests/Messages/RemoveConversationReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/RemoveConversationReactionHandlerTests.cs
@@ -17,6 +17,9 @@ namespace Harmonie.Application.Tests.Messages;
 
 public sealed class RemoveConversationReactionHandlerTests
 {
+    private const string TestUsername = "testuser";
+    private const string TestDisplayName = "Test User";
+
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IMessageRepository> _messageRepositoryMock;
     private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
@@ -143,7 +146,10 @@ public sealed class RemoveConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .ReturnsAsync(new ConversationAccess(conversation,
+                Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne),
+                CallerUsername: TestUsername,
+                CallerDisplayName: TestDisplayName));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -166,7 +172,10 @@ public sealed class RemoveConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .ReturnsAsync(new ConversationAccess(conversation,
+                Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne),
+                CallerUsername: TestUsername,
+                CallerDisplayName: TestDisplayName));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -188,6 +197,8 @@ public sealed class RemoveConversationReactionHandlerTests
                     n.ConversationId == conversation.Id &&
                     n.MessageId == messageId &&
                     n.UserId == participantOne &&
+                    n.Username == TestUsername &&
+                    n.DisplayName == TestDisplayName &&
                     n.Emoji == "❤"),
                 It.IsAny<CancellationToken>()),
             Times.Once);
@@ -204,7 +215,10 @@ public sealed class RemoveConversationReactionHandlerTests
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .ReturnsAsync(new ConversationAccess(conversation,
+                Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne),
+                CallerUsername: TestUsername,
+                CallerDisplayName: TestDisplayName));
 
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))


### PR DESCRIPTION
Closes #352.

## Résumé

Trois chantiers qui améliorent l'expérience des réactions :

### 1. Enrichir `GetMessages` avec les 5 premiers utilisateurs par réaction
Le DTO `MessageReactionDto` inclut désormais un champ `Users` (max 5) avec `userId`, `username`, `displayName` pour chaque réaction, sans régression de performance (la query de résumé `GROUP BY` reste inchangée).

### 2. Nouveaux endpoints pour lister tous les utilisateurs d'une réaction
- `GET /api/channels/{channelId}/messages/{messageId}/reactions/{emoji}/users`
- `GET /api/conversations/{conversationId}/messages/{messageId}/reactions/{emoji}/users`

Paginés avec curseur, incluant `TotalCount`.

### 3. `Username`/`DisplayName` dans les événements SignalR
Les événements `ReactionAdded` et `ReactionRemoved` incluent maintenant `ReactorUsername` et `ReactorDisplayName` pour éviter un lookup côté front.