### PR TITLE
feat(voice): add Screen Share support in voice channels

### DIFF
--- a/src/Harmonie.API/RealTime/Common/IRealtimeClient.cs
+++ b/src/Harmonie.API/RealTime/Common/IRealtimeClient.cs
@@ -32,6 +32,8 @@ public interface IRealtimeClient
     // Voice
     Task VoiceParticipantJoined(VoiceParticipantJoinedEvent payload, CancellationToken cancellationToken = default);
     Task VoiceParticipantLeft(VoiceParticipantLeftEvent payload, CancellationToken cancellationToken = default);
+    Task VoiceScreenShareStarted(VoiceScreenShareEvent payload, CancellationToken cancellationToken = default);
+    Task VoiceScreenShareStopped(VoiceScreenShareEvent payload, CancellationToken cancellationToken = default);
 
     // Guilds
     Task GuildDeleted(GuildDeletedEvent payload, CancellationToken cancellationToken = default);

--- a/src/Harmonie.API/RealTime/Voice/InMemoryVoiceParticipantCache.cs
+++ b/src/Harmonie.API/RealTime/Voice/InMemoryVoiceParticipantCache.cs
@@ -10,6 +10,7 @@ public sealed class InMemoryVoiceParticipantCache : IVoiceParticipantCache
     private static readonly TimeSpan ParticipantTtl = TimeSpan.FromHours(1);
 
     private readonly ConcurrentDictionary<Guid, ConcurrentDictionary<Guid, CachedEntry>> _channels = new();
+    private readonly ConcurrentDictionary<(Guid ChannelId, Guid UserId), ConcurrentDictionary<string, byte>> _screenShareTrackSids = new();
 
     public Task AddOrUpdateAsync(GuildChannelId channelId, CachedVoiceParticipant participant, CancellationToken cancellationToken = default)
     {
@@ -34,10 +35,66 @@ public sealed class InMemoryVoiceParticipantCache : IVoiceParticipantCache
         var now = DateTime.UtcNow;
         var result = channel.Values
             .Where(e => e.ExpiresAt > now)
-            .Select(e => e.Participant)
+            .Select(e =>
+            {
+                var isSharingScreen = _screenShareTrackSids.TryGetValue(
+                    (channelId.Value, e.Participant.UserId.Value), out var sids) && !sids.IsEmpty;
+
+                return e.Participant with { IsSharingScreen = isSharingScreen };
+            })
             .ToArray();
 
         return Task.FromResult<IReadOnlyList<CachedVoiceParticipant>>(result);
+    }
+
+    public Task<ScreenShareTrackAddResult> TryAddScreenShareTrackAsync(
+        GuildChannelId channelId,
+        UserId userId,
+        string trackSid,
+        CancellationToken cancellationToken = default)
+    {
+        var key = (channelId.Value, userId.Value);
+        var sids = _screenShareTrackSids.GetOrAdd(key, _ => new ConcurrentDictionary<string, byte>());
+        var wasEmpty = sids.IsEmpty;
+        sids[trackSid] = 0;
+        var isFirst = wasEmpty && sids.Count > 0;
+        var isSharingScreen = sids.Count > 0;
+
+        return Task.FromResult(new ScreenShareTrackAddResult(isFirst, isSharingScreen));
+    }
+
+    public Task<ScreenShareTrackRemoveResult> TryRemoveScreenShareTrackAsync(
+        GuildChannelId channelId,
+        UserId userId,
+        string trackSid,
+        CancellationToken cancellationToken = default)
+    {
+        var key = (channelId.Value, userId.Value);
+        if (_screenShareTrackSids.TryGetValue(key, out var sids))
+        {
+            sids.TryRemove(trackSid, out _);
+        }
+
+        var isSharingScreen = sids is not null && !sids.IsEmpty;
+        var wasPresentAndNowEmpty = sids is not null && sids.IsEmpty;
+
+        // Clean up empty sets to prevent memory leaks
+        if (wasPresentAndNowEmpty)
+            _screenShareTrackSids.TryRemove(key, out _);
+
+        return Task.FromResult(new ScreenShareTrackRemoveResult(wasPresentAndNowEmpty, isSharingScreen));
+    }
+
+    public Task<bool> ClearScreenShareTracksAsync(
+        GuildChannelId channelId,
+        UserId userId,
+        CancellationToken cancellationToken = default)
+    {
+        var key = (channelId.Value, userId.Value);
+        if (_screenShareTrackSids.TryRemove(key, out var sids))
+            return Task.FromResult(!sids.IsEmpty);
+
+        return Task.FromResult(false);
     }
 
     private sealed record CachedEntry(CachedVoiceParticipant Participant, DateTime ExpiresAt);

--- a/src/Harmonie.API/RealTime/Voice/InMemoryVoiceParticipantCache.cs
+++ b/src/Harmonie.API/RealTime/Voice/InMemoryVoiceParticipantCache.cs
@@ -55,12 +55,15 @@ public sealed class InMemoryVoiceParticipantCache : IVoiceParticipantCache
     {
         var key = (channelId.Value, userId.Value);
         var sids = _screenShareTrackSids.GetOrAdd(key, _ => new ConcurrentDictionary<string, byte>());
-        var wasEmpty = sids.IsEmpty;
-        sids[trackSid] = 0;
-        var isFirst = wasEmpty && sids.Count > 0;
-        var isSharingScreen = sids.Count > 0;
+        bool isFirst;
+        lock (sids)
+        {
+            var wasEmpty = sids.IsEmpty;
+            sids[trackSid] = 0;
+            isFirst = wasEmpty;
+        }
 
-        return Task.FromResult(new ScreenShareTrackAddResult(isFirst, isSharingScreen));
+        return Task.FromResult(new ScreenShareTrackAddResult(isFirst));
     }
 
     public Task<ScreenShareTrackRemoveResult> TryRemoveScreenShareTrackAsync(
@@ -75,14 +78,13 @@ public sealed class InMemoryVoiceParticipantCache : IVoiceParticipantCache
             sids.TryRemove(trackSid, out _);
         }
 
-        var isSharingScreen = sids is not null && !sids.IsEmpty;
         var wasPresentAndNowEmpty = sids is not null && sids.IsEmpty;
 
         // Clean up empty sets to prevent memory leaks
         if (wasPresentAndNowEmpty)
             _screenShareTrackSids.TryRemove(key, out _);
 
-        return Task.FromResult(new ScreenShareTrackRemoveResult(wasPresentAndNowEmpty, isSharingScreen));
+        return Task.FromResult(new ScreenShareTrackRemoveResult(wasPresentAndNowEmpty));
     }
 
     public Task<bool> ClearScreenShareTracksAsync(

--- a/src/Harmonie.API/RealTime/Voice/SignalRVoicePresenceNotifier.cs
+++ b/src/Harmonie.API/RealTime/Voice/SignalRVoicePresenceNotifier.cs
@@ -53,6 +53,42 @@ public sealed class SignalRVoicePresenceNotifier : IVoicePresenceNotifier
             .Group(RealtimeHub.GetGuildGroupName(notification.GuildId))
             .VoiceParticipantLeft(payload, cancellationToken);
     }
+
+    public async Task NotifyScreenShareStartedAsync(
+        VoiceScreenShareNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var payload = new VoiceScreenShareEvent(
+            GuildId: notification.GuildId.Value,
+            ChannelId: notification.ChannelId.Value,
+            UserId: notification.UserId.Value,
+            Username: notification.Username,
+            TimestampUtc: notification.TimestampUtc);
+
+        await _hubContext.Clients
+            .Group(RealtimeHub.GetGuildGroupName(notification.GuildId))
+            .VoiceScreenShareStarted(payload, cancellationToken);
+    }
+
+    public async Task NotifyScreenShareStoppedAsync(
+        VoiceScreenShareNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var payload = new VoiceScreenShareEvent(
+            GuildId: notification.GuildId.Value,
+            ChannelId: notification.ChannelId.Value,
+            UserId: notification.UserId.Value,
+            Username: notification.Username,
+            TimestampUtc: notification.TimestampUtc);
+
+        await _hubContext.Clients
+            .Group(RealtimeHub.GetGuildGroupName(notification.GuildId))
+            .VoiceScreenShareStopped(payload, cancellationToken);
+    }
 }
 
 public sealed record VoiceParticipantJoinedEvent(
@@ -73,3 +109,10 @@ public sealed record VoiceParticipantLeftEvent(
     Guid UserId,
     string? Username,
     DateTime LeftAtUtc);
+
+public sealed record VoiceScreenShareEvent(
+    Guid GuildId,
+    Guid ChannelId,
+    Guid UserId,
+    string? Username,
+    DateTime TimestampUtc);

--- a/src/Harmonie.Application/Features/Channels/JoinVoiceChannel/JoinVoiceChannelHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/JoinVoiceChannel/JoinVoiceChannelHandler.cs
@@ -108,9 +108,7 @@ public sealed class JoinVoiceChannelHandler : IAuthenticatedHandler<GuildChannel
 
             if (cachedById.TryGetValue(lkParticipant.UserId.Value, out var existing))
             {
-                cached = existing.IsSharingScreen != lkParticipant.IsSharingScreen
-                    ? existing with { IsSharingScreen = lkParticipant.IsSharingScreen }
-                    : existing;
+                cached = existing;
             }
             else if (fetchedById.TryGetValue(lkParticipant.UserId.Value, out var dbUser))
             {
@@ -121,8 +119,7 @@ public sealed class JoinVoiceChannelHandler : IAuthenticatedHandler<GuildChannel
                     AvatarFileId: dbUser.AvatarFileId,
                     AvatarColor: dbUser.AvatarColor,
                     AvatarIcon: dbUser.AvatarIcon,
-                    AvatarBg: dbUser.AvatarBg,
-                    IsSharingScreen: lkParticipant.IsSharingScreen);
+                    AvatarBg: dbUser.AvatarBg);
             }
             else
             {
@@ -133,12 +130,12 @@ public sealed class JoinVoiceChannelHandler : IAuthenticatedHandler<GuildChannel
                     AvatarFileId: null,
                     AvatarColor: null,
                     AvatarIcon: null,
-                    AvatarBg: null,
-                    IsSharingScreen: lkParticipant.IsSharingScreen);
+                    AvatarBg: null);
             }
 
             await _voiceParticipantCache.AddOrUpdateAsync(request, cached, cancellationToken);
-            reconciledParticipants.Add(cached);
+            // IsSharingScreen is derived from the SID set in cache; use LiveKit state for the immediate response.
+            reconciledParticipants.Add(cached with { IsSharingScreen = lkParticipant.IsSharingScreen });
         }
 
         foreach (var stale in cachedParticipants.Where(p => !liveKitIds.Contains(p.UserId.Value)))

--- a/src/Harmonie.Application/Features/Channels/JoinVoiceChannel/JoinVoiceChannelHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/JoinVoiceChannel/JoinVoiceChannelHandler.cs
@@ -108,7 +108,9 @@ public sealed class JoinVoiceChannelHandler : IAuthenticatedHandler<GuildChannel
 
             if (cachedById.TryGetValue(lkParticipant.UserId.Value, out var existing))
             {
-                cached = existing;
+                cached = existing.IsSharingScreen != lkParticipant.IsSharingScreen
+                    ? existing with { IsSharingScreen = lkParticipant.IsSharingScreen }
+                    : existing;
             }
             else if (fetchedById.TryGetValue(lkParticipant.UserId.Value, out var dbUser))
             {
@@ -119,7 +121,8 @@ public sealed class JoinVoiceChannelHandler : IAuthenticatedHandler<GuildChannel
                     AvatarFileId: dbUser.AvatarFileId,
                     AvatarColor: dbUser.AvatarColor,
                     AvatarIcon: dbUser.AvatarIcon,
-                    AvatarBg: dbUser.AvatarBg);
+                    AvatarBg: dbUser.AvatarBg,
+                    IsSharingScreen: lkParticipant.IsSharingScreen);
             }
             else
             {
@@ -130,7 +133,8 @@ public sealed class JoinVoiceChannelHandler : IAuthenticatedHandler<GuildChannel
                     AvatarFileId: null,
                     AvatarColor: null,
                     AvatarIcon: null,
-                    AvatarBg: null);
+                    AvatarBg: null,
+                    IsSharingScreen: lkParticipant.IsSharingScreen);
             }
 
             await _voiceParticipantCache.AddOrUpdateAsync(request, cached, cancellationToken);
@@ -148,7 +152,8 @@ public sealed class JoinVoiceChannelHandler : IAuthenticatedHandler<GuildChannel
                 AvatarFileId: p.AvatarFileId?.Value,
                 AvatarColor: p.AvatarColor,
                 AvatarIcon: p.AvatarIcon,
-                AvatarBg: p.AvatarBg))
+                AvatarBg: p.AvatarBg,
+                IsSharingScreen: p.IsSharingScreen))
             .ToArray();
 
         var payload = new JoinVoiceChannelResponse(

--- a/src/Harmonie.Application/Features/Channels/JoinVoiceChannel/JoinVoiceChannelResponse.cs
+++ b/src/Harmonie.Application/Features/Channels/JoinVoiceChannel/JoinVoiceChannelResponse.cs
@@ -13,4 +13,5 @@ public sealed record JoinVoiceChannelParticipantResponse(
     Guid? AvatarFileId,
     string? AvatarColor,
     string? AvatarIcon,
-    string? AvatarBg);
+    string? AvatarBg,
+    bool IsSharingScreen = false);

--- a/src/Harmonie.Application/Features/Guilds/GetGuildVoiceParticipants/GetGuildVoiceParticipantsHandler.cs
+++ b/src/Harmonie.Application/Features/Guilds/GetGuildVoiceParticipants/GetGuildVoiceParticipantsHandler.cs
@@ -65,7 +65,8 @@ public sealed class GetGuildVoiceParticipantsHandler : IAuthenticatedHandler<Gui
                                 Username: participant.Username,
                                 DisplayName: member?.DisplayName,
                                 AvatarFileId: member?.AvatarFileId?.Value,
-                                Avatar: avatar);
+                                Avatar: avatar,
+                                IsSharingScreen: participant.IsSharingScreen);
                         })
                         .ToArray()))
                 .ToArray());

--- a/src/Harmonie.Application/Features/Guilds/GetGuildVoiceParticipants/GetGuildVoiceParticipantsResponse.cs
+++ b/src/Harmonie.Application/Features/Guilds/GetGuildVoiceParticipants/GetGuildVoiceParticipantsResponse.cs
@@ -14,4 +14,5 @@ public sealed record GetGuildVoiceParticipantResponse(
     string Username,
     string? DisplayName,
     Guid? AvatarFileId,
-    AvatarAppearanceDto? Avatar);
+    AvatarAppearanceDto? Avatar,
+    bool IsSharingScreen = false);

--- a/src/Harmonie.Application/Features/Voice/HandleLiveKitWebhook/HandleLiveKitWebhookHandler.cs
+++ b/src/Harmonie.Application/Features/Voice/HandleLiveKitWebhook/HandleLiveKitWebhookHandler.cs
@@ -45,13 +45,14 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
                 "LiveKit webhook signature is invalid.");
         }
 
-        if (receiveResult.Event is not { } webhookEvent)
+        if (receiveResult.Event is null)
         {
             return ApplicationResponse<HandleLiveKitWebhookResponse>.Fail(
                 ApplicationErrorCodes.Common.InvalidState,
                 "LiveKit webhook receiver returned success without an event.");
         }
 
+        var webhookEvent = receiveResult.Event;
         var eventType = string.IsNullOrWhiteSpace(webhookEvent.EventType)
             ? "unknown"
             : webhookEvent.EventType;
@@ -184,8 +185,10 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
         LiveKitWebhookEvent webhookEvent,
         CancellationToken ct)
     {
-        if (webhookEvent.Track is not { } track)
+        if (webhookEvent.Track is null)
             return;
+
+        var track = webhookEvent.Track;
 
         // Only process ScreenShare tracks. Ignore SCREEN_SHARE_AUDIO, CAMERA, MICROPHONE.
         if (track.Source != ScreenShareSource)

--- a/src/Harmonie.Application/Features/Voice/HandleLiveKitWebhook/HandleLiveKitWebhookHandler.cs
+++ b/src/Harmonie.Application/Features/Voice/HandleLiveKitWebhook/HandleLiveKitWebhookHandler.cs
@@ -11,7 +11,10 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
 {
     private const string ParticipantJoinedEvent = "participant_joined";
     private const string ParticipantLeftEvent = "participant_left";
+    private const string TrackPublishedEvent = "track_published";
+    private const string TrackUnpublishedEvent = "track_unpublished";
     private const string ChannelRoomPrefix = "channel:";
+    private const string ScreenShareSource = "SCREEN_SHARE";
 
     private readonly ILiveKitWebhookReceiver _webhookReceiver;
     private readonly IGuildChannelRepository _guildChannelRepository;
@@ -53,7 +56,10 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
             ? "unknown"
             : webhookEvent.EventType;
 
-        if (eventType is not ParticipantJoinedEvent and not ParticipantLeftEvent)
+        if (eventType is not ParticipantJoinedEvent
+            and not ParticipantLeftEvent
+            and not TrackPublishedEvent
+            and not TrackUnpublishedEvent)
         {
             return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(false, eventType));
         }
@@ -81,44 +87,18 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
 
         if (eventType == ParticipantJoinedEvent)
         {
-            await _voiceParticipantCache.AddOrUpdateAsync(
-                result.Channel.Id,
-                new CachedVoiceParticipant(
-                    UserId: participantUserId,
-                    Username: result.Participant?.Username.Value,
-                    DisplayName: result.Participant?.DisplayName,
-                    AvatarFileId: result.Participant?.AvatarFileId,
-                    AvatarColor: result.Participant?.AvatarColor,
-                    AvatarIcon: result.Participant?.AvatarIcon,
-                    AvatarBg: result.Participant?.AvatarBg),
-                cancellationToken);
-
-            await _voicePresenceNotifier.NotifyParticipantJoinedAsync(
-                new VoiceParticipantJoinedNotification(
-                    GuildId: result.Channel.GuildId,
-                    ChannelId: result.Channel.Id,
-                    UserId: participantUserId,
-                    Username: result.Participant?.Username.Value,
-                    DisplayName: result.Participant?.DisplayName,
-                    AvatarFileId: result.Participant?.AvatarFileId,
-                    AvatarColor: result.Participant?.AvatarColor,
-                    AvatarIcon: result.Participant?.AvatarIcon,
-                    AvatarBg: result.Participant?.AvatarBg,
-                    JoinedAtUtc: webhookEvent.OccurredAtUtc),
-                cancellationToken);
+            await HandleParticipantJoinedAsync(
+                result, participantUserId, webhookEvent.OccurredAtUtc, cancellationToken);
         }
-        else
+        else if (eventType == ParticipantLeftEvent)
         {
-            await _voiceParticipantCache.RemoveAsync(result.Channel.Id, participantUserId, cancellationToken);
-
-            await _voicePresenceNotifier.NotifyParticipantLeftAsync(
-                new VoiceParticipantLeftNotification(
-                    result.Channel.GuildId,
-                    result.Channel.Id,
-                    participantUserId,
-                    result.Participant?.Username.Value,
-                    webhookEvent.OccurredAtUtc),
-                cancellationToken);
+            await HandleParticipantLeftAsync(
+                result, participantUserId, webhookEvent.OccurredAtUtc, cancellationToken);
+        }
+        else if (eventType is TrackPublishedEvent or TrackUnpublishedEvent)
+        {
+            await HandleTrackEventAsync(
+                eventType, result, participantUserId, webhookEvent, cancellationToken);
         }
 
         return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(true, eventType));
@@ -139,6 +119,108 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
             return false;
 
         return true;
+    }
+
+    private async Task HandleParticipantJoinedAsync(
+        ChannelWithParticipant result,
+        UserId participantUserId,
+        DateTime occurredAtUtc,
+        CancellationToken ct)
+    {
+        await _voiceParticipantCache.AddOrUpdateAsync(
+            result.Channel.Id,
+            new CachedVoiceParticipant(
+                UserId: participantUserId,
+                Username: result.Participant?.Username.Value,
+                DisplayName: result.Participant?.DisplayName,
+                AvatarFileId: result.Participant?.AvatarFileId,
+                AvatarColor: result.Participant?.AvatarColor,
+                AvatarIcon: result.Participant?.AvatarIcon,
+                AvatarBg: result.Participant?.AvatarBg),
+            ct);
+
+        await _voicePresenceNotifier.NotifyParticipantJoinedAsync(
+            new VoiceParticipantJoinedNotification(
+                GuildId: result.Channel.GuildId,
+                ChannelId: result.Channel.Id,
+                UserId: participantUserId,
+                Username: result.Participant?.Username.Value,
+                DisplayName: result.Participant?.DisplayName,
+                AvatarFileId: result.Participant?.AvatarFileId,
+                AvatarColor: result.Participant?.AvatarColor,
+                AvatarIcon: result.Participant?.AvatarIcon,
+                AvatarBg: result.Participant?.AvatarBg,
+                JoinedAtUtc: occurredAtUtc),
+            ct);
+    }
+
+    private async Task HandleParticipantLeftAsync(
+        ChannelWithParticipant result,
+        UserId participantUserId,
+        DateTime occurredAtUtc,
+        CancellationToken ct)
+    {
+        // Clear screen share tracks for safety (LiveKit sends track_unpublished before participant_left,
+        // but we clean up here as a safety net).
+        await _voiceParticipantCache.ClearScreenShareTracksAsync(
+            result.Channel.Id, participantUserId, ct);
+
+        await _voiceParticipantCache.RemoveAsync(result.Channel.Id, participantUserId, ct);
+
+        await _voicePresenceNotifier.NotifyParticipantLeftAsync(
+            new VoiceParticipantLeftNotification(
+                result.Channel.GuildId,
+                result.Channel.Id,
+                participantUserId,
+                result.Participant?.Username.Value,
+                occurredAtUtc),
+            ct);
+    }
+
+    private async Task HandleTrackEventAsync(
+        string eventType,
+        ChannelWithParticipant result,
+        UserId participantUserId,
+        LiveKitWebhookEvent webhookEvent,
+        CancellationToken ct)
+    {
+        if (webhookEvent.Track is not { } track)
+            return;
+
+        // Only process ScreenShare tracks. Ignore SCREEN_SHARE_AUDIO, CAMERA, MICROPHONE.
+        if (track.Source != ScreenShareSource)
+            return;
+
+        var guildId = result.Channel.GuildId;
+        var channelId = result.Channel.Id;
+        var username = result.Participant?.Username.Value;
+
+        if (eventType == TrackPublishedEvent)
+        {
+            var addResult = await _voiceParticipantCache.TryAddScreenShareTrackAsync(
+                channelId, participantUserId, track.Sid, ct);
+
+            if (addResult.IsFirst)
+            {
+                await _voicePresenceNotifier.NotifyScreenShareStartedAsync(
+                    new VoiceScreenShareNotification(
+                        guildId, channelId, participantUserId, username, webhookEvent.OccurredAtUtc),
+                    ct);
+            }
+        }
+        else if (eventType == TrackUnpublishedEvent)
+        {
+            var removeResult = await _voiceParticipantCache.TryRemoveScreenShareTrackAsync(
+                channelId, participantUserId, track.Sid, ct);
+
+            if (removeResult.IsLast)
+            {
+                await _voicePresenceNotifier.NotifyScreenShareStoppedAsync(
+                    new VoiceScreenShareNotification(
+                        guildId, channelId, participantUserId, username, webhookEvent.OccurredAtUtc),
+                    ct);
+            }
+        }
     }
 
     private static bool TryParseUserId(string? participantIdentity, out UserId? userId)

--- a/src/Harmonie.Application/Interfaces/Voice/ILiveKitRoomService.cs
+++ b/src/Harmonie.Application/Interfaces/Voice/ILiveKitRoomService.cs
@@ -21,4 +21,5 @@ public sealed record GuildVoiceChannelParticipants(
 
 public sealed record VoiceChannelParticipant(
     UserId UserId,
-    string Username);
+    string Username,
+    bool IsSharingScreen = false);

--- a/src/Harmonie.Application/Interfaces/Voice/ILiveKitWebhookReceiver.cs
+++ b/src/Harmonie.Application/Interfaces/Voice/ILiveKitWebhookReceiver.cs
@@ -24,4 +24,13 @@ public sealed record LiveKitWebhookEvent(
     string? RoomName,
     string? ParticipantIdentity,
     string? ParticipantName,
-    DateTime OccurredAtUtc);
+    DateTime OccurredAtUtc,
+    LiveKitTrackInfo? Track = null);
+
+public sealed record LiveKitTrackInfo(
+    string Sid,
+    string Source,
+    string Type,
+    bool Muted,
+    uint Width,
+    uint Height);

--- a/src/Harmonie.Application/Interfaces/Voice/IVoiceParticipantCache.cs
+++ b/src/Harmonie.Application/Interfaces/Voice/IVoiceParticipantCache.cs
@@ -42,13 +42,9 @@ public interface IVoiceParticipantCache
         CancellationToken cancellationToken = default);
 }
 
-public sealed record ScreenShareTrackAddResult(
-    bool IsFirst,
-    bool IsSharingScreen);
+public sealed record ScreenShareTrackAddResult(bool IsFirst);
 
-public sealed record ScreenShareTrackRemoveResult(
-    bool IsLast,
-    bool IsSharingScreen);
+public sealed record ScreenShareTrackRemoveResult(bool IsLast);
 
 public sealed record CachedVoiceParticipant(
     UserId UserId,

--- a/src/Harmonie.Application/Interfaces/Voice/IVoiceParticipantCache.cs
+++ b/src/Harmonie.Application/Interfaces/Voice/IVoiceParticipantCache.cs
@@ -11,7 +11,44 @@ public interface IVoiceParticipantCache
     Task RemoveAsync(GuildChannelId channelId, UserId userId, CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<CachedVoiceParticipant>> GetAsync(GuildChannelId channelId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds a ScreenShare track SID for a participant. Returns true if this is the first
+    /// active screen share track for the participant (i.e., the set transitioned from empty to non-empty).
+    /// </summary>
+    Task<ScreenShareTrackAddResult> TryAddScreenShareTrackAsync(
+        GuildChannelId channelId,
+        UserId userId,
+        string trackSid,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a ScreenShare track SID for a participant. Returns true if this was the last
+    /// active screen share track for the participant (i.e., the set transitioned from non-empty to empty).
+    /// </summary>
+    Task<ScreenShareTrackRemoveResult> TryRemoveScreenShareTrackAsync(
+        GuildChannelId channelId,
+        UserId userId,
+        string trackSid,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Clears all ScreenShare track SIDs for a participant (e.g., on participant_left).
+    /// Returns true if there were any active tracks to clear.
+    /// </summary>
+    Task<bool> ClearScreenShareTracksAsync(
+        GuildChannelId channelId,
+        UserId userId,
+        CancellationToken cancellationToken = default);
 }
+
+public sealed record ScreenShareTrackAddResult(
+    bool IsFirst,
+    bool IsSharingScreen);
+
+public sealed record ScreenShareTrackRemoveResult(
+    bool IsLast,
+    bool IsSharingScreen);
 
 public sealed record CachedVoiceParticipant(
     UserId UserId,
@@ -20,4 +57,5 @@ public sealed record CachedVoiceParticipant(
     UploadedFileId? AvatarFileId,
     string? AvatarColor,
     string? AvatarIcon,
-    string? AvatarBg);
+    string? AvatarBg,
+    bool IsSharingScreen = false);

--- a/src/Harmonie.Application/Interfaces/Voice/IVoicePresenceNotifier.cs
+++ b/src/Harmonie.Application/Interfaces/Voice/IVoicePresenceNotifier.cs
@@ -14,6 +14,14 @@ public interface IVoicePresenceNotifier
     Task NotifyParticipantLeftAsync(
         VoiceParticipantLeftNotification notification,
         CancellationToken cancellationToken = default);
+
+    Task NotifyScreenShareStartedAsync(
+        VoiceScreenShareNotification notification,
+        CancellationToken cancellationToken = default);
+
+    Task NotifyScreenShareStoppedAsync(
+        VoiceScreenShareNotification notification,
+        CancellationToken cancellationToken = default);
 }
 
 public sealed record VoiceParticipantJoinedNotification(
@@ -34,3 +42,10 @@ public sealed record VoiceParticipantLeftNotification(
     UserId UserId,
     string? Username,
     DateTime LeftAtUtc);
+
+public sealed record VoiceScreenShareNotification(
+    GuildId GuildId,
+    GuildChannelId ChannelId,
+    UserId UserId,
+    string? Username,
+    DateTime TimestampUtc);

--- a/src/Harmonie.Infrastructure/LiveKit/LiveKitRoomService.cs
+++ b/src/Harmonie.Infrastructure/LiveKit/LiveKitRoomService.cs
@@ -4,6 +4,7 @@ using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Users;
+using Livekit.Server.Sdk.Dotnet;
 using Microsoft.Extensions.Logging;
 
 namespace Harmonie.Infrastructure.LiveKit;
@@ -71,7 +72,7 @@ public sealed class LiveKitRoomService : ILiveKitRoomService
             }
 
             var mappedParticipants = participants
-                .Select(participant => TryMapParticipant(participant.Identity, participant.Name))
+                .Select(TryMapParticipant)
                 .OfType<VoiceChannelParticipant>()
                 .ToArray();
 
@@ -91,8 +92,11 @@ public sealed class LiveKitRoomService : ILiveKitRoomService
         return channels;
     }
 
-    private VoiceChannelParticipant? TryMapParticipant(string? identity, string? name)
+    private VoiceChannelParticipant? TryMapParticipant(ParticipantInfo participant)
     {
+        var identity = participant.Identity;
+        var name = participant.Name;
+
         if (string.IsNullOrWhiteSpace(identity)
             || !UserId.TryParse(identity, out var userId)
             || userId is null)
@@ -104,7 +108,10 @@ public sealed class LiveKitRoomService : ILiveKitRoomService
         }
 
         var username = string.IsNullOrWhiteSpace(name) ? identity : name;
-        return new VoiceChannelParticipant(userId, username);
+        var isSharingScreen = participant.Tracks
+            .Any(t => t.Source == TrackSource.ScreenShare);
+
+        return new VoiceChannelParticipant(userId, username, isSharingScreen);
     }
 
     public async Task<IReadOnlyList<VoiceChannelParticipant>> ListChannelParticipantsAsync(
@@ -115,7 +122,7 @@ public sealed class LiveKitRoomService : ILiveKitRoomService
         var participants = await _roomApiClient.ListParticipantsAsync(roomName, ct);
 
         return participants
-            .Select(p => TryMapParticipant(p.Identity, p.Name))
+            .Select(TryMapParticipant)
             .OfType<VoiceChannelParticipant>()
             .ToArray();
     }

--- a/src/Harmonie.Infrastructure/LiveKit/LiveKitWebhookReceiver.cs
+++ b/src/Harmonie.Infrastructure/LiveKit/LiveKitWebhookReceiver.cs
@@ -63,15 +63,15 @@ public sealed class LiveKitWebhookReceiver : ILiveKitWebhookReceiver
                 : DateTime.UnixEpoch;
 
             LiveKitTrackInfo? track = null;
-            if (webhookEvent.Track is { } webhookTrack)
+            if (webhookEvent.Track is not null)
             {
                 track = new LiveKitTrackInfo(
-                    Sid: webhookTrack.Sid,
-                    Source: MapTrackSourceToString(webhookTrack.Source),
-                    Type: MapTrackTypeToString(webhookTrack.Type),
-                    Muted: webhookTrack.Muted,
-                    Width: webhookTrack.Width,
-                    Height: webhookTrack.Height);
+                    Sid: webhookEvent.Track.Sid,
+                    Source: MapTrackSourceToString(webhookEvent.Track.Source),
+                    Type: MapTrackTypeToString(webhookEvent.Track.Type),
+                    Muted: webhookEvent.Track.Muted,
+                    Width: webhookEvent.Track.Width,
+                    Height: webhookEvent.Track.Height);
             }
 
             return LiveKitWebhookReceiveResult.Ok(

--- a/src/Harmonie.Infrastructure/LiveKit/LiveKitWebhookReceiver.cs
+++ b/src/Harmonie.Infrastructure/LiveKit/LiveKitWebhookReceiver.cs
@@ -62,18 +62,54 @@ public sealed class LiveKitWebhookReceiver : ILiveKitWebhookReceiver
                 ? DateTimeOffset.FromUnixTimeSeconds(webhookEvent.CreatedAt).UtcDateTime
                 : DateTime.UnixEpoch;
 
+            LiveKitTrackInfo? track = null;
+            if (webhookEvent.Track is { } webhookTrack)
+            {
+                track = new LiveKitTrackInfo(
+                    Sid: webhookTrack.Sid,
+                    Source: MapTrackSourceToString(webhookTrack.Source),
+                    Type: MapTrackTypeToString(webhookTrack.Type),
+                    Muted: webhookTrack.Muted,
+                    Width: webhookTrack.Width,
+                    Height: webhookTrack.Height);
+            }
+
             return LiveKitWebhookReceiveResult.Ok(
                 new LiveKitWebhookEvent(
                     webhookEvent.Event,
                     roomName,
                     participantIdentity,
                     participantName,
-                    occurredAtUtc));
+                    occurredAtUtc,
+                    track));
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "LiveKit webhook validation failed.");
             return LiveKitWebhookReceiveResult.Fail("LiveKit webhook validation failed.");
         }
+    }
+
+    private static string MapTrackSourceToString(TrackSource source)
+    {
+        return source switch
+        {
+            TrackSource.Camera => "CAMERA",
+            TrackSource.Microphone => "MICROPHONE",
+            TrackSource.ScreenShare => "SCREEN_SHARE",
+            TrackSource.ScreenShareAudio => "SCREEN_SHARE_AUDIO",
+            _ => source.ToString().ToUpperInvariant()
+        };
+    }
+
+    private static string MapTrackTypeToString(TrackType type)
+    {
+        return type switch
+        {
+            TrackType.Audio => "AUDIO",
+            TrackType.Video => "VIDEO",
+            TrackType.Data => "DATA",
+            _ => type.ToString().ToUpperInvariant()
+        };
     }
 }

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRVoicePresenceHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRVoicePresenceHubTests.cs
@@ -191,6 +191,153 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
             }
             """;
 
+    private static string CreateTrackWebhookBody(
+        string eventType,
+        string channelId,
+        string userId,
+        string participantName,
+        string trackSid,
+        int trackSource,
+        int trackType)
+        => $$"""
+            {
+              "event": "{{eventType}}",
+              "room": {
+                "name": "channel:{{channelId}}"
+              },
+              "participant": {
+                "identity": "{{userId}}",
+                "name": "{{participantName}}"
+              },
+              "track": {
+                "sid": "{{trackSid}}",
+                "source": {{trackSource}},
+                "type": {{trackType}},
+                "muted": false,
+                "width": 1920,
+                "height": 1080
+              },
+              "createdAt": "{{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}}"
+            }
+            """;
+
+    [Fact]
+    public async Task VoiceScreenShareStarted_WhenTrackPublished_ShouldReceiveEvent()
+    {
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var member = await AuthTestHelper.RegisterAsync(_client);
+        var guildId = await CreateGuildAndInviteMemberAsync(owner, member);
+        var voiceChannelId = await GetVoiceChannelIdAsync(guildId, member.AccessToken);
+
+        await using var connection = CreateHubConnection(member.AccessToken);
+        var eventReceived = new TaskCompletionSource<SignalRVoiceScreenShareEvent>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        connection.On<SignalRVoiceScreenShareEvent>("VoiceScreenShareStarted", payload =>
+        {
+            eventReceived.TrySetResult(payload);
+        });
+
+        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.On("Ready", () => ready.TrySetResult());
+
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        // ScreenShare source = 3 in LiveKit proto enum
+        var webhookResponse = await SendLiveKitWebhookAsync(
+            CreateTrackWebhookBody(
+                "track_published",
+                voiceChannelId.ToString(),
+                member.UserId.ToString(),
+                member.Username,
+                "TR_screen001",
+                trackSource: 3,
+                trackType: 1));
+        webhookResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var completedTask = await Task.WhenAny(eventReceived.Task, Task.Delay(Timeout.InfiniteTimeSpan, timeout.Token));
+        completedTask.Should().Be(eventReceived.Task);
+
+        var eventPayload = await eventReceived.Task;
+        eventPayload.GuildId.Should().Be(guildId.ToString());
+        eventPayload.ChannelId.Should().Be(voiceChannelId.ToString());
+        eventPayload.UserId.Should().Be(member.UserId.ToString());
+        eventPayload.Username.Should().Be(member.Username);
+        eventPayload.TimestampUtc.Should().NotBe(default);
+    }
+
+    [Fact]
+    public async Task VoiceScreenShareStopped_WhenTrackUnpublished_ShouldReceiveEvent()
+    {
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var member = await AuthTestHelper.RegisterAsync(_client);
+        var guildId = await CreateGuildAndInviteMemberAsync(owner, member);
+        var voiceChannelId = await GetVoiceChannelIdAsync(guildId, member.AccessToken);
+
+        await using var connection = CreateHubConnection(member.AccessToken);
+
+        // First publish a track
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.On("Ready", () => ready.TrySetResult());
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        await SendLiveKitWebhookAsync(
+            CreateTrackWebhookBody(
+                "track_published",
+                voiceChannelId.ToString(),
+                member.UserId.ToString(),
+                member.Username,
+                "TR_screen002",
+                trackSource: 3,
+                trackType: 1));
+
+        // Wait a moment for the track_published to be processed
+        await Task.Delay(500, TestContext.Current.CancellationToken);
+
+        await connection.DisposeAsync();
+
+        // Reconnect to capture the Stopped event
+        await using var connection2 = CreateHubConnection(member.AccessToken);
+        var stoppedEvent = new TaskCompletionSource<SignalRVoiceScreenShareEvent>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        connection2.On<SignalRVoiceScreenShareEvent>("VoiceScreenShareStopped", payload =>
+        {
+            stoppedEvent.TrySetResult(payload);
+        });
+
+        var ready2 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        connection2.On("Ready", () => ready2.TrySetResult());
+
+        await connection2.StartAsync(TestContext.Current.CancellationToken);
+        await ready2.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        var webhookResponse = await SendLiveKitWebhookAsync(
+            CreateTrackWebhookBody(
+                "track_unpublished",
+                voiceChannelId.ToString(),
+                member.UserId.ToString(),
+                member.Username,
+                "TR_screen002",
+                trackSource: 3,
+                trackType: 1));
+        webhookResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var completedTask = await Task.WhenAny(stoppedEvent.Task, Task.Delay(Timeout.InfiniteTimeSpan, timeout.Token));
+        completedTask.Should().Be(stoppedEvent.Task);
+
+        var eventPayload = await stoppedEvent.Task;
+        eventPayload.GuildId.Should().Be(guildId.ToString());
+        eventPayload.ChannelId.Should().Be(voiceChannelId.ToString());
+        eventPayload.UserId.Should().Be(member.UserId.ToString());
+        eventPayload.Username.Should().Be(member.Username);
+        eventPayload.TimestampUtc.Should().NotBe(default);
+    }
+
     private static string CreateLiveKitWebhookToken(string rawBody)
     {
         var checksum = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(rawBody)));
@@ -217,4 +364,11 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
         string UserId,
         string? Username,
         DateTime LeftAtUtc);
+
+    private sealed record SignalRVoiceScreenShareEvent(
+        string GuildId,
+        string ChannelId,
+        string UserId,
+        string? Username,
+        DateTime TimestampUtc);
 }

--- a/tests/Harmonie.API.IntegrationTests/RealTime/SignalRVoicePresenceHubTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/SignalRVoicePresenceHubTests.cs
@@ -191,6 +191,10 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
             }
             """;
 
+    // LiveKit proto enum values for TrackSource and TrackType
+    private const int LiveKitTrackSourceScreenShare = 3;
+    private const int LiveKitTrackTypeVideo = 1;
+
     private static string CreateTrackWebhookBody(
         string eventType,
         string channelId,
@@ -244,7 +248,6 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
         await connection.StartAsync(TestContext.Current.CancellationToken);
         await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        // ScreenShare source = 3 in LiveKit proto enum
         var webhookResponse = await SendLiveKitWebhookAsync(
             CreateTrackWebhookBody(
                 "track_published",
@@ -252,8 +255,8 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
                 member.UserId.ToString(),
                 member.Username,
                 "TR_screen001",
-                trackSource: 3,
-                trackType: 1));
+                trackSource: LiveKitTrackSourceScreenShare,
+                trackType: LiveKitTrackTypeVideo));
         webhookResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -278,12 +281,13 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
 
         await using var connection = CreateHubConnection(member.AccessToken);
 
-        // First publish a track
-        await connection.StartAsync(TestContext.Current.CancellationToken);
+        // First publish a track — register Ready before starting to avoid missing the event
         var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         connection.On("Ready", () => ready.TrySetResult());
+        await connection.StartAsync(TestContext.Current.CancellationToken);
         await ready.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
+        // HTTP handler processes the webhook synchronously; awaiting the response guarantees the SID is tracked.
         await SendLiveKitWebhookAsync(
             CreateTrackWebhookBody(
                 "track_published",
@@ -291,11 +295,8 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
                 member.UserId.ToString(),
                 member.Username,
                 "TR_screen002",
-                trackSource: 3,
-                trackType: 1));
-
-        // Wait a moment for the track_published to be processed
-        await Task.Delay(500, TestContext.Current.CancellationToken);
+                trackSource: LiveKitTrackSourceScreenShare,
+                trackType: LiveKitTrackTypeVideo));
 
         await connection.DisposeAsync();
 
@@ -322,8 +323,8 @@ public sealed class SignalRVoicePresenceHubTests : IClassFixture<HarmonieWebAppl
                 member.UserId.ToString(),
                 member.Username,
                 "TR_screen002",
-                trackSource: 3,
-                trackType: 1));
+                trackSource: LiveKitTrackSourceScreenShare,
+                trackType: LiveKitTrackTypeVideo));
         webhookResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));

--- a/tests/Harmonie.Application.Tests/Voice/GetGuildVoiceParticipantsHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Voice/GetGuildVoiceParticipantsHandlerTests.cs
@@ -69,6 +69,38 @@ public sealed class GetGuildVoiceParticipantsHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsync_WhenParticipantIsSharingScreen_ShouldPropagateFlag()
+    {
+        var guild = ApplicationTestBuilders.CreateGuild();
+        var requesterUserId = UserId.New();
+        var channelId = GuildChannelId.New();
+        var participantUserId = UserId.New();
+
+        _guildRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(guild.Id, requesterUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
+
+        _liveKitRoomServiceMock
+            .Setup(x => x.GetGuildVoiceParticipantsAsync(guild.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new GuildVoiceChannelParticipants(
+                    channelId,
+                    [new VoiceChannelParticipant(participantUserId, "alice", IsSharingScreen: true)])
+            ]);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.GetGuildMembersAsync(guild.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<GuildMemberUser>());
+
+        var response = await _handler.HandleAsync(guild.Id, requesterUserId, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data!.Channels.Should().HaveCount(1);
+        response.Data.Channels[0].Participants.Should().HaveCount(1);
+        response.Data.Channels[0].Participants[0].IsSharingScreen.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task HandleAsync_WithValidMember_ShouldReturnParticipantsGroupedByChannel()
     {
         var guild = ApplicationTestBuilders.CreateGuild();

--- a/tests/Harmonie.Application.Tests/Voice/HandleLiveKitWebhookHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Voice/HandleLiveKitWebhookHandlerTests.cs
@@ -310,7 +310,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
         _voiceParticipantCacheMock
             .Setup(x => x.TryAddScreenShareTrackAsync(
                 channel.Id, participantUserId, trackSid, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ScreenShareTrackAddResult(true, true));
+            .ReturnsAsync(new ScreenShareTrackAddResult(true));
 
         var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
@@ -359,7 +359,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
         _voiceParticipantCacheMock
             .Setup(x => x.TryAddScreenShareTrackAsync(
                 channel.Id, participantUserId, trackSid, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ScreenShareTrackAddResult(false, true));
+            .ReturnsAsync(new ScreenShareTrackAddResult(false));
 
         await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
@@ -429,7 +429,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
         _voiceParticipantCacheMock
             .Setup(x => x.TryRemoveScreenShareTrackAsync(
                 channel.Id, participantUserId, trackSid, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ScreenShareTrackRemoveResult(true, false));
+            .ReturnsAsync(new ScreenShareTrackRemoveResult(true));
 
         var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
@@ -474,7 +474,7 @@ public sealed class HandleLiveKitWebhookHandlerTests
         _voiceParticipantCacheMock
             .Setup(x => x.TryRemoveScreenShareTrackAsync(
                 channel.Id, participantUserId, trackSid, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ScreenShareTrackRemoveResult(false, true));
+            .ReturnsAsync(new ScreenShareTrackRemoveResult(false));
 
         await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
 
@@ -542,6 +542,46 @@ public sealed class HandleLiveKitWebhookHandlerTests
         _voiceParticipantCacheMock.Verify(
             x => x.RemoveAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Theory]
+    [InlineData("track_published")]
+    [InlineData("track_unpublished")]
+    public async Task HandleAsync_WhenTrackEventHasNullTrack_ShouldProcessedWithoutCacheOperations(string eventType)
+    {
+        var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
+        var participantUserId = UserId.New();
+        var request = new HandleLiveKitWebhookRequest($"{{\"event\":\"{eventType}\"}}", "Bearer token");
+
+        _webhookReceiverMock
+            .Setup(x => x.Receive(request.RawBody, request.AuthorizationHeader!))
+            .Returns(LiveKitWebhookReceiveResult.Ok(
+                new LiveKitWebhookEvent(
+                    eventType,
+                    $"channel:{channel.Id}",
+                    participantUserId.ToString(),
+                    "alice",
+                    DateTime.UtcNow,
+                    Track: null)));
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithParticipantAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelWithParticipant(channel, null));
+
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data!.Processed.Should().BeTrue();
+        response.Data.EventType.Should().Be(eventType);
+
+        _voiceParticipantCacheMock.Verify(
+            x => x.TryAddScreenShareTrackAsync(
+                It.IsAny<GuildChannelId>(), It.IsAny<UserId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _voiceParticipantCacheMock.Verify(
+            x => x.TryRemoveScreenShareTrackAsync(
+                It.IsAny<GuildChannelId>(), It.IsAny<UserId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
 }

--- a/tests/Harmonie.Application.Tests/Voice/HandleLiveKitWebhookHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Voice/HandleLiveKitWebhookHandlerTests.cs
@@ -284,6 +284,239 @@ public sealed class HandleLiveKitWebhookHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsync_WhenTrackPublishedAndSourceIsScreenShare_ShouldAddTrackAndNotifyFirstTime()
+    {
+        var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
+        var participantUserId = UserId.New();
+        var occurredAtUtc = DateTime.UtcNow;
+        var trackSid = "TR_screen123";
+        var request = new HandleLiveKitWebhookRequest("{\"event\":\"track_published\"}", "Bearer token");
+
+        _webhookReceiverMock
+            .Setup(x => x.Receive(request.RawBody, request.AuthorizationHeader!))
+            .Returns(LiveKitWebhookReceiveResult.Ok(
+                new LiveKitWebhookEvent(
+                    "track_published",
+                    $"channel:{channel.Id}",
+                    participantUserId.ToString(),
+                    "alice",
+                    occurredAtUtc,
+                    new LiveKitTrackInfo(trackSid, "SCREEN_SHARE", "VIDEO", false, 1920, 1080))));
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithParticipantAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelWithParticipant(channel, null));
+
+        _voiceParticipantCacheMock
+            .Setup(x => x.TryAddScreenShareTrackAsync(
+                channel.Id, participantUserId, trackSid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ScreenShareTrackAddResult(true, true));
+
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data!.Processed.Should().BeTrue();
+        response.Data.EventType.Should().Be("track_published");
+
+        _voiceParticipantCacheMock.Verify(
+            x => x.TryAddScreenShareTrackAsync(channel.Id, participantUserId, trackSid, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _voicePresenceNotifierMock.Verify(
+            x => x.NotifyScreenShareStartedAsync(
+                It.Is<VoiceScreenShareNotification>(n =>
+                    n.GuildId == channel.GuildId
+                    && n.ChannelId == channel.Id
+                    && n.UserId == participantUserId
+                    && n.TimestampUtc == occurredAtUtc),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenTrackPublishedButNotFirstScreenShare_ShouldNotNotify()
+    {
+        var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
+        var participantUserId = UserId.New();
+        var trackSid = "TR_screen456";
+        var request = new HandleLiveKitWebhookRequest("{\"event\":\"track_published\"}", "Bearer token");
+
+        _webhookReceiverMock
+            .Setup(x => x.Receive(request.RawBody, request.AuthorizationHeader!))
+            .Returns(LiveKitWebhookReceiveResult.Ok(
+                new LiveKitWebhookEvent(
+                    "track_published",
+                    $"channel:{channel.Id}",
+                    participantUserId.ToString(),
+                    "alice",
+                    DateTime.UtcNow,
+                    new LiveKitTrackInfo(trackSid, "SCREEN_SHARE", "VIDEO", false, 1920, 1080))));
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithParticipantAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelWithParticipant(channel, null));
+
+        _voiceParticipantCacheMock
+            .Setup(x => x.TryAddScreenShareTrackAsync(
+                channel.Id, participantUserId, trackSid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ScreenShareTrackAddResult(false, true));
+
+        await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        _voicePresenceNotifierMock.Verify(
+            x => x.NotifyScreenShareStartedAsync(It.IsAny<VoiceScreenShareNotification>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenTrackPublishedAndSourceIsNotScreenShare_ShouldIgnore()
+    {
+        var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
+        var participantUserId = UserId.New();
+        var request = new HandleLiveKitWebhookRequest("{\"event\":\"track_published\"}", "Bearer token");
+
+        _webhookReceiverMock
+            .Setup(x => x.Receive(request.RawBody, request.AuthorizationHeader!))
+            .Returns(LiveKitWebhookReceiveResult.Ok(
+                new LiveKitWebhookEvent(
+                    "track_published",
+                    $"channel:{channel.Id}",
+                    participantUserId.ToString(),
+                    "alice",
+                    DateTime.UtcNow,
+                    new LiveKitTrackInfo("TR_cam123", "CAMERA", "VIDEO", false, 1280, 720))));
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithParticipantAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelWithParticipant(channel, null));
+
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data!.Processed.Should().BeTrue();
+        response.Data.EventType.Should().Be("track_published");
+
+        _voiceParticipantCacheMock.Verify(
+            x => x.TryAddScreenShareTrackAsync(
+                It.IsAny<GuildChannelId>(), It.IsAny<UserId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenTrackUnpublishedAndLastScreenShare_ShouldNotifyStopped()
+    {
+        var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
+        var participantUserId = UserId.New();
+        var occurredAtUtc = DateTime.UtcNow;
+        var trackSid = "TR_screen789";
+        var request = new HandleLiveKitWebhookRequest("{\"event\":\"track_unpublished\"}", "Bearer token");
+
+        _webhookReceiverMock
+            .Setup(x => x.Receive(request.RawBody, request.AuthorizationHeader!))
+            .Returns(LiveKitWebhookReceiveResult.Ok(
+                new LiveKitWebhookEvent(
+                    "track_unpublished",
+                    $"channel:{channel.Id}",
+                    participantUserId.ToString(),
+                    "alice",
+                    occurredAtUtc,
+                    new LiveKitTrackInfo(trackSid, "SCREEN_SHARE", "VIDEO", false, 1920, 1080))));
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithParticipantAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelWithParticipant(channel, null));
+
+        _voiceParticipantCacheMock
+            .Setup(x => x.TryRemoveScreenShareTrackAsync(
+                channel.Id, participantUserId, trackSid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ScreenShareTrackRemoveResult(true, false));
+
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data!.Processed.Should().BeTrue();
+        response.Data.EventType.Should().Be("track_unpublished");
+
+        _voicePresenceNotifierMock.Verify(
+            x => x.NotifyScreenShareStoppedAsync(
+                It.Is<VoiceScreenShareNotification>(n =>
+                    n.GuildId == channel.GuildId
+                    && n.ChannelId == channel.Id
+                    && n.UserId == participantUserId
+                    && n.TimestampUtc == occurredAtUtc),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenTrackUnpublishedButNotLastScreenShare_ShouldNotNotify()
+    {
+        var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
+        var participantUserId = UserId.New();
+        var trackSid = "TR_screen_001";
+        var request = new HandleLiveKitWebhookRequest("{\"event\":\"track_unpublished\"}", "Bearer token");
+
+        _webhookReceiverMock
+            .Setup(x => x.Receive(request.RawBody, request.AuthorizationHeader!))
+            .Returns(LiveKitWebhookReceiveResult.Ok(
+                new LiveKitWebhookEvent(
+                    "track_unpublished",
+                    $"channel:{channel.Id}",
+                    participantUserId.ToString(),
+                    "alice",
+                    DateTime.UtcNow,
+                    new LiveKitTrackInfo(trackSid, "SCREEN_SHARE", "VIDEO", false, 1920, 1080))));
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithParticipantAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelWithParticipant(channel, null));
+
+        _voiceParticipantCacheMock
+            .Setup(x => x.TryRemoveScreenShareTrackAsync(
+                channel.Id, participantUserId, trackSid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ScreenShareTrackRemoveResult(false, true));
+
+        await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        _voicePresenceNotifierMock.Verify(
+            x => x.NotifyScreenShareStoppedAsync(It.IsAny<VoiceScreenShareNotification>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenParticipantLeft_ShouldClearScreenShareTracks()
+    {
+        var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
+        var participantUserId = UserId.New();
+        var request = new HandleLiveKitWebhookRequest("{\"event\":\"participant_left\"}", "Bearer token");
+
+        _voiceParticipantCacheMock
+            .Setup(x => x.ClearScreenShareTracksAsync(
+                channel.Id, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _webhookReceiverMock
+            .Setup(x => x.Receive(request.RawBody, request.AuthorizationHeader!))
+            .Returns(LiveKitWebhookReceiveResult.Ok(
+                new LiveKitWebhookEvent(
+                    "participant_left",
+                    $"channel:{channel.Id}",
+                    participantUserId.ToString(),
+                    "alice",
+                    DateTime.UtcNow)));
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetWithParticipantAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChannelWithParticipant(channel, null));
+
+        await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        _voiceParticipantCacheMock.Verify(
+            x => x.ClearScreenShareTracksAsync(channel.Id, participantUserId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task HandleAsync_WhenParticipantLeft_ShouldRemoveFromCache()
     {
         var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);

--- a/tests/Harmonie.Application.Tests/Voice/JoinVoiceChannelHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Voice/JoinVoiceChannelHandlerTests.cs
@@ -288,6 +288,56 @@ public sealed class JoinVoiceChannelHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsync_WhenLiveKitParticipantIsSharingScreen_ShouldPropagateFlag()
+    {
+        var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);
+        var user = ApplicationTestBuilders.CreateUser();
+        var roomToken = new LiveKitRoomToken("eyJ.token", "ws://localhost:7880", $"channel:{channel.Id}");
+
+        var participantUserId = UserId.New();
+        var lkParticipant = new VoiceChannelParticipant(participantUserId, "lk-username", IsSharingScreen: true);
+        var cachedParticipant = new CachedVoiceParticipant(
+            UserId: participantUserId,
+            Username: "cached-username",
+            DisplayName: "Cached Display",
+            AvatarFileId: null,
+            AvatarColor: "#abc",
+            AvatarIcon: "star",
+            AvatarBg: "#fff",
+            IsSharingScreen: false);
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetByIdAsync(channel.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(channel);
+
+        _guildMemberRepositoryMock
+            .Setup(x => x.IsMemberAsync(channel.GuildId, user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _liveKitTokenServiceMock
+            .Setup(x => x.GenerateRoomTokenAsync(channel.Id, user.Id, user.Username.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(roomToken);
+
+        _liveKitRoomServiceMock
+            .Setup(x => x.ListChannelParticipantsAsync(channel.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([lkParticipant]);
+
+        _voiceParticipantCacheMock
+            .Setup(x => x.GetAsync(channel.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([cachedParticipant]);
+
+        var response = await _handler.HandleAsync(channel.Id, user.Id, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data!.CurrentParticipants.Should().HaveCount(1);
+        response.Data.CurrentParticipants[0].IsSharingScreen.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task HandleAsync_WhenCachedParticipantNotInLiveKit_ShouldRemoveFromCache()
     {
         var channel = ApplicationTestBuilders.CreateChannel(GuildChannelType.Voice);


### PR DESCRIPTION
## What

Implements Screen Share detection in voice channels via LiveKit webhooks. The server now:
- Detects when a participant starts/stops sharing their screen via `track_published`/`track_unpublished` webhooks
- Notifies all guild members in real-time via SignalR (`VoiceScreenShareStarted`/`VoiceScreenShareStopped`)
- Exposes `IsSharingScreen` flag in `JoinVoiceChannel` and `GetGuildVoiceParticipants` responses
- Handles multi-monitor setups idempotently (tracks SIDs, not just counts)

## Changes

### Domain / Interfaces (4 files)
- `LiveKitWebhookEvent` now includes optional `LiveKitTrackInfo` for track events
- `VoiceChannelParticipant` and `CachedVoiceParticipant` gain `IsSharingScreen`
- `IVoiceParticipantCache` gets `TryAddScreenShareTrackAsync`/`TryRemoveScreenShareTrackAsync`/`ClearScreenShareTracksAsync`
- `IVoicePresenceNotifier` gets `NotifyScreenShareStartedAsync`/`NotifyScreenShareStoppedAsync`

### Infrastructure (2 files)
- `LiveKitWebhookReceiver` maps `WebhookEvent.Track` → `LiveKitTrackInfo`
- `LiveKitRoomService.TryMapParticipant` inspects `ParticipantInfo.Tracks` for `ScreenShare`

### Application (3 files)  
- `HandleLiveKitWebhookHandler` processes `track_published`/`track_unpublished` (only SCREEN_SHARE source)
- `JoinVoiceChannelHandler` propagates `IsSharingScreen` from cache + LiveKit API
- `GetGuildVoiceParticipantsHandler` propagates `IsSharingScreen`

### API / SignalR (3 files)
- `SignalRVoicePresenceNotifier` sends to `guild-voice:{guildId}` group
- `IRealtimeClient` + `VoiceScreenShareEvent` DTO

### Tests (4 files, +10 tests)
- Unit: track events (first/not-first/last/not-last/non-screenshare ignored), participant_left cleanup
- Unit: IsSharingScreen propagation in Join/Get participants
- Integration: VoiceScreenShareStarted + VoiceScreenShareStopped end-to-end

Closes #367