### PR TITLE
feat: support HTML anchor tags in link preview URL parsing (#356)

### DIFF
--- a/src/Harmonie.Application/Services/LinkPreviewResolutionService.cs
+++ b/src/Harmonie.Application/Services/LinkPreviewResolutionService.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Channels;
@@ -18,6 +19,10 @@ public sealed class LinkPreviewResolutionService
     private static readonly TimeSpan PreviewCacheMaxAge = TimeSpan.FromHours(24);
     private static readonly TimeSpan ResolutionTimeout = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
+    private static readonly Regex HrefRegex = new(
+        @"href\s*=\s*[""'](https?://[^""'\s>]+)[""']",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled,
+        TimeSpan.FromMilliseconds(200));
     private const int MaxUrlsPerMessage = 5;
 
     private readonly IServiceScopeFactory _serviceScopeFactory;
@@ -38,6 +43,7 @@ public sealed class LinkPreviewResolutionService
 
         var urls = new List<Uri>(MaxUrlsPerMessage);
 
+        // First pass: split by whitespace (plain text)
         foreach (var token in content.Split(' ', StringSplitOptions.RemoveEmptyEntries))
         {
             if (urls.Count >= MaxUrlsPerMessage)
@@ -53,6 +59,32 @@ public sealed class LinkPreviewResolutionService
                 continue;
 
             urls.Add(uri);
+        }
+
+        // Second pass: extract href from <a> tags (HTML content from rich text editors)
+        if (urls.Count == 0 && content.Contains("<a ", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                foreach (Match match in HrefRegex.Matches(content))
+                {
+                    if (urls.Count >= MaxUrlsPerMessage)
+                        break;
+
+                    var href = match.Groups[1].Value;
+                    if (Uri.TryCreate(href, UriKind.Absolute, out var uri)
+                        && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
+                        && IsSafeHost(uri)
+                        && !urls.Contains(uri))
+                    {
+                        urls.Add(uri);
+                    }
+                }
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                // Malformed HTML — skip
+            }
         }
 
         return urls;

--- a/tests/Harmonie.Application.Tests/Messages/LinkPreviewResolutionServiceParseUrlsTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/LinkPreviewResolutionServiceParseUrlsTests.cs
@@ -106,4 +106,48 @@ public sealed class LinkPreviewResolutionServiceParseUrlsTests
         result.Should().HaveCount(1);
         result[0].ToString().Should().Be("https://example.com/page?q=1#section");
     }
+
+    [Fact]
+    public void ParseUrls_WhenHtmlAnchorTag_ShouldExtractHref()
+    {
+        var content = "<p><a href=\"https://www.youtube.com/watch?v=nUp_bv_sOeI\" rel=\"noopener noreferrer\" target=\"_blank\">https://www.youtube.com/watch?v=nUp_bv_sOeI</a></p>";
+
+        var result = _service.ParseUrls(content);
+
+        result.Should().HaveCount(1);
+        result[0].ToString().Should().Be("https://www.youtube.com/watch?v=nUp_bv_sOeI");
+    }
+
+    [Fact]
+    public void ParseUrls_WhenHtmlWithMultipleAnchors_ShouldExtractAll()
+    {
+        var content = "<a href=\"https://a.com\">a</a> <a href='https://b.com'>b</a>";
+
+        var result = _service.ParseUrls(content);
+
+        result.Should().HaveCount(2);
+        result[0].ToString().Should().Be("https://a.com/");
+        result[1].ToString().Should().Be("https://b.com/");
+    }
+
+    [Fact]
+    public void ParseUrls_WhenPlainTextHasUrl_PrefersPlainTextOverHtml()
+    {
+        var content = "https://plain.com <a href=\"https://html.com\">link</a>";
+
+        var result = _service.ParseUrls(content);
+
+        result.Should().HaveCount(1);
+        result[0].ToString().Should().Be("https://plain.com/");
+    }
+
+    [Fact]
+    public void ParseUrls_WhenHtmlAnchorHasNoHttps_ShouldBeIgnored()
+    {
+        var content = "<a href=\"ftp://files.com\">files</a>";
+
+        var result = _service.ParseUrls(content);
+
+        result.Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
## What

`ParseUrls` now supports HTML content from rich text editors. When plain-text
tokenization finds no URLs, it falls back to extracting `href` attributes from
`<a>` tags using a compiled Regex with a 200ms timeout.

### Example

Input:
```json
{"content":"<p><a href=\"https://www.youtube.com/watch?v=nUp_bv_sOeI\" rel=\"noopener noreferrer\" target=\"_blank\">https://www.youtube.com/watch?v=nUp_bv_sOeI</a></p>"}
```

Before: 0 URLs extracted → no preview
After: 1 URL extracted → preview resolved

### Tests

4 new unit tests:
- Single anchor tag
- Multiple anchors (double + single quotes)
- Plain text takes priority over HTML (no fallback triggered)
- Non-HTTP href ignored

Closes #356