### PR TITLE
feat: include link previews in GetMessages responses (#356)

### DIFF
--- a/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesHandler.cs
@@ -2,7 +2,6 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Users;
@@ -17,16 +16,13 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetChannelMessage
 
     private readonly IGuildChannelRepository _guildChannelRepository;
     private readonly IMessagePaginationRepository _channelMessageRepository;
-    private readonly ILinkPreviewRepository _linkPreviewRepository;
 
     public GetMessagesHandler(
         IGuildChannelRepository guildChannelRepository,
-        IMessagePaginationRepository channelMessageRepository,
-        ILinkPreviewRepository linkPreviewRepository)
+        IMessagePaginationRepository channelMessageRepository)
     {
         _guildChannelRepository = guildChannelRepository;
         _channelMessageRepository = channelMessageRepository;
-        _linkPreviewRepository = linkPreviewRepository;
     }
 
     public async Task<ApplicationResponse<GetMessagesResponse>> HandleAsync(
@@ -82,21 +78,14 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetChannelMessage
             currentUserId,
             cancellationToken);
 
-        var messageIds = page.Items.Select(x => x.Id).ToArray();
-        IReadOnlyList<MessageLinkPreview> linkPreviews = messageIds.Length > 0
-            ? await _linkPreviewRepository.GetByMessageIdsAsync(messageIds, cancellationToken)
-            : Array.Empty<MessageLinkPreview>();
-        var linkPreviewsByMessageId = linkPreviews
-            .GroupBy(p => p.MessageId.Value)
-            .ToDictionary(g => g.Key, g => (IReadOnlyList<MessageLinkPreview>)g.ToArray());
-
         var items = page.Items
             .OrderBy(x => x.CreatedAtUtc)
             .ThenBy(x => x.Id.Value)
             .Select(x =>
             {
                 page.ReactionsByMessageId.TryGetValue(x.Id.Value, out var reactions);
-                linkPreviewsByMessageId.TryGetValue(x.Id.Value, out var previews);
+                IReadOnlyList<LinkPreviewDto>? previews = null;
+                page.LinkPreviewsByMessageId?.TryGetValue(x.Id.Value, out previews);
                 return new GetMessagesItemResponse(
                     MessageId: x.Id.Value,
                     AuthorUserId: x.AuthorUserId.Value,
@@ -105,7 +94,7 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetChannelMessage
                     Reactions: reactions?.Select(r => new MessageReactionDto(r.Emoji, r.Count, r.ReactedByCaller,
                         r.Users.Select(u => new ReactionUserDto(u.UserId, u.Username, u.DisplayName)).ToArray())).ToArray()
                               ?? Array.Empty<MessageReactionDto>(),
-                    LinkPreviews: previews?.Select(p => new LinkPreviewDto(p.Url, p.Title, p.Description, p.ImageUrl, p.SiteName)).ToArray(),
+                    LinkPreviews: previews?.ToArray(),
                     CreatedAtUtc: x.CreatedAtUtc,
                     UpdatedAtUtc: x.UpdatedAtUtc);
             })

--- a/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesHandler.cs
@@ -2,6 +2,7 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Users;
@@ -16,13 +17,16 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetChannelMessage
 
     private readonly IGuildChannelRepository _guildChannelRepository;
     private readonly IMessagePaginationRepository _channelMessageRepository;
+    private readonly ILinkPreviewRepository _linkPreviewRepository;
 
     public GetMessagesHandler(
         IGuildChannelRepository guildChannelRepository,
-        IMessagePaginationRepository channelMessageRepository)
+        IMessagePaginationRepository channelMessageRepository,
+        ILinkPreviewRepository linkPreviewRepository)
     {
         _guildChannelRepository = guildChannelRepository;
         _channelMessageRepository = channelMessageRepository;
+        _linkPreviewRepository = linkPreviewRepository;
     }
 
     public async Task<ApplicationResponse<GetMessagesResponse>> HandleAsync(
@@ -78,12 +82,21 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetChannelMessage
             currentUserId,
             cancellationToken);
 
+        var messageIds = page.Items.Select(x => x.Id).ToArray();
+        IReadOnlyList<MessageLinkPreview> linkPreviews = messageIds.Length > 0
+            ? await _linkPreviewRepository.GetByMessageIdsAsync(messageIds, cancellationToken)
+            : Array.Empty<MessageLinkPreview>();
+        var linkPreviewsByMessageId = linkPreviews
+            .GroupBy(p => p.MessageId.Value)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<MessageLinkPreview>)g.ToArray());
+
         var items = page.Items
             .OrderBy(x => x.CreatedAtUtc)
             .ThenBy(x => x.Id.Value)
             .Select(x =>
             {
                 page.ReactionsByMessageId.TryGetValue(x.Id.Value, out var reactions);
+                linkPreviewsByMessageId.TryGetValue(x.Id.Value, out var previews);
                 return new GetMessagesItemResponse(
                     MessageId: x.Id.Value,
                     AuthorUserId: x.AuthorUserId.Value,
@@ -92,6 +105,7 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetChannelMessage
                     Reactions: reactions?.Select(r => new MessageReactionDto(r.Emoji, r.Count, r.ReactedByCaller,
                         r.Users.Select(u => new ReactionUserDto(u.UserId, u.Username, u.DisplayName)).ToArray())).ToArray()
                               ?? Array.Empty<MessageReactionDto>(),
+                    LinkPreviews: previews?.Select(p => new LinkPreviewDto(p.Url, p.Title, p.Description, p.ImageUrl, p.SiteName)).ToArray(),
                     CreatedAtUtc: x.CreatedAtUtc,
                     UpdatedAtUtc: x.UpdatedAtUtc);
             })

--- a/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesResponse.cs
+++ b/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesResponse.cs
@@ -16,5 +16,6 @@ public sealed record GetMessagesItemResponse(
     string? Content,
     IReadOnlyList<MessageAttachmentDto> Attachments,
     IReadOnlyList<MessageReactionDto> Reactions,
+    IReadOnlyList<LinkPreviewDto>? LinkPreviews,
     DateTime CreatedAtUtc,
     DateTime? UpdatedAtUtc);

--- a/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesHandler.cs
@@ -2,7 +2,6 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Users;
 
@@ -16,16 +15,13 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetConversationMe
 
     private readonly IConversationRepository _conversationRepository;
     private readonly IMessagePaginationRepository _conversationMessageRepository;
-    private readonly ILinkPreviewRepository _linkPreviewRepository;
 
     public GetMessagesHandler(
         IConversationRepository conversationRepository,
-        IMessagePaginationRepository conversationMessageRepository,
-        ILinkPreviewRepository linkPreviewRepository)
+        IMessagePaginationRepository conversationMessageRepository)
     {
         _conversationRepository = conversationRepository;
         _conversationMessageRepository = conversationMessageRepository;
-        _linkPreviewRepository = linkPreviewRepository;
     }
 
     public async Task<ApplicationResponse<GetMessagesResponse>> HandleAsync(
@@ -73,21 +69,14 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetConversationMe
             currentUserId,
             cancellationToken);
 
-        var messageIds = page.Items.Select(x => x.Id).ToArray();
-        IReadOnlyList<MessageLinkPreview> linkPreviews = messageIds.Length > 0
-            ? await _linkPreviewRepository.GetByMessageIdsAsync(messageIds, cancellationToken)
-            : Array.Empty<MessageLinkPreview>();
-        var linkPreviewsByMessageId = linkPreviews
-            .GroupBy(p => p.MessageId.Value)
-            .ToDictionary(g => g.Key, g => (IReadOnlyList<MessageLinkPreview>)g.ToArray());
-
         var items = page.Items
             .OrderBy(x => x.CreatedAtUtc)
             .ThenBy(x => x.Id.Value)
             .Select(x =>
             {
                 page.ReactionsByMessageId.TryGetValue(x.Id.Value, out var reactions);
-                linkPreviewsByMessageId.TryGetValue(x.Id.Value, out var previews);
+                IReadOnlyList<LinkPreviewDto>? previews = null;
+                page.LinkPreviewsByMessageId?.TryGetValue(x.Id.Value, out previews);
                 return new GetMessagesItemResponse(
                     MessageId: x.Id.Value,
                     AuthorUserId: x.AuthorUserId.Value,
@@ -96,7 +85,7 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetConversationMe
                     Reactions: reactions?.Select(r => new MessageReactionDto(r.Emoji, r.Count, r.ReactedByCaller,
                         r.Users.Select(u => new ReactionUserDto(u.UserId, u.Username, u.DisplayName)).ToArray())).ToArray()
                               ?? Array.Empty<MessageReactionDto>(),
-                    LinkPreviews: previews?.Select(p => new LinkPreviewDto(p.Url, p.Title, p.Description, p.ImageUrl, p.SiteName)).ToArray(),
+                    LinkPreviews: previews?.ToArray(),
                     CreatedAtUtc: x.CreatedAtUtc,
                     UpdatedAtUtc: x.UpdatedAtUtc);
             })

--- a/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesHandler.cs
@@ -2,6 +2,7 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Users;
 
@@ -15,13 +16,16 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetConversationMe
 
     private readonly IConversationRepository _conversationRepository;
     private readonly IMessagePaginationRepository _conversationMessageRepository;
+    private readonly ILinkPreviewRepository _linkPreviewRepository;
 
     public GetMessagesHandler(
         IConversationRepository conversationRepository,
-        IMessagePaginationRepository conversationMessageRepository)
+        IMessagePaginationRepository conversationMessageRepository,
+        ILinkPreviewRepository linkPreviewRepository)
     {
         _conversationRepository = conversationRepository;
         _conversationMessageRepository = conversationMessageRepository;
+        _linkPreviewRepository = linkPreviewRepository;
     }
 
     public async Task<ApplicationResponse<GetMessagesResponse>> HandleAsync(
@@ -69,12 +73,21 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetConversationMe
             currentUserId,
             cancellationToken);
 
+        var messageIds = page.Items.Select(x => x.Id).ToArray();
+        IReadOnlyList<MessageLinkPreview> linkPreviews = messageIds.Length > 0
+            ? await _linkPreviewRepository.GetByMessageIdsAsync(messageIds, cancellationToken)
+            : Array.Empty<MessageLinkPreview>();
+        var linkPreviewsByMessageId = linkPreviews
+            .GroupBy(p => p.MessageId.Value)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<MessageLinkPreview>)g.ToArray());
+
         var items = page.Items
             .OrderBy(x => x.CreatedAtUtc)
             .ThenBy(x => x.Id.Value)
             .Select(x =>
             {
                 page.ReactionsByMessageId.TryGetValue(x.Id.Value, out var reactions);
+                linkPreviewsByMessageId.TryGetValue(x.Id.Value, out var previews);
                 return new GetMessagesItemResponse(
                     MessageId: x.Id.Value,
                     AuthorUserId: x.AuthorUserId.Value,
@@ -83,6 +96,7 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetConversationMe
                     Reactions: reactions?.Select(r => new MessageReactionDto(r.Emoji, r.Count, r.ReactedByCaller,
                         r.Users.Select(u => new ReactionUserDto(u.UserId, u.Username, u.DisplayName)).ToArray())).ToArray()
                               ?? Array.Empty<MessageReactionDto>(),
+                    LinkPreviews: previews?.Select(p => new LinkPreviewDto(p.Url, p.Title, p.Description, p.ImageUrl, p.SiteName)).ToArray(),
                     CreatedAtUtc: x.CreatedAtUtc,
                     UpdatedAtUtc: x.UpdatedAtUtc);
             })

--- a/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesResponse.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesResponse.cs
@@ -16,5 +16,6 @@ public sealed record GetMessagesItemResponse(
     string? Content,
     IReadOnlyList<MessageAttachmentDto> Attachments,
     IReadOnlyList<MessageReactionDto> Reactions,
+    IReadOnlyList<LinkPreviewDto>? LinkPreviews,
     DateTime CreatedAtUtc,
     DateTime? UpdatedAtUtc);

--- a/src/Harmonie.Application/Interfaces/Messages/IMessageRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Messages/IMessageRepository.cs
@@ -1,3 +1,4 @@
+using Harmonie.Application.Common.Messages;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Channels;
@@ -54,6 +55,7 @@ public sealed record MessagePage(
     IReadOnlyList<Message> Items,
     MessageCursor? NextCursor,
     IReadOnlyDictionary<Guid, IReadOnlyList<MessageReactionSummary>> ReactionsByMessageId,
+    IReadOnlyDictionary<Guid, IReadOnlyList<LinkPreviewDto>>? LinkPreviewsByMessageId = null,
     MessageReadState? LastReadState = null);
 
 public sealed record SearchGuildMessagesQuery(

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessagePaginationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessagePaginationRepository.cs
@@ -111,6 +111,22 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
                    FROM channel_read_states
                    WHERE user_id    = @CallerId
                      AND channel_id = @ChannelId;
+
+                   SELECT message_id AS "MessageId",
+                          url AS "Url",
+                          title AS "Title",
+                          description AS "Description",
+                          image_url AS "ImageUrl",
+                          site_name AS "SiteName"
+                   FROM message_link_previews
+                   WHERE message_id IN (
+                       SELECT id FROM messages
+                       WHERE channel_id = @ChannelId
+                         AND deleted_at_utc IS NULL
+                         {cursorFilter}
+                       ORDER BY created_at_utc DESC, id DESC
+                       LIMIT @Take)
+                   ORDER BY message_id;
                    """;
 
         var parameters = new DynamicParameters();
@@ -135,6 +151,7 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
         var reactionRows = (await multi.ReadAsync<ReactionSummaryRow>()).ToArray();
         var reactionUserRows = (await multi.ReadAsync<ReactionUserRow>()).ToArray();
         var readStateRow = await multi.ReadFirstOrDefaultAsync<ReadStateRow?>();
+        var linkPreviewRows = (await multi.ReadAsync<MessageLinkPreviewRow>()).ToArray();
 
         var hasMore = rows.Length > limit;
         var pageRows = hasMore ? rows.Take(limit).ToArray() : rows;
@@ -145,6 +162,8 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
         var reactionsByMessageId = MessageRepositoryHelpers.BuildReactionsDictionary(
             reactionRows.Where(r => pageMessageIds.Contains(r.MessageId)),
             reactionUserRows.Where(r => pageMessageIds.Contains(r.MessageId)));
+        var linkPreviewsByMessageId = MessageRepositoryHelpers.BuildLinkPreviewsDictionary(
+            linkPreviewRows.Where(r => pageMessageIds.Contains(r.MessageId)));
 
         var items = pageRows
             .Select(row => MessageRepositoryHelpers.MapToMessage(row, attachmentsByMessageId))
@@ -170,7 +189,7 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
                 readStateRow.ReadAtUtc);
         }
 
-        return new MessagePage(items, nextCursor, reactionsByMessageId, lastReadState);
+        return new MessagePage(items, nextCursor, reactionsByMessageId, linkPreviewsByMessageId, lastReadState);
     }
 
     public async Task<MessagePage> GetConversationPageAsync(
@@ -264,6 +283,22 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
                    FROM conversation_read_states
                    WHERE user_id         = @CallerId
                      AND conversation_id = @ConversationId;
+
+                   SELECT message_id AS "MessageId",
+                          url AS "Url",
+                          title AS "Title",
+                          description AS "Description",
+                          image_url AS "ImageUrl",
+                          site_name AS "SiteName"
+                   FROM message_link_previews
+                   WHERE message_id IN (
+                       SELECT id FROM messages
+                       WHERE conversation_id = @ConversationId
+                         AND deleted_at_utc IS NULL
+                         {cursorFilter}
+                       ORDER BY created_at_utc DESC, id DESC
+                       LIMIT @Take)
+                   ORDER BY message_id;
                    """;
 
         var parameters = new DynamicParameters();
@@ -288,6 +323,7 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
         var reactionRows = (await multi.ReadAsync<ReactionSummaryRow>()).ToArray();
         var reactionUserRows = (await multi.ReadAsync<ReactionUserRow>()).ToArray();
         var readStateRow = await multi.ReadFirstOrDefaultAsync<ReadStateRow?>();
+        var linkPreviewRows = (await multi.ReadAsync<MessageLinkPreviewRow>()).ToArray();
 
         var hasMore = rows.Length > limit;
         var pageRows = hasMore ? rows.Take(limit).ToArray() : rows;
@@ -298,6 +334,8 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
         var reactionsByMessageId = MessageRepositoryHelpers.BuildReactionsDictionary(
             reactionRows.Where(r => pageMessageIds.Contains(r.MessageId)),
             reactionUserRows.Where(r => pageMessageIds.Contains(r.MessageId)));
+        var linkPreviewsByMessageId = MessageRepositoryHelpers.BuildLinkPreviewsDictionary(
+            linkPreviewRows.Where(r => pageMessageIds.Contains(r.MessageId)));
 
         var items = pageRows
             .Select(row => MessageRepositoryHelpers.MapToMessage(row, attachmentsByMessageId))
@@ -323,7 +361,7 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
                 readStateRow.ReadAtUtc);
         }
 
-        return new MessagePage(items, nextCursor, reactionsByMessageId, lastReadState);
+        return new MessagePage(items, nextCursor, reactionsByMessageId, linkPreviewsByMessageId, lastReadState);
     }
 
     private sealed class ReadStateRow

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepositoryHelpers.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepositoryHelpers.cs
@@ -1,4 +1,5 @@
 using Dapper;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Channels;
@@ -137,5 +138,22 @@ internal static class MessageRepositoryHelpers
             row.UpdatedAtUtc,
             row.DeletedAtUtc,
             attachments);
+    }
+
+    internal static IReadOnlyDictionary<Guid, IReadOnlyList<LinkPreviewDto>> BuildLinkPreviewsDictionary(
+        IEnumerable<MessageLinkPreviewRow> rows)
+    {
+        return rows
+            .GroupBy(row => row.MessageId)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyList<LinkPreviewDto>)group
+                    .Select(row => new LinkPreviewDto(
+                        row.Url,
+                        row.Title,
+                        row.Description,
+                        row.ImageUrl,
+                        row.SiteName))
+                    .ToArray());
     }
 }

--- a/tests/Harmonie.Application.Tests/Messages/GetConversationMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetConversationMessagesHandlerTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Conversations.GetMessages;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
@@ -125,6 +126,51 @@ public sealed class GetConversationMessagesHandlerTests
         response.Data.Items[0].Reactions.Should().BeEmpty();
         response.Data.Items[1].Content.Should().Be("Second");
         response.Data.NextCursor.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenMessagesHaveLinkPreviews_ShouldIncludeThem()
+    {
+        var participantOne = UserId.New();
+        var participantTwo = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(participantOne, participantTwo);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+
+        var message = ApplicationTestBuilders.CreateConversationMessage(conversation.Id, participantTwo, content: "Check https://example.com", createdAtUtc: DateTime.UtcNow.AddMinutes(-1));
+
+        var previews = new Dictionary<Guid, IReadOnlyList<LinkPreviewDto>>
+        {
+            [message.Id.Value] = [new LinkPreviewDto("https://example.com", "Title", "Desc", null, "Site")]
+        };
+
+        _directMessageRepositoryMock
+            .Setup(x => x.GetConversationPageAsync(
+                conversation.Id,
+                It.IsAny<MessageCursor?>(),
+                50,
+                participantOne,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MessagePage(
+                [message],
+                null,
+                new Dictionary<Guid, IReadOnlyList<MessageReactionSummary>>(),
+                previews));
+
+        var response = await _handler.HandleAsync(
+            new GetConversationMessagesInput(conversation.Id, Limit: 50),
+            participantOne,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data.Should().NotBeNull();
+        response.Data!.Items.Should().HaveCount(1);
+        response.Data.Items[0].LinkPreviews.Should().NotBeNull();
+        response.Data.Items[0].LinkPreviews.Should().HaveCount(1);
+        response.Data.Items[0].LinkPreviews![0].Url.Should().Be("https://example.com");
+        response.Data.Items[0].LinkPreviews[0].Title.Should().Be("Title");
     }
 
 }

--- a/tests/Harmonie.Application.Tests/Messages/GetConversationMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetConversationMessagesHandlerTests.cs
@@ -18,16 +18,25 @@ public sealed class GetConversationMessagesHandlerTests
 {
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IMessagePaginationRepository> _directMessageRepositoryMock;
+    private readonly Mock<ILinkPreviewRepository> _linkPreviewRepositoryMock;
     private readonly GetMessagesHandler _handler;
 
     public GetConversationMessagesHandlerTests()
     {
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _directMessageRepositoryMock = new Mock<IMessagePaginationRepository>();
+        _linkPreviewRepositoryMock = new Mock<ILinkPreviewRepository>();
+
+        _linkPreviewRepositoryMock
+            .Setup(x => x.GetByMessageIdsAsync(
+                It.IsAny<IReadOnlyCollection<MessageId>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<MessageLinkPreview>());
 
         _handler = new GetMessagesHandler(
             _conversationRepositoryMock.Object,
-            _directMessageRepositoryMock.Object);
+            _directMessageRepositoryMock.Object,
+            _linkPreviewRepositoryMock.Object);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/GetConversationMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetConversationMessagesHandlerTests.cs
@@ -18,25 +18,16 @@ public sealed class GetConversationMessagesHandlerTests
 {
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IMessagePaginationRepository> _directMessageRepositoryMock;
-    private readonly Mock<ILinkPreviewRepository> _linkPreviewRepositoryMock;
     private readonly GetMessagesHandler _handler;
 
     public GetConversationMessagesHandlerTests()
     {
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _directMessageRepositoryMock = new Mock<IMessagePaginationRepository>();
-        _linkPreviewRepositoryMock = new Mock<ILinkPreviewRepository>();
-
-        _linkPreviewRepositoryMock
-            .Setup(x => x.GetByMessageIdsAsync(
-                It.IsAny<IReadOnlyCollection<MessageId>>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<MessageLinkPreview>());
 
         _handler = new GetMessagesHandler(
             _conversationRepositoryMock.Object,
-            _directMessageRepositoryMock.Object,
-            _linkPreviewRepositoryMock.Object);
+            _directMessageRepositoryMock.Object);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/GetMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetMessagesHandlerTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Channels.GetMessages;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Messages;
@@ -123,8 +124,55 @@ public sealed class GetMessagesHandlerTests
         response.Data.Items[0].Content.Should().Be("First");
         response.Data.Items[0].Attachments.Should().BeEmpty();
         response.Data.Items[0].Reactions.Should().BeEmpty();
+        response.Data.Items[0].LinkPreviews.Should().BeNull();
         response.Data.Items[1].Content.Should().Be("Second");
         response.Data.NextCursor.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenMessagesHaveLinkPreviews_ShouldIncludeThem()
+    {
+        var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Text);
+        var userId = UserId.New();
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(channel.Id, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
+
+        var message = ApplicationTestBuilders.CreateChannelMessage(channel.Id, userId, content: "Check https://example.com", createdAtUtc: DateTime.UtcNow.AddMinutes(-1));
+
+        var previews = new Dictionary<Guid, IReadOnlyList<LinkPreviewDto>>
+        {
+            [message.Id.Value] = [new LinkPreviewDto("https://example.com", "Example", "Description", null, "Example Site")]
+        };
+
+        _channelMessageRepositoryMock
+            .Setup(x => x.GetChannelPageAsync(
+                channel.Id,
+                It.IsAny<MessageCursor?>(),
+                50,
+                userId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MessagePage(
+                [message],
+                null,
+                new Dictionary<Guid, IReadOnlyList<MessageReactionSummary>>(),
+                previews));
+
+        var response = await _handler.HandleAsync(
+            new GetChannelMessagesInput(channel.Id, Limit: 50),
+            userId,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data.Should().NotBeNull();
+        response.Data!.Items.Should().HaveCount(1);
+        response.Data.Items[0].LinkPreviews.Should().NotBeNull();
+        response.Data.Items[0].LinkPreviews.Should().HaveCount(1);
+        response.Data.Items[0].LinkPreviews![0].Url.Should().Be("https://example.com");
+        response.Data.Items[0].LinkPreviews[0].Title.Should().Be("Example");
+        response.Data.Items[0].LinkPreviews[0].Description.Should().Be("Description");
+        response.Data.Items[0].LinkPreviews[0].SiteName.Should().Be("Example Site");
     }
 
 }

--- a/tests/Harmonie.Application.Tests/Messages/GetMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetMessagesHandlerTests.cs
@@ -20,16 +20,25 @@ public sealed class GetMessagesHandlerTests
 {
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IMessagePaginationRepository> _channelMessageRepositoryMock;
+    private readonly Mock<ILinkPreviewRepository> _linkPreviewRepositoryMock;
     private readonly GetMessagesHandler _handler;
 
     public GetMessagesHandlerTests()
     {
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
         _channelMessageRepositoryMock = new Mock<IMessagePaginationRepository>();
+        _linkPreviewRepositoryMock = new Mock<ILinkPreviewRepository>();
+
+        _linkPreviewRepositoryMock
+            .Setup(x => x.GetByMessageIdsAsync(
+                It.IsAny<IReadOnlyCollection<MessageId>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<MessageLinkPreview>());
 
         _handler = new GetMessagesHandler(
             _guildChannelRepositoryMock.Object,
-            _channelMessageRepositoryMock.Object);
+            _channelMessageRepositoryMock.Object,
+            _linkPreviewRepositoryMock.Object);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/GetMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetMessagesHandlerTests.cs
@@ -20,25 +20,16 @@ public sealed class GetMessagesHandlerTests
 {
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IMessagePaginationRepository> _channelMessageRepositoryMock;
-    private readonly Mock<ILinkPreviewRepository> _linkPreviewRepositoryMock;
     private readonly GetMessagesHandler _handler;
 
     public GetMessagesHandlerTests()
     {
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
         _channelMessageRepositoryMock = new Mock<IMessagePaginationRepository>();
-        _linkPreviewRepositoryMock = new Mock<ILinkPreviewRepository>();
-
-        _linkPreviewRepositoryMock
-            .Setup(x => x.GetByMessageIdsAsync(
-                It.IsAny<IReadOnlyCollection<MessageId>>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<MessageLinkPreview>());
 
         _handler = new GetMessagesHandler(
             _guildChannelRepositoryMock.Object,
-            _channelMessageRepositoryMock.Object,
-            _linkPreviewRepositoryMock.Object);
+            _channelMessageRepositoryMock.Object);
     }
 
     [Fact]


### PR DESCRIPTION
## What

Adds `LinkPreviews` field to `GetMessagesItemResponse` for both channel and conversation endpoints.

When fetching messages, the handler now queries `ILinkPreviewRepository.GetByMessageIdsAsync`
and maps the results into each message item. Returns `null` for messages without previews
(either no URL, or preview not yet resolved).

### Example response

```json
{
  "messageId": "...",
  "content": "Check https://example.com",
  "linkPreviews": [
    {
      "url": "https://example.com",
      "title": "Example Title",
      "description": "Example Description",
      "imageUrl": null,
      "siteName": "Example Site"
    }
  ]
}
```

Closes #356