### PR TITLE
feat(voice): conversation voice calls with screen sharing (#366)

### DIFF
--- a/src/Harmonie.API/Configuration/RealTimeConfiguration.cs
+++ b/src/Harmonie.API/Configuration/RealTimeConfiguration.cs
@@ -5,6 +5,7 @@ using Harmonie.API.RealTime.Guilds;
 using Harmonie.API.RealTime.Messages;
 using Harmonie.API.RealTime.Users;
 using Harmonie.API.RealTime.Voice;
+using Harmonie.API.RealTime.Voice.Conversations;
 using Harmonie.API.SignalRDoc.Extensions;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
@@ -26,6 +27,8 @@ public static class RealTimeConfiguration
         services.AddScoped<IGuildNotifier, SignalRGuildNotifier>();
         services.AddScoped<IVoicePresenceNotifier, SignalRVoicePresenceNotifier>();
         services.AddSingleton<IVoiceParticipantCache, InMemoryVoiceParticipantCache>();
+        services.AddScoped<IConversationVoicePresenceNotifier, SignalRConversationVoicePresenceNotifier>();
+        services.AddSingleton<IConversationVoiceParticipantCache, InMemoryConversationVoiceParticipantCache>();
         services.AddScoped<IConversationMessageNotifier, SignalRConversationMessageNotifier>();
         services.AddScoped<IConversationNotifier, SignalRConversationNotifier>();
         services.AddScoped<IUserPresenceNotifier, SignalRUserPresenceNotifier>();

--- a/src/Harmonie.API/Endpoints/ConversationEndpoints.cs
+++ b/src/Harmonie.API/Endpoints/ConversationEndpoints.cs
@@ -1,5 +1,7 @@
 using Harmonie.Application.Features.Conversations.CreateGroupConversation;
 using Harmonie.Application.Features.Conversations.DeleteConversation;
+using Harmonie.Application.Features.Conversations.GetConversationVoiceParticipants;
+using Harmonie.Application.Features.Conversations.JoinConversationVoice;
 using Harmonie.Application.Features.Conversations.ListConversations;
 using Harmonie.Application.Features.Conversations.OpenConversation;
 using Harmonie.Application.Features.Conversations.SearchConversationMessages;
@@ -47,5 +49,9 @@ public static class ConversationEndpoints
         ConversationPinMessage.Map(app);
         ConversationUnpinMessage.Map(app);
         ConversationGetPinnedMessages.Map(app);
+
+        // Voice
+        JoinConversationVoiceEndpoint.Map(app);
+        GetConversationVoiceParticipantsEndpoint.Map(app);
     }
 }

--- a/src/Harmonie.API/RealTime/Common/IRealtimeClient.cs
+++ b/src/Harmonie.API/RealTime/Common/IRealtimeClient.cs
@@ -4,6 +4,7 @@ using Harmonie.API.RealTime.Guilds;
 using Harmonie.API.RealTime.Messages;
 using Harmonie.API.RealTime.Users;
 using Harmonie.API.RealTime.Voice;
+using Harmonie.API.RealTime.Voice.Conversations;
 
 namespace Harmonie.API.RealTime.Common;
 
@@ -29,11 +30,17 @@ public interface IRealtimeClient
     Task ConversationMessageUpdated(ConversationMessageUpdatedEvent payload, CancellationToken cancellationToken = default);
     Task ConversationMessageDeleted(ConversationMessageDeletedEvent payload, CancellationToken cancellationToken = default);
 
-    // Voice
+    // Voice (guild channels)
     Task VoiceParticipantJoined(VoiceParticipantJoinedEvent payload, CancellationToken cancellationToken = default);
     Task VoiceParticipantLeft(VoiceParticipantLeftEvent payload, CancellationToken cancellationToken = default);
     Task VoiceScreenShareStarted(VoiceScreenShareEvent payload, CancellationToken cancellationToken = default);
     Task VoiceScreenShareStopped(VoiceScreenShareEvent payload, CancellationToken cancellationToken = default);
+
+    // Voice (conversations)
+    Task ConversationVoiceParticipantJoined(ConversationVoiceParticipantJoinedEvent payload, CancellationToken cancellationToken = default);
+    Task ConversationVoiceParticipantLeft(ConversationVoiceParticipantLeftEvent payload, CancellationToken cancellationToken = default);
+    Task ConversationVoiceScreenShareStarted(ConversationVoiceScreenShareEvent payload, CancellationToken cancellationToken = default);
+    Task ConversationVoiceScreenShareStopped(ConversationVoiceScreenShareEvent payload, CancellationToken cancellationToken = default);
 
     // Guilds
     Task GuildDeleted(GuildDeletedEvent payload, CancellationToken cancellationToken = default);

--- a/src/Harmonie.API/RealTime/Voice/Conversations/InMemoryConversationVoiceParticipantCache.cs
+++ b/src/Harmonie.API/RealTime/Voice/Conversations/InMemoryConversationVoiceParticipantCache.cs
@@ -1,0 +1,102 @@
+using System.Collections.Concurrent;
+using Harmonie.Application.Interfaces.Voice;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.API.RealTime.Voice.Conversations;
+
+public sealed class InMemoryConversationVoiceParticipantCache : IConversationVoiceParticipantCache
+{
+    private static readonly TimeSpan ParticipantTtl = TimeSpan.FromHours(1);
+
+    private readonly ConcurrentDictionary<Guid, ConcurrentDictionary<Guid, CachedEntry>> _conversations = new();
+    private readonly ConcurrentDictionary<(Guid ConversationId, Guid UserId), ConcurrentDictionary<string, byte>> _screenShareTrackSids = new();
+
+    public Task AddOrUpdateAsync(ConversationId conversationId, CachedVoiceParticipant participant, CancellationToken cancellationToken = default)
+    {
+        var conversation = _conversations.GetOrAdd(conversationId.Value, _ => new ConcurrentDictionary<Guid, CachedEntry>());
+        conversation[participant.UserId.Value] = new CachedEntry(participant, DateTime.UtcNow + ParticipantTtl);
+        return Task.CompletedTask;
+    }
+
+    public Task RemoveAsync(ConversationId conversationId, UserId userId, CancellationToken cancellationToken = default)
+    {
+        if (_conversations.TryGetValue(conversationId.Value, out var conversation))
+            conversation.TryRemove(userId.Value, out _);
+
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<CachedVoiceParticipant>> GetAsync(ConversationId conversationId, CancellationToken cancellationToken = default)
+    {
+        if (!_conversations.TryGetValue(conversationId.Value, out var conversation))
+            return Task.FromResult<IReadOnlyList<CachedVoiceParticipant>>(Array.Empty<CachedVoiceParticipant>());
+
+        var now = DateTime.UtcNow;
+        var result = conversation.Values
+            .Where(e => e.ExpiresAt > now)
+            .Select(e =>
+            {
+                var isSharingScreen = _screenShareTrackSids.TryGetValue(
+                    (conversationId.Value, e.Participant.UserId.Value), out var sids) && !sids.IsEmpty;
+
+                return e.Participant with { IsSharingScreen = isSharingScreen };
+            })
+            .ToArray();
+
+        return Task.FromResult<IReadOnlyList<CachedVoiceParticipant>>(result);
+    }
+
+    public Task<ScreenShareTrackAddResult> TryAddScreenShareTrackAsync(
+        ConversationId conversationId,
+        UserId userId,
+        string trackSid,
+        CancellationToken cancellationToken = default)
+    {
+        var key = (conversationId.Value, userId.Value);
+        var sids = _screenShareTrackSids.GetOrAdd(key, _ => new ConcurrentDictionary<string, byte>());
+        bool isFirst;
+        lock (sids)
+        {
+            var wasEmpty = sids.IsEmpty;
+            sids[trackSid] = 0;
+            isFirst = wasEmpty;
+        }
+
+        return Task.FromResult(new ScreenShareTrackAddResult(isFirst));
+    }
+
+    public Task<ScreenShareTrackRemoveResult> TryRemoveScreenShareTrackAsync(
+        ConversationId conversationId,
+        UserId userId,
+        string trackSid,
+        CancellationToken cancellationToken = default)
+    {
+        var key = (conversationId.Value, userId.Value);
+        if (_screenShareTrackSids.TryGetValue(key, out var sids))
+        {
+            sids.TryRemove(trackSid, out _);
+        }
+
+        var wasPresentAndNowEmpty = sids is not null && sids.IsEmpty;
+
+        if (wasPresentAndNowEmpty)
+            _screenShareTrackSids.TryRemove(key, out _);
+
+        return Task.FromResult(new ScreenShareTrackRemoveResult(wasPresentAndNowEmpty));
+    }
+
+    public Task<bool> ClearScreenShareTracksAsync(
+        ConversationId conversationId,
+        UserId userId,
+        CancellationToken cancellationToken = default)
+    {
+        var key = (conversationId.Value, userId.Value);
+        if (_screenShareTrackSids.TryRemove(key, out var sids))
+            return Task.FromResult(!sids.IsEmpty);
+
+        return Task.FromResult(false);
+    }
+
+    private sealed record CachedEntry(CachedVoiceParticipant Participant, DateTime ExpiresAt);
+}

--- a/src/Harmonie.API/RealTime/Voice/Conversations/SignalRConversationVoicePresenceNotifier.cs
+++ b/src/Harmonie.API/RealTime/Voice/Conversations/SignalRConversationVoicePresenceNotifier.cs
@@ -1,0 +1,112 @@
+using Harmonie.API.RealTime.Common;
+using Harmonie.Application.Interfaces.Voice;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Harmonie.API.RealTime.Voice.Conversations;
+
+public sealed class SignalRConversationVoicePresenceNotifier : IConversationVoicePresenceNotifier
+{
+    private readonly IHubContext<RealtimeHub, IRealtimeClient> _hubContext;
+
+    public SignalRConversationVoicePresenceNotifier(IHubContext<RealtimeHub, IRealtimeClient> hubContext)
+    {
+        _hubContext = hubContext;
+    }
+
+    public async Task NotifyParticipantJoinedAsync(
+        ConversationVoiceParticipantJoinedNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var payload = new ConversationVoiceParticipantJoinedEvent(
+            ConversationId: notification.ConversationId.Value,
+            UserId: notification.UserId.Value,
+            Username: notification.Username,
+            DisplayName: notification.DisplayName,
+            AvatarFileId: notification.AvatarFileId?.Value,
+            AvatarColor: notification.AvatarColor,
+            AvatarIcon: notification.AvatarIcon,
+            AvatarBg: notification.AvatarBg,
+            JoinedAtUtc: notification.JoinedAtUtc);
+
+        await _hubContext.Clients
+            .Group(RealtimeHub.GetConversationGroupName(notification.ConversationId))
+            .ConversationVoiceParticipantJoined(payload, cancellationToken);
+    }
+
+    public async Task NotifyParticipantLeftAsync(
+        ConversationVoiceParticipantLeftNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var payload = new ConversationVoiceParticipantLeftEvent(
+            ConversationId: notification.ConversationId.Value,
+            UserId: notification.UserId.Value,
+            Username: notification.Username,
+            LeftAtUtc: notification.LeftAtUtc);
+
+        await _hubContext.Clients
+            .Group(RealtimeHub.GetConversationGroupName(notification.ConversationId))
+            .ConversationVoiceParticipantLeft(payload, cancellationToken);
+    }
+
+    public async Task NotifyScreenShareStartedAsync(
+        ConversationVoiceScreenShareNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var payload = new ConversationVoiceScreenShareEvent(
+            ConversationId: notification.ConversationId.Value,
+            UserId: notification.UserId.Value,
+            Username: notification.Username,
+            TimestampUtc: notification.TimestampUtc);
+
+        await _hubContext.Clients
+            .Group(RealtimeHub.GetConversationGroupName(notification.ConversationId))
+            .ConversationVoiceScreenShareStarted(payload, cancellationToken);
+    }
+
+    public async Task NotifyScreenShareStoppedAsync(
+        ConversationVoiceScreenShareNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var payload = new ConversationVoiceScreenShareEvent(
+            ConversationId: notification.ConversationId.Value,
+            UserId: notification.UserId.Value,
+            Username: notification.Username,
+            TimestampUtc: notification.TimestampUtc);
+
+        await _hubContext.Clients
+            .Group(RealtimeHub.GetConversationGroupName(notification.ConversationId))
+            .ConversationVoiceScreenShareStopped(payload, cancellationToken);
+    }
+}
+
+public sealed record ConversationVoiceParticipantJoinedEvent(
+    Guid ConversationId,
+    Guid UserId,
+    string? Username,
+    string? DisplayName,
+    Guid? AvatarFileId,
+    string? AvatarColor,
+    string? AvatarIcon,
+    string? AvatarBg,
+    DateTime JoinedAtUtc);
+
+public sealed record ConversationVoiceParticipantLeftEvent(
+    Guid ConversationId,
+    Guid UserId,
+    string? Username,
+    DateTime LeftAtUtc);
+
+public sealed record ConversationVoiceScreenShareEvent(
+    Guid ConversationId,
+    Guid UserId,
+    string? Username,
+    DateTime TimestampUtc);

--- a/src/Harmonie.Application/Common/ApplicationErrorCodes.cs
+++ b/src/Harmonie.Application/Common/ApplicationErrorCodes.cs
@@ -113,5 +113,6 @@ public static class ApplicationErrorCodes
         public const string CannotOpenSelf = "CONVERSATION_CANNOT_OPEN_SELF";
         public const string AccessDenied = "CONVERSATION_ACCESS_DENIED";
         public const string InvalidConversationType = "CONVERSATION_INVALID_TYPE";
+        public const string VoiceAccessDenied = "CONVERSATION_VOICE_ACCESS_DENIED";
     }
 }

--- a/src/Harmonie.Application/Common/EndpointExtensions.cs
+++ b/src/Harmonie.Application/Common/EndpointExtensions.cs
@@ -335,6 +335,7 @@ public static class EndpointExtensions
             ApplicationErrorCodes.Conversation.CannotOpenSelf => HttpStatusCode.BadRequest,
             ApplicationErrorCodes.Conversation.AccessDenied => HttpStatusCode.Forbidden,
             ApplicationErrorCodes.Conversation.InvalidConversationType => HttpStatusCode.BadRequest,
+            ApplicationErrorCodes.Conversation.VoiceAccessDenied => HttpStatusCode.Forbidden,
             ApplicationErrorCodes.Reaction.MessageNotFound => HttpStatusCode.NotFound,
             ApplicationErrorCodes.Pin.MessageNotFound => HttpStatusCode.NotFound,
             ApplicationErrorCodes.Pin.AlreadyPinned => HttpStatusCode.Conflict,

--- a/src/Harmonie.Application/Features/Conversations/GetConversationVoiceParticipants/GetConversationVoiceParticipantsEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetConversationVoiceParticipants/GetConversationVoiceParticipantsEndpoint.cs
@@ -1,0 +1,39 @@
+using Harmonie.Application.Common;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Harmonie.Application.Features.Conversations.GetConversationVoiceParticipants;
+
+public static class GetConversationVoiceParticipantsEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/conversations/{conversationId}/voice/participants", HandleAsync)
+            .WithName("GetConversationVoiceParticipants")
+            .WithTags("Conversations")
+            .RequireAuthorization()
+            .WithSummary("Get active voice participants in a conversation")
+            .WithDescription("Returns the list of participants currently in the conversation voice call.")
+            .Produces<GetConversationVoiceParticipantsResponse>(StatusCodes.Status200OK)
+            .ProducesErrors(
+                ApplicationErrorCodes.Common.ValidationFailed,
+                ApplicationErrorCodes.Auth.InvalidCredentials,
+                ApplicationErrorCodes.Conversation.NotFound,
+                ApplicationErrorCodes.Conversation.VoiceAccessDenied);
+    }
+
+    private static async Task<IResult> HandleAsync(
+        ConversationId conversationId,
+        [FromServices] IAuthenticatedHandler<ConversationId, GetConversationVoiceParticipantsResponse> handler,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
+
+        var response = await handler.HandleAsync(conversationId, currentUserId, cancellationToken);
+        return response.ToHttpResult(httpContext);
+    }
+}

--- a/src/Harmonie.Application/Features/Conversations/GetConversationVoiceParticipants/GetConversationVoiceParticipantsHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetConversationVoiceParticipants/GetConversationVoiceParticipantsHandler.cs
@@ -1,0 +1,75 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Interfaces.Voice;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Features.Conversations.GetConversationVoiceParticipants;
+
+public sealed class GetConversationVoiceParticipantsHandler
+    : IAuthenticatedHandler<ConversationId, GetConversationVoiceParticipantsResponse>
+{
+    private readonly IConversationRepository _conversationRepository;
+    private readonly ILiveKitRoomService _liveKitRoomService;
+    private readonly IConversationVoiceParticipantCache _voiceParticipantCache;
+
+    public GetConversationVoiceParticipantsHandler(
+        IConversationRepository conversationRepository,
+        ILiveKitRoomService liveKitRoomService,
+        IConversationVoiceParticipantCache voiceParticipantCache)
+    {
+        _conversationRepository = conversationRepository;
+        _liveKitRoomService = liveKitRoomService;
+        _voiceParticipantCache = voiceParticipantCache;
+    }
+
+    public async Task<ApplicationResponse<GetConversationVoiceParticipantsResponse>> HandleAsync(
+        ConversationId request,
+        UserId currentUserId,
+        CancellationToken cancellationToken = default)
+    {
+        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(request, currentUserId, cancellationToken);
+        if (access is null)
+        {
+            return ApplicationResponse<GetConversationVoiceParticipantsResponse>.Fail(
+                ApplicationErrorCodes.Conversation.NotFound,
+                "Conversation was not found");
+        }
+
+        if (access.Participant is null)
+        {
+            return ApplicationResponse<GetConversationVoiceParticipantsResponse>.Fail(
+                ApplicationErrorCodes.Conversation.VoiceAccessDenied,
+                "You do not have access to this conversation");
+        }
+
+        var liveKitParticipantsTask = _liveKitRoomService.ListConversationParticipantsAsync(request, cancellationToken);
+        var cachedParticipantsTask = _voiceParticipantCache.GetAsync(request, cancellationToken);
+
+        await Task.WhenAll(liveKitParticipantsTask, cachedParticipantsTask);
+
+        var liveKitParticipants = liveKitParticipantsTask.Result;
+        var cachedParticipants = cachedParticipantsTask.Result;
+
+        var cachedById = cachedParticipants.ToDictionary(p => p.UserId.Value);
+
+        var participants = liveKitParticipants
+            .Select(lkParticipant =>
+            {
+                cachedById.TryGetValue(lkParticipant.UserId.Value, out var cached);
+                return new ConversationVoiceParticipantDto(
+                    UserId: lkParticipant.UserId.Value,
+                    Username: cached?.Username ?? lkParticipant.Username,
+                    DisplayName: cached?.DisplayName,
+                    AvatarFileId: cached?.AvatarFileId?.Value,
+                    AvatarColor: cached?.AvatarColor,
+                    AvatarIcon: cached?.AvatarIcon,
+                    AvatarBg: cached?.AvatarBg,
+                    IsSharingScreen: lkParticipant.IsSharingScreen);
+            })
+            .ToArray();
+
+        return ApplicationResponse<GetConversationVoiceParticipantsResponse>.Ok(
+            new GetConversationVoiceParticipantsResponse(participants));
+    }
+}

--- a/src/Harmonie.Application/Features/Conversations/GetConversationVoiceParticipants/GetConversationVoiceParticipantsResponse.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetConversationVoiceParticipants/GetConversationVoiceParticipantsResponse.cs
@@ -1,0 +1,14 @@
+namespace Harmonie.Application.Features.Conversations.GetConversationVoiceParticipants;
+
+public sealed record GetConversationVoiceParticipantsResponse(
+    IReadOnlyList<ConversationVoiceParticipantDto> Participants);
+
+public sealed record ConversationVoiceParticipantDto(
+    Guid UserId,
+    string? Username,
+    string? DisplayName,
+    Guid? AvatarFileId,
+    string? AvatarColor,
+    string? AvatarIcon,
+    string? AvatarBg,
+    bool IsSharingScreen = false);

--- a/src/Harmonie.Application/Features/Conversations/JoinConversationVoice/JoinConversationVoiceEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/JoinConversationVoice/JoinConversationVoiceEndpoint.cs
@@ -1,0 +1,40 @@
+using Harmonie.Application.Common;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Harmonie.Application.Features.Conversations.JoinConversationVoice;
+
+public static class JoinConversationVoiceEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/conversations/{conversationId}/voice/join", HandleAsync)
+            .WithName("JoinConversationVoice")
+            .WithTags("Conversations")
+            .RequireAuthorization()
+            .WithSummary("Join a conversation voice call")
+            .WithDescription("Returns a LiveKit access token for an authenticated participant in a conversation voice call.")
+            .Produces<JoinConversationVoiceResponse>(StatusCodes.Status200OK)
+            .ProducesErrors(
+                ApplicationErrorCodes.Common.ValidationFailed,
+                ApplicationErrorCodes.Auth.InvalidCredentials,
+                ApplicationErrorCodes.Conversation.NotFound,
+                ApplicationErrorCodes.Conversation.VoiceAccessDenied,
+                ApplicationErrorCodes.User.NotFound);
+    }
+
+    private static async Task<IResult> HandleAsync(
+        ConversationId conversationId,
+        [FromServices] IAuthenticatedHandler<ConversationId, JoinConversationVoiceResponse> handler,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
+
+        var response = await handler.HandleAsync(conversationId, currentUserId, cancellationToken);
+        return response.ToHttpResult(httpContext);
+    }
+}

--- a/src/Harmonie.Application/Features/Conversations/JoinConversationVoice/JoinConversationVoiceHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/JoinConversationVoice/JoinConversationVoiceHandler.cs
@@ -1,0 +1,148 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Interfaces.Users;
+using Harmonie.Application.Interfaces.Voice;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Features.Conversations.JoinConversationVoice;
+
+public sealed class JoinConversationVoiceHandler : IAuthenticatedHandler<ConversationId, JoinConversationVoiceResponse>
+{
+    private readonly IConversationRepository _conversationRepository;
+    private readonly IUserRepository _userRepository;
+    private readonly ILiveKitTokenService _liveKitTokenService;
+    private readonly ILiveKitRoomService _liveKitRoomService;
+    private readonly IConversationVoiceParticipantCache _voiceParticipantCache;
+
+    public JoinConversationVoiceHandler(
+        IConversationRepository conversationRepository,
+        IUserRepository userRepository,
+        ILiveKitTokenService liveKitTokenService,
+        ILiveKitRoomService liveKitRoomService,
+        IConversationVoiceParticipantCache voiceParticipantCache)
+    {
+        _conversationRepository = conversationRepository;
+        _userRepository = userRepository;
+        _liveKitTokenService = liveKitTokenService;
+        _liveKitRoomService = liveKitRoomService;
+        _voiceParticipantCache = voiceParticipantCache;
+    }
+
+    public async Task<ApplicationResponse<JoinConversationVoiceResponse>> HandleAsync(
+        ConversationId request,
+        UserId currentUserId,
+        CancellationToken cancellationToken = default)
+    {
+        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(request, currentUserId, cancellationToken);
+        if (access is null)
+        {
+            return ApplicationResponse<JoinConversationVoiceResponse>.Fail(
+                ApplicationErrorCodes.Conversation.NotFound,
+                "Conversation was not found");
+        }
+
+        if (access.Participant is null)
+        {
+            return ApplicationResponse<JoinConversationVoiceResponse>.Fail(
+                ApplicationErrorCodes.Conversation.VoiceAccessDenied,
+                "You do not have access to this conversation");
+        }
+
+        var user = await _userRepository.GetByIdAsync(currentUserId, cancellationToken);
+        if (user is null)
+        {
+            return ApplicationResponse<JoinConversationVoiceResponse>.Fail(
+                ApplicationErrorCodes.User.NotFound,
+                "User profile was not found");
+        }
+
+        var roomTokenTask = _liveKitTokenService.GenerateConversationRoomTokenAsync(
+            request,
+            currentUserId,
+            user.Username.Value,
+            cancellationToken);
+        var liveKitParticipantsTask = _liveKitRoomService.ListConversationParticipantsAsync(request, cancellationToken);
+        var cachedParticipantsTask = _voiceParticipantCache.GetAsync(request, cancellationToken);
+
+        await Task.WhenAll(roomTokenTask, liveKitParticipantsTask, cachedParticipantsTask);
+
+        var roomToken = roomTokenTask.Result;
+        var liveKitParticipants = liveKitParticipantsTask.Result;
+        var cachedParticipants = cachedParticipantsTask.Result;
+
+        var cachedById = cachedParticipants.ToDictionary(p => p.UserId.Value);
+        var liveKitIds = liveKitParticipants.Select(p => p.UserId.Value).ToHashSet();
+
+        var missingIds = liveKitParticipants
+            .Where(p => !cachedById.ContainsKey(p.UserId.Value))
+            .Select(p => p.UserId)
+            .ToArray();
+
+        var fetchedUsers = missingIds.Length > 0
+            ? await _userRepository.GetManyByIdsAsync(missingIds, cancellationToken)
+            : [];
+        var fetchedById = fetchedUsers.ToDictionary(u => u.Id.Value);
+
+        var reconciledParticipants = new List<CachedVoiceParticipant>(liveKitParticipants.Count);
+
+        foreach (var lkParticipant in liveKitParticipants)
+        {
+            CachedVoiceParticipant cached;
+
+            if (cachedById.TryGetValue(lkParticipant.UserId.Value, out var existing))
+            {
+                cached = existing;
+            }
+            else if (fetchedById.TryGetValue(lkParticipant.UserId.Value, out var dbUser))
+            {
+                cached = new CachedVoiceParticipant(
+                    UserId: dbUser.Id,
+                    Username: dbUser.Username.Value,
+                    DisplayName: dbUser.DisplayName,
+                    AvatarFileId: dbUser.AvatarFileId,
+                    AvatarColor: dbUser.AvatarColor,
+                    AvatarIcon: dbUser.AvatarIcon,
+                    AvatarBg: dbUser.AvatarBg);
+            }
+            else
+            {
+                cached = new CachedVoiceParticipant(
+                    UserId: lkParticipant.UserId,
+                    Username: lkParticipant.Username,
+                    DisplayName: null,
+                    AvatarFileId: null,
+                    AvatarColor: null,
+                    AvatarIcon: null,
+                    AvatarBg: null);
+            }
+
+            await _voiceParticipantCache.AddOrUpdateAsync(request, cached, cancellationToken);
+            // IsSharingScreen is derived from the SID set in cache; use LiveKit state for the immediate response.
+            reconciledParticipants.Add(cached with { IsSharingScreen = lkParticipant.IsSharingScreen });
+        }
+
+        foreach (var stale in cachedParticipants.Where(p => !liveKitIds.Contains(p.UserId.Value)))
+            await _voiceParticipantCache.RemoveAsync(request, stale.UserId, cancellationToken);
+
+        var currentParticipants = reconciledParticipants
+            .Select(p => new JoinConversationVoiceParticipantResponse(
+                UserId: p.UserId.Value,
+                Username: p.Username,
+                DisplayName: p.DisplayName,
+                AvatarFileId: p.AvatarFileId?.Value,
+                AvatarColor: p.AvatarColor,
+                AvatarIcon: p.AvatarIcon,
+                AvatarBg: p.AvatarBg,
+                IsSharingScreen: p.IsSharingScreen))
+            .ToArray();
+
+        var payload = new JoinConversationVoiceResponse(
+            Token: roomToken.Token,
+            Url: roomToken.Url,
+            RoomName: roomToken.RoomName,
+            CurrentParticipants: currentParticipants);
+
+        return ApplicationResponse<JoinConversationVoiceResponse>.Ok(payload);
+    }
+}

--- a/src/Harmonie.Application/Features/Conversations/JoinConversationVoice/JoinConversationVoiceResponse.cs
+++ b/src/Harmonie.Application/Features/Conversations/JoinConversationVoice/JoinConversationVoiceResponse.cs
@@ -1,0 +1,17 @@
+namespace Harmonie.Application.Features.Conversations.JoinConversationVoice;
+
+public sealed record JoinConversationVoiceResponse(
+    string Token,
+    string Url,
+    string RoomName,
+    IReadOnlyList<JoinConversationVoiceParticipantResponse> CurrentParticipants);
+
+public sealed record JoinConversationVoiceParticipantResponse(
+    Guid UserId,
+    string? Username,
+    string? DisplayName,
+    Guid? AvatarFileId,
+    string? AvatarColor,
+    string? AvatarIcon,
+    string? AvatarBg,
+    bool IsSharingScreen = false);

--- a/src/Harmonie.Application/Features/Voice/HandleLiveKitWebhook/HandleLiveKitWebhookHandler.cs
+++ b/src/Harmonie.Application/Features/Voice/HandleLiveKitWebhook/HandleLiveKitWebhookHandler.cs
@@ -1,8 +1,10 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Voice;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Users;
 
 namespace Harmonie.Application.Features.Voice.HandleLiveKitWebhook;
@@ -14,23 +16,33 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
     private const string TrackPublishedEvent = "track_published";
     private const string TrackUnpublishedEvent = "track_unpublished";
     private const string ChannelRoomPrefix = "channel:";
+    private const string ConversationRoomPrefix = "conversation:";
     private const string ScreenShareSource = "SCREEN_SHARE";
 
     private readonly ILiveKitWebhookReceiver _webhookReceiver;
     private readonly IGuildChannelRepository _guildChannelRepository;
+    private readonly IConversationRepository _conversationRepository;
     private readonly IVoicePresenceNotifier _voicePresenceNotifier;
     private readonly IVoiceParticipantCache _voiceParticipantCache;
+    private readonly IConversationVoicePresenceNotifier _conversationVoicePresenceNotifier;
+    private readonly IConversationVoiceParticipantCache _conversationVoiceParticipantCache;
 
     public HandleLiveKitWebhookHandler(
         ILiveKitWebhookReceiver webhookReceiver,
         IGuildChannelRepository guildChannelRepository,
+        IConversationRepository conversationRepository,
         IVoicePresenceNotifier voicePresenceNotifier,
-        IVoiceParticipantCache voiceParticipantCache)
+        IVoiceParticipantCache voiceParticipantCache,
+        IConversationVoicePresenceNotifier conversationVoicePresenceNotifier,
+        IConversationVoiceParticipantCache conversationVoiceParticipantCache)
     {
         _webhookReceiver = webhookReceiver;
         _guildChannelRepository = guildChannelRepository;
+        _conversationRepository = conversationRepository;
         _voicePresenceNotifier = voicePresenceNotifier;
         _voiceParticipantCache = voiceParticipantCache;
+        _conversationVoicePresenceNotifier = conversationVoicePresenceNotifier;
+        _conversationVoiceParticipantCache = conversationVoiceParticipantCache;
     }
 
     public async Task<ApplicationResponse<HandleLiveKitWebhookResponse>> HandleAsync(
@@ -65,44 +77,44 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
             return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(false, eventType));
         }
 
-        if (!TryParseChannelId(webhookEvent.RoomName, out var channelId) || channelId is null)
-        {
-            return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(false, eventType));
-        }
-
         if (!TryParseUserId(webhookEvent.ParticipantIdentity, out var participantUserId) || participantUserId is null)
         {
             return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(false, eventType));
         }
 
-        var result = await _guildChannelRepository.GetWithParticipantAsync(channelId, participantUserId, cancellationToken);
-        if (result is null)
+        if (TryParseChannelId(webhookEvent.RoomName, out var channelId) && channelId is not null)
         {
-            return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(false, eventType));
+            var result = await _guildChannelRepository.GetWithParticipantAsync(channelId, participantUserId, cancellationToken);
+            if (result is null || result.Channel.Type != GuildChannelType.Voice)
+                return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(false, eventType));
+
+            if (eventType == ParticipantJoinedEvent)
+                await HandleParticipantJoinedAsync(result, participantUserId, webhookEvent.OccurredAtUtc, cancellationToken);
+            else if (eventType == ParticipantLeftEvent)
+                await HandleParticipantLeftAsync(result, participantUserId, webhookEvent.OccurredAtUtc, cancellationToken);
+            else if (eventType is TrackPublishedEvent or TrackUnpublishedEvent)
+                await HandleTrackEventAsync(eventType, result, participantUserId, webhookEvent, cancellationToken);
+
+            return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(true, eventType));
         }
 
-        if (result.Channel.Type != GuildChannelType.Voice)
+        if (TryParseConversationId(webhookEvent.RoomName, out var conversationId) && conversationId is not null)
         {
-            return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(false, eventType));
+            var result = await _conversationRepository.GetWithParticipantAsync(conversationId, participantUserId, cancellationToken);
+            if (result is null)
+                return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(false, eventType));
+
+            if (eventType == ParticipantJoinedEvent)
+                await HandleConversationParticipantJoinedAsync(result, participantUserId, webhookEvent.OccurredAtUtc, cancellationToken);
+            else if (eventType == ParticipantLeftEvent)
+                await HandleConversationParticipantLeftAsync(result, participantUserId, webhookEvent.OccurredAtUtc, cancellationToken);
+            else if (eventType is TrackPublishedEvent or TrackUnpublishedEvent)
+                await HandleConversationTrackEventAsync(eventType, result, participantUserId, webhookEvent, cancellationToken);
+
+            return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(true, eventType));
         }
 
-        if (eventType == ParticipantJoinedEvent)
-        {
-            await HandleParticipantJoinedAsync(
-                result, participantUserId, webhookEvent.OccurredAtUtc, cancellationToken);
-        }
-        else if (eventType == ParticipantLeftEvent)
-        {
-            await HandleParticipantLeftAsync(
-                result, participantUserId, webhookEvent.OccurredAtUtc, cancellationToken);
-        }
-        else if (eventType is TrackPublishedEvent or TrackUnpublishedEvent)
-        {
-            await HandleTrackEventAsync(
-                eventType, result, participantUserId, webhookEvent, cancellationToken);
-        }
-
-        return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(true, eventType));
+        return ApplicationResponse<HandleLiveKitWebhookResponse>.Ok(new(false, eventType));
     }
 
     private static bool TryParseChannelId(string? roomName, out GuildChannelId? channelId)
@@ -232,6 +244,23 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
         }
     }
 
+    private static bool TryParseConversationId(string? roomName, out ConversationId? conversationId)
+    {
+        conversationId = null;
+
+        if (string.IsNullOrWhiteSpace(roomName)
+            || !roomName.StartsWith(ConversationRoomPrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var rawConversationId = roomName[ConversationRoomPrefix.Length..];
+        if (!ConversationId.TryParse(rawConversationId, out conversationId) || conversationId is null)
+            return false;
+
+        return true;
+    }
+
     private static bool TryParseUserId(string? participantIdentity, out UserId? userId)
     {
         userId = null;
@@ -243,5 +272,106 @@ public sealed class HandleLiveKitWebhookHandler : IHandler<HandleLiveKitWebhookR
             return false;
 
         return true;
+    }
+
+    private async Task HandleConversationParticipantJoinedAsync(
+        ConversationWithParticipant result,
+        UserId participantUserId,
+        DateTime occurredAtUtc,
+        CancellationToken ct)
+    {
+        await _conversationVoiceParticipantCache.AddOrUpdateAsync(
+            result.Conversation.Id,
+            new CachedVoiceParticipant(
+                UserId: participantUserId,
+                Username: result.Participant?.Username.Value,
+                DisplayName: result.Participant?.DisplayName,
+                AvatarFileId: result.Participant?.AvatarFileId,
+                AvatarColor: result.Participant?.AvatarColor,
+                AvatarIcon: result.Participant?.AvatarIcon,
+                AvatarBg: result.Participant?.AvatarBg),
+            ct);
+
+        await _conversationVoicePresenceNotifier.NotifyParticipantJoinedAsync(
+            new ConversationVoiceParticipantJoinedNotification(
+                ConversationId: result.Conversation.Id,
+                UserId: participantUserId,
+                Username: result.Participant?.Username.Value,
+                DisplayName: result.Participant?.DisplayName,
+                AvatarFileId: result.Participant?.AvatarFileId,
+                AvatarColor: result.Participant?.AvatarColor,
+                AvatarIcon: result.Participant?.AvatarIcon,
+                AvatarBg: result.Participant?.AvatarBg,
+                JoinedAtUtc: occurredAtUtc),
+            ct);
+    }
+
+    private async Task HandleConversationParticipantLeftAsync(
+        ConversationWithParticipant result,
+        UserId participantUserId,
+        DateTime occurredAtUtc,
+        CancellationToken ct)
+    {
+        // Clear screen share tracks for safety (LiveKit sends track_unpublished before participant_left,
+        // but we clean up here as a safety net).
+        await _conversationVoiceParticipantCache.ClearScreenShareTracksAsync(
+            result.Conversation.Id, participantUserId, ct);
+
+        await _conversationVoiceParticipantCache.RemoveAsync(result.Conversation.Id, participantUserId, ct);
+
+        await _conversationVoicePresenceNotifier.NotifyParticipantLeftAsync(
+            new ConversationVoiceParticipantLeftNotification(
+                ConversationId: result.Conversation.Id,
+                UserId: participantUserId,
+                Username: result.Participant?.Username.Value,
+                LeftAtUtc: occurredAtUtc),
+            ct);
+    }
+
+    private async Task HandleConversationTrackEventAsync(
+        string eventType,
+        ConversationWithParticipant result,
+        UserId participantUserId,
+        LiveKitWebhookEvent webhookEvent,
+        CancellationToken ct)
+    {
+        if (webhookEvent.Track is null)
+            return;
+
+        var track = webhookEvent.Track;
+
+        // Only process ScreenShare tracks. Ignore SCREEN_SHARE_AUDIO, CAMERA, MICROPHONE.
+        if (track.Source != ScreenShareSource)
+            return;
+
+        var conversationId = result.Conversation.Id;
+        var username = result.Participant?.Username.Value;
+
+        if (eventType == TrackPublishedEvent)
+        {
+            var addResult = await _conversationVoiceParticipantCache.TryAddScreenShareTrackAsync(
+                conversationId, participantUserId, track.Sid, ct);
+
+            if (addResult.IsFirst)
+            {
+                await _conversationVoicePresenceNotifier.NotifyScreenShareStartedAsync(
+                    new ConversationVoiceScreenShareNotification(
+                        conversationId, participantUserId, username, webhookEvent.OccurredAtUtc),
+                    ct);
+            }
+        }
+        else if (eventType == TrackUnpublishedEvent)
+        {
+            var removeResult = await _conversationVoiceParticipantCache.TryRemoveScreenShareTrackAsync(
+                conversationId, participantUserId, track.Sid, ct);
+
+            if (removeResult.IsLast)
+            {
+                await _conversationVoicePresenceNotifier.NotifyScreenShareStoppedAsync(
+                    new ConversationVoiceScreenShareNotification(
+                        conversationId, participantUserId, username, webhookEvent.OccurredAtUtc),
+                    ct);
+            }
+        }
     }
 }

--- a/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
@@ -1,5 +1,6 @@
 using Harmonie.Domain.Entities.Conversations;
 using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
 
 namespace Harmonie.Application.Interfaces.Conversations;
@@ -12,6 +13,18 @@ public sealed record ConversationParticipantSummary(
     string? AvatarColor,
     string? AvatarIcon,
     string? AvatarBg);
+
+public sealed record ConversationParticipantProfile(
+    Username Username,
+    string? DisplayName,
+    UploadedFileId? AvatarFileId,
+    string? AvatarColor,
+    string? AvatarIcon,
+    string? AvatarBg);
+
+public sealed record ConversationWithParticipant(
+    Conversation Conversation,
+    ConversationParticipantProfile? Participant);
 
 public sealed record ConversationGetOrCreateResult(Conversation Conversation, bool WasCreated);
 
@@ -49,6 +62,11 @@ public interface IConversationRepository
         CancellationToken cancellationToken = default);
 
     Task<ConversationAccess?> GetByIdWithParticipantCheckAsync(
+        ConversationId conversationId,
+        UserId userId,
+        CancellationToken cancellationToken = default);
+
+    Task<ConversationWithParticipant?> GetWithParticipantAsync(
         ConversationId conversationId,
         UserId userId,
         CancellationToken cancellationToken = default);

--- a/src/Harmonie.Application/Interfaces/Voice/IConversationVoiceParticipantCache.cs
+++ b/src/Harmonie.Application/Interfaces/Voice/IConversationVoiceParticipantCache.cs
@@ -1,0 +1,30 @@
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Interfaces.Voice;
+
+public interface IConversationVoiceParticipantCache
+{
+    Task AddOrUpdateAsync(ConversationId conversationId, CachedVoiceParticipant participant, CancellationToken cancellationToken = default);
+
+    Task RemoveAsync(ConversationId conversationId, UserId userId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<CachedVoiceParticipant>> GetAsync(ConversationId conversationId, CancellationToken cancellationToken = default);
+
+    Task<ScreenShareTrackAddResult> TryAddScreenShareTrackAsync(
+        ConversationId conversationId,
+        UserId userId,
+        string trackSid,
+        CancellationToken cancellationToken = default);
+
+    Task<ScreenShareTrackRemoveResult> TryRemoveScreenShareTrackAsync(
+        ConversationId conversationId,
+        UserId userId,
+        string trackSid,
+        CancellationToken cancellationToken = default);
+
+    Task<bool> ClearScreenShareTracksAsync(
+        ConversationId conversationId,
+        UserId userId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Harmonie.Application/Interfaces/Voice/IConversationVoicePresenceNotifier.cs
+++ b/src/Harmonie.Application/Interfaces/Voice/IConversationVoicePresenceNotifier.cs
@@ -1,0 +1,47 @@
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Uploads;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Interfaces.Voice;
+
+public interface IConversationVoicePresenceNotifier
+{
+    Task NotifyParticipantJoinedAsync(
+        ConversationVoiceParticipantJoinedNotification notification,
+        CancellationToken cancellationToken = default);
+
+    Task NotifyParticipantLeftAsync(
+        ConversationVoiceParticipantLeftNotification notification,
+        CancellationToken cancellationToken = default);
+
+    Task NotifyScreenShareStartedAsync(
+        ConversationVoiceScreenShareNotification notification,
+        CancellationToken cancellationToken = default);
+
+    Task NotifyScreenShareStoppedAsync(
+        ConversationVoiceScreenShareNotification notification,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record ConversationVoiceParticipantJoinedNotification(
+    ConversationId ConversationId,
+    UserId UserId,
+    string? Username,
+    string? DisplayName,
+    UploadedFileId? AvatarFileId,
+    string? AvatarColor,
+    string? AvatarIcon,
+    string? AvatarBg,
+    DateTime JoinedAtUtc);
+
+public sealed record ConversationVoiceParticipantLeftNotification(
+    ConversationId ConversationId,
+    UserId UserId,
+    string? Username,
+    DateTime LeftAtUtc);
+
+public sealed record ConversationVoiceScreenShareNotification(
+    ConversationId ConversationId,
+    UserId UserId,
+    string? Username,
+    DateTime TimestampUtc);

--- a/src/Harmonie.Application/Interfaces/Voice/ILiveKitRoomService.cs
+++ b/src/Harmonie.Application/Interfaces/Voice/ILiveKitRoomService.cs
@@ -1,5 +1,6 @@
 using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Users;
 
 namespace Harmonie.Application.Interfaces.Voice;
@@ -12,6 +13,10 @@ public interface ILiveKitRoomService
 
     Task<IReadOnlyList<VoiceChannelParticipant>> ListChannelParticipantsAsync(
         GuildChannelId channelId,
+        CancellationToken ct);
+
+    Task<IReadOnlyList<VoiceChannelParticipant>> ListConversationParticipantsAsync(
+        ConversationId conversationId,
         CancellationToken ct);
 }
 

--- a/src/Harmonie.Application/Interfaces/Voice/ILiveKitTokenService.cs
+++ b/src/Harmonie.Application/Interfaces/Voice/ILiveKitTokenService.cs
@@ -1,4 +1,5 @@
 using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Users;
 
 namespace Harmonie.Application.Interfaces.Voice;
@@ -12,6 +13,12 @@ public interface ILiveKitTokenService
 {
     Task<LiveKitRoomToken> GenerateRoomTokenAsync(
         GuildChannelId channelId,
+        UserId userId,
+        string username,
+        CancellationToken ct);
+
+    Task<LiveKitRoomToken> GenerateConversationRoomTokenAsync(
+        ConversationId conversationId,
         UserId userId,
         string username,
         CancellationToken ct);

--- a/src/Harmonie.Application/Registration/ConversationRegistration.cs
+++ b/src/Harmonie.Application/Registration/ConversationRegistration.cs
@@ -1,5 +1,8 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Features.Conversations.AcknowledgeRead;
+using Harmonie.Application.Features.Conversations.GetConversationVoiceParticipants;
+using Harmonie.Application.Features.Conversations.JoinConversationVoice;
+using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Application.Features.Conversations.AddReaction;
 using Harmonie.Application.Features.Conversations.CreateGroupConversation;
 using Harmonie.Application.Features.Conversations.DeleteConversation;
@@ -49,6 +52,10 @@ public static class ConversationRegistration
         services.AddAuthenticatedHandler<ConversationPinMessageInput, bool, PinMessageHandler>();
         services.AddAuthenticatedHandler<ConversationUnpinMessageInput, bool, UnpinMessageHandler>();
         services.AddAuthenticatedHandler<GetConversationPinnedMessagesInput, GetConversationPinnedMessagesResponse, GetPinnedMessagesHandler>();
+
+        // Voice
+        services.AddAuthenticatedHandler<ConversationId, JoinConversationVoiceResponse, JoinConversationVoiceHandler>();
+        services.AddAuthenticatedHandler<ConversationId, GetConversationVoiceParticipantsResponse, GetConversationVoiceParticipantsHandler>();
 
         return services;
     }

--- a/src/Harmonie.Infrastructure/Authentication/LiveKitTokenService.cs
+++ b/src/Harmonie.Infrastructure/Authentication/LiveKitTokenService.cs
@@ -1,5 +1,6 @@
 using Harmonie.Application.Interfaces.Voice;
 using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Users;
 using Harmonie.Infrastructure.Configuration;
 using Livekit.Server.Sdk.Dotnet;
@@ -19,13 +20,26 @@ public sealed class LiveKitTokenService : ILiveKitTokenService
         string username,
         CancellationToken ct)
     {
-        var roomName = $"channel:{channelId}";
+        return Task.FromResult(BuildToken($"channel:{channelId}", userId, username));
+    }
+
+    public Task<LiveKitRoomToken> GenerateConversationRoomTokenAsync(
+        ConversationId conversationId,
+        UserId userId,
+        string username,
+        CancellationToken ct)
+    {
+        return Task.FromResult(BuildToken($"conversation:{conversationId}", userId, username));
+    }
+
+    private LiveKitRoomToken BuildToken(string roomName, UserId userId, string username)
+    {
         var jwt = new AccessToken(_settings.ApiKey, _settings.ApiSecret)
             .WithIdentity(userId.ToString())
             .WithName(username)
             .WithGrants(new VideoGrants { RoomJoin = true, Room = roomName })
             .ToJwt();
 
-        return Task.FromResult(new LiveKitRoomToken(jwt, _settings.PublicUrl, roomName));
+        return new LiveKitRoomToken(jwt, _settings.PublicUrl, roomName);
     }
 }

--- a/src/Harmonie.Infrastructure/LiveKit/LiveKitRoomService.cs
+++ b/src/Harmonie.Infrastructure/LiveKit/LiveKitRoomService.cs
@@ -2,6 +2,7 @@ using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Voice;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Users;
 using Livekit.Server.Sdk.Dotnet;
@@ -49,7 +50,7 @@ public sealed class LiveKitRoomService : ILiveKitRoomService
 
         foreach (var voiceChannel in voiceChannels)
         {
-            var roomName = BuildRoomName(voiceChannel.Id);
+            var roomName = BuildChannelRoomName(voiceChannel.Id);
             if (!activeRoomNames.Contains(roomName))
             {
                 _logger.LogDebug(
@@ -118,7 +119,7 @@ public sealed class LiveKitRoomService : ILiveKitRoomService
         GuildChannelId channelId,
         CancellationToken ct)
     {
-        var roomName = BuildRoomName(channelId);
+        var roomName = BuildChannelRoomName(channelId);
         var participants = await _roomApiClient.ListParticipantsAsync(roomName, ct);
 
         return participants
@@ -127,6 +128,19 @@ public sealed class LiveKitRoomService : ILiveKitRoomService
             .ToArray();
     }
 
-    private static string BuildRoomName(GuildChannelId channelId)
+    public async Task<IReadOnlyList<VoiceChannelParticipant>> ListConversationParticipantsAsync(
+        ConversationId conversationId,
+        CancellationToken ct)
+    {
+        var roomName = $"conversation:{conversationId}";
+        var participants = await _roomApiClient.ListParticipantsAsync(roomName, ct);
+
+        return participants
+            .Select(TryMapParticipant)
+            .OfType<VoiceChannelParticipant>()
+            .ToArray();
+    }
+
+    private static string BuildChannelRoomName(GuildChannelId channelId)
         => $"{ChannelRoomPrefix}{channelId}";
 }

--- a/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
@@ -2,6 +2,7 @@ using Dapper;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Domain.Entities.Conversations;
 using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
 using Harmonie.Infrastructure.Persistence.Common;
 using Harmonie.Infrastructure.Rows.Conversations;
@@ -272,6 +273,63 @@ public sealed class ConversationRepository : IConversationRepository
         return new ConversationAccess(conversation, participant, row.Username, row.DisplayName);
     }
 
+    public async Task<ConversationWithParticipant?> GetWithParticipantAsync(
+        ConversationId conversationId,
+        UserId userId,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+                           SELECT c.id              AS "Id",
+                                  c.type            AS "Type",
+                                  c.name            AS "Name",
+                                  c.created_at_utc  AS "CreatedAtUtc",
+                                  cp.user_id        AS "ParticipantUserId",
+                                  u.username        AS "Username",
+                                  u.display_name    AS "DisplayName",
+                                  u.avatar_file_id  AS "AvatarFileId",
+                                  u.avatar_color    AS "AvatarColor",
+                                  u.avatar_icon     AS "AvatarIcon",
+                                  u.avatar_bg       AS "AvatarBg"
+                           FROM conversations c
+                           LEFT JOIN conversation_participants cp
+                             ON cp.conversation_id = c.id AND cp.user_id = @UserId
+                           LEFT JOIN users u
+                             ON u.id = @UserId
+                            AND u.deleted_at IS NULL
+                           WHERE c.id = @ConversationId
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new { ConversationId = conversationId.Value, UserId = userId.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        var row = await connection.QueryFirstOrDefaultAsync<ConversationWithParticipantProfileRow>(command);
+        if (row is null)
+            return null;
+
+        var conversation = MapToConversation(row);
+
+        if (row.ParticipantUserId is null || row.Username is null)
+            return new ConversationWithParticipant(conversation, null);
+
+        var usernameResult = Username.Create(row.Username);
+        if (usernameResult.IsFailure || usernameResult.Value is null)
+            throw new InvalidOperationException("Stored username is invalid.");
+
+        var profile = new ConversationParticipantProfile(
+            usernameResult.Value,
+            row.DisplayName,
+            row.AvatarFileId.HasValue ? UploadedFileId.From(row.AvatarFileId.Value) : null,
+            row.AvatarColor,
+            row.AvatarIcon,
+            row.AvatarBg);
+
+        return new ConversationWithParticipant(conversation, profile);
+    }
+
     public async Task DeleteAsync(
         ConversationId conversationId,
         CancellationToken cancellationToken = default)
@@ -359,5 +417,37 @@ public sealed class ConversationRepository : IConversationRepository
 
         public string? DisplayName { get; init; }
     }
+
+    private sealed class ConversationWithParticipantProfileRow
+    {
+        public Guid Id { get; init; }
+
+        public string Type { get; init; } = string.Empty;
+
+        public string? Name { get; init; }
+
+        public DateTime CreatedAtUtc { get; init; }
+
+        public Guid? ParticipantUserId { get; init; }
+
+        public string? Username { get; init; }
+
+        public string? DisplayName { get; init; }
+
+        public Guid? AvatarFileId { get; init; }
+
+        public string? AvatarColor { get; init; }
+
+        public string? AvatarIcon { get; init; }
+
+        public string? AvatarBg { get; init; }
+    }
+
+    private static Conversation MapToConversation(ConversationWithParticipantProfileRow row)
+        => Conversation.Rehydrate(
+            ConversationId.From(row.Id),
+            ParseConversationType(row.Type),
+            row.Name,
+            row.CreatedAtUtc);
 
 }

--- a/tests/Harmonie.API.IntegrationTests/Conversations/GetConversationVoiceParticipantsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/GetConversationVoiceParticipantsTests.cs
@@ -1,0 +1,99 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Harmonie.API.IntegrationTests.Common;
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Conversations.GetConversationVoiceParticipants;
+using Harmonie.Application.Features.Conversations.OpenConversation;
+using Xunit;
+
+namespace Harmonie.API.IntegrationTests.Conversations;
+
+public sealed class GetConversationVoiceParticipantsTests : IClassFixture<HarmonieWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public GetConversationVoiceParticipantsTests(HarmonieWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task GetConversationVoiceParticipants_WhenParticipantQueriesEmptyRoom_ShouldReturn200WithEmptyList()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var target = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await OpenConversationAndGetIdAsync(caller.AccessToken, target.UserId);
+
+        var response = await _client.SendAuthorizedGetAsync(
+            $"/api/conversations/{conversationId}/voice/participants",
+            caller.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<GetConversationVoiceParticipantsResponse>(TestContext.Current.CancellationToken);
+        payload.Should().NotBeNull();
+        payload!.Participants.Should().NotBeNull();
+        payload.Participants.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetConversationVoiceParticipants_WhenUserIsNotParticipant_ShouldReturn403()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var target = await AuthTestHelper.RegisterAsync(_client);
+        var outsider = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await OpenConversationAndGetIdAsync(caller.AccessToken, target.UserId);
+
+        var response = await _client.SendAuthorizedGetAsync(
+            $"/api/conversations/{conversationId}/voice/participants",
+            outsider.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Conversation.VoiceAccessDenied);
+    }
+
+    [Fact]
+    public async Task GetConversationVoiceParticipants_WhenConversationDoesNotExist_ShouldReturn404()
+    {
+        var user = await AuthTestHelper.RegisterAsync(_client);
+
+        var response = await _client.SendAuthorizedGetAsync(
+            $"/api/conversations/{Guid.NewGuid()}/voice/participants",
+            user.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
+    }
+
+    [Fact]
+    public async Task GetConversationVoiceParticipants_WhenNotAuthenticated_ShouldReturn401()
+    {
+        var response = await _client.GetAsync(
+            $"/api/conversations/{Guid.NewGuid()}/voice/participants",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────────
+
+    private async Task<Guid> OpenConversationAndGetIdAsync(string accessToken, Guid targetUserId)
+    {
+        var response = await _client.SendAuthorizedPostAsync(
+            "/api/conversations",
+            new OpenConversationRequest(targetUserId),
+            accessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var payload = await response.Content.ReadFromJsonAsync<OpenConversationResponse>(TestContext.Current.CancellationToken);
+        return payload!.ConversationId;
+    }
+}

--- a/tests/Harmonie.API.IntegrationTests/Conversations/JoinConversationVoiceTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/JoinConversationVoiceTests.cs
@@ -1,0 +1,101 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Harmonie.API.IntegrationTests.Common;
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Conversations.JoinConversationVoice;
+using Harmonie.Application.Features.Conversations.OpenConversation;
+using Xunit;
+
+namespace Harmonie.API.IntegrationTests.Conversations;
+
+public sealed class JoinConversationVoiceTests : IClassFixture<HarmonieWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public JoinConversationVoiceTests(HarmonieWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task JoinConversationVoice_WhenParticipantJoins_ShouldReturn200WithToken()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var target = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await OpenConversationAndGetIdAsync(caller.AccessToken, target.UserId);
+
+        var response = await _client.SendAuthorizedPostNoBodyAsync(
+            $"/api/conversations/{conversationId}/voice/join",
+            caller.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<JoinConversationVoiceResponse>(TestContext.Current.CancellationToken);
+        payload.Should().NotBeNull();
+        payload!.Token.Should().NotBeNullOrWhiteSpace();
+        payload.RoomName.Should().Be($"conversation:{conversationId}");
+        payload.CurrentParticipants.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task JoinConversationVoice_WhenUserIsNotParticipant_ShouldReturn403()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var target = await AuthTestHelper.RegisterAsync(_client);
+        var outsider = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await OpenConversationAndGetIdAsync(caller.AccessToken, target.UserId);
+
+        var response = await _client.SendAuthorizedPostNoBodyAsync(
+            $"/api/conversations/{conversationId}/voice/join",
+            outsider.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Conversation.VoiceAccessDenied);
+    }
+
+    [Fact]
+    public async Task JoinConversationVoice_WhenConversationDoesNotExist_ShouldReturn404()
+    {
+        var user = await AuthTestHelper.RegisterAsync(_client);
+
+        var response = await _client.SendAuthorizedPostNoBodyAsync(
+            $"/api/conversations/{Guid.NewGuid()}/voice/join",
+            user.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
+    }
+
+    [Fact]
+    public async Task JoinConversationVoice_WhenNotAuthenticated_ShouldReturn401()
+    {
+        var response = await _client.PostAsync(
+            $"/api/conversations/{Guid.NewGuid()}/voice/join",
+            content: null,
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────────
+
+    private async Task<Guid> OpenConversationAndGetIdAsync(string accessToken, Guid targetUserId)
+    {
+        var response = await _client.SendAuthorizedPostAsync(
+            "/api/conversations",
+            new OpenConversationRequest(targetUserId),
+            accessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var payload = await response.Content.ReadFromJsonAsync<OpenConversationResponse>(TestContext.Current.CancellationToken);
+        return payload!.ConversationId;
+    }
+}

--- a/tests/Harmonie.API.IntegrationTests/Guilds/GuildVoiceParticipantsEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/GuildVoiceParticipantsEndpointTests.cs
@@ -7,6 +7,7 @@ using Harmonie.Application.Features.Guilds.CreateGuild;
 using Harmonie.Application.Features.Guilds.GetGuildChannels;
 using Harmonie.Application.Features.Guilds.GetGuildVoiceParticipants;
 using Harmonie.Application.Interfaces.Voice;
+using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Users;
@@ -134,6 +135,11 @@ public sealed class GuildVoiceParticipantsEndpointTests : IClassFixture<Harmonie
 
         public Task<IReadOnlyList<VoiceChannelParticipant>> ListChannelParticipantsAsync(
             GuildChannelId channelId,
+            CancellationToken ct)
+            => Task.FromResult<IReadOnlyList<VoiceChannelParticipant>>([]);
+
+        public Task<IReadOnlyList<VoiceChannelParticipant>> ListConversationParticipantsAsync(
+            ConversationId conversationId,
             CancellationToken ct)
             => Task.FromResult<IReadOnlyList<VoiceChannelParticipant>>([]);
     }

--- a/tests/Harmonie.Application.Tests/Conversations/GetConversationVoiceParticipantsHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/GetConversationVoiceParticipantsHandlerTests.cs
@@ -1,0 +1,126 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Conversations.GetConversationVoiceParticipants;
+using Harmonie.Application.Tests.Common;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Interfaces.Voice;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Users;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Conversations;
+
+public sealed class GetConversationVoiceParticipantsHandlerTests
+{
+    private readonly Mock<IConversationRepository> _conversationRepositoryMock;
+    private readonly Mock<ILiveKitRoomService> _liveKitRoomServiceMock;
+    private readonly Mock<IConversationVoiceParticipantCache> _voiceParticipantCacheMock;
+    private readonly GetConversationVoiceParticipantsHandler _handler;
+
+    public GetConversationVoiceParticipantsHandlerTests()
+    {
+        _conversationRepositoryMock = new Mock<IConversationRepository>();
+        _liveKitRoomServiceMock = new Mock<ILiveKitRoomService>();
+        _voiceParticipantCacheMock = new Mock<IConversationVoiceParticipantCache>();
+
+        _voiceParticipantCacheMock
+            .Setup(x => x.GetAsync(It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        _liveKitRoomServiceMock
+            .Setup(x => x.ListConversationParticipantsAsync(It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        _handler = new GetConversationVoiceParticipantsHandler(
+            _conversationRepositoryMock.Object,
+            _liveKitRoomServiceMock.Object,
+            _voiceParticipantCacheMock.Object);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenConversationDoesNotExist_ShouldReturnNotFound()
+    {
+        var conversationId = ConversationId.New();
+        var userId = UserId.New();
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversationId, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConversationAccess?)null);
+
+        var response = await _handler.HandleAsync(conversationId, userId, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeFalse();
+        response.Error.Should().NotBeNull();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenUserIsNotParticipant_ShouldReturnVoiceAccessDenied()
+    {
+        var conversationId = ConversationId.New();
+        var userId = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(userId, UserId.New());
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversationId, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: null));
+
+        var response = await _handler.HandleAsync(conversationId, userId, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeFalse();
+        response.Error.Should().NotBeNull();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.VoiceAccessDenied);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenRoomIsEmpty_ShouldReturnEmptyList()
+    {
+        var userId = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(userId, UserId.New());
+        var participant = ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, userId);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, participant));
+
+        var response = await _handler.HandleAsync(conversation.Id, userId, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data.Should().NotBeNull();
+        response.Data!.Participants.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenParticipantsInLiveKit_ShouldReturnEnrichedWithCacheData()
+    {
+        var userId = UserId.New();
+        var otherUserId = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(userId, otherUserId);
+        var participant = ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, userId);
+        var cached = new CachedVoiceParticipant(otherUserId, "other_user", "Other User", null, "#ABC", null, null);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, participant));
+
+        _liveKitRoomServiceMock
+            .Setup(x => x.ListConversationParticipantsAsync(conversation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new VoiceChannelParticipant(otherUserId, "other_user", IsSharingScreen: true)]);
+
+        _voiceParticipantCacheMock
+            .Setup(x => x.GetAsync(conversation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([cached]);
+
+        var response = await _handler.HandleAsync(conversation.Id, userId, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data!.Participants.Should().HaveCount(1);
+
+        var dto = response.Data.Participants[0];
+        dto.UserId.Should().Be(otherUserId.Value);
+        dto.DisplayName.Should().Be("Other User");
+        dto.AvatarColor.Should().Be("#ABC");
+        dto.IsSharingScreen.Should().BeTrue();
+    }
+}

--- a/tests/Harmonie.Application.Tests/Conversations/JoinConversationVoiceHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/JoinConversationVoiceHandlerTests.cs
@@ -1,0 +1,216 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Conversations.JoinConversationVoice;
+using Harmonie.Application.Tests.Common;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Interfaces.Users;
+using Harmonie.Application.Interfaces.Voice;
+using Harmonie.Domain.Entities.Conversations;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Users;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Conversations;
+
+public sealed class JoinConversationVoiceHandlerTests
+{
+    private readonly Mock<IConversationRepository> _conversationRepositoryMock;
+    private readonly Mock<IUserRepository> _userRepositoryMock;
+    private readonly Mock<ILiveKitTokenService> _liveKitTokenServiceMock;
+    private readonly Mock<ILiveKitRoomService> _liveKitRoomServiceMock;
+    private readonly Mock<IConversationVoiceParticipantCache> _voiceParticipantCacheMock;
+    private readonly JoinConversationVoiceHandler _handler;
+
+    public JoinConversationVoiceHandlerTests()
+    {
+        _conversationRepositoryMock = new Mock<IConversationRepository>();
+        _userRepositoryMock = new Mock<IUserRepository>();
+        _liveKitTokenServiceMock = new Mock<ILiveKitTokenService>();
+        _liveKitRoomServiceMock = new Mock<ILiveKitRoomService>();
+        _voiceParticipantCacheMock = new Mock<IConversationVoiceParticipantCache>();
+
+        _voiceParticipantCacheMock
+            .Setup(x => x.GetAsync(It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        _voiceParticipantCacheMock
+            .Setup(x => x.AddOrUpdateAsync(It.IsAny<ConversationId>(), It.IsAny<CachedVoiceParticipant>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _liveKitRoomServiceMock
+            .Setup(x => x.ListConversationParticipantsAsync(It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        _handler = new JoinConversationVoiceHandler(
+            _conversationRepositoryMock.Object,
+            _userRepositoryMock.Object,
+            _liveKitTokenServiceMock.Object,
+            _liveKitRoomServiceMock.Object,
+            _voiceParticipantCacheMock.Object);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenConversationDoesNotExist_ShouldReturnNotFound()
+    {
+        var conversationId = ConversationId.New();
+        var userId = UserId.New();
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversationId, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConversationAccess?)null);
+
+        var response = await _handler.HandleAsync(conversationId, userId, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeFalse();
+        response.Error.Should().NotBeNull();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.NotFound);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenUserIsNotParticipant_ShouldReturnVoiceAccessDenied()
+    {
+        var conversationId = ConversationId.New();
+        var userId = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(userId, UserId.New());
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversationId, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, Participant: null));
+
+        var response = await _handler.HandleAsync(conversationId, userId, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeFalse();
+        response.Error.Should().NotBeNull();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Conversation.VoiceAccessDenied);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenUserProfileNotFound_ShouldReturnUserNotFound()
+    {
+        var userId = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(userId, UserId.New());
+        var participant = ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, userId);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, participant));
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Harmonie.Domain.Entities.Users.User?)null);
+
+        var response = await _handler.HandleAsync(conversation.Id, userId, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeFalse();
+        response.Error.Should().NotBeNull();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.User.NotFound);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenRoomIsEmpty_ShouldReturnTokenWithNoParticipants()
+    {
+        var userId = UserId.New();
+        var user = ApplicationTestBuilders.CreateUser(userId);
+        var conversation = ApplicationTestBuilders.CreateConversation(userId, UserId.New());
+        var participant = ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, userId);
+        var roomName = $"conversation:{conversation.Id}";
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, participant));
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _liveKitTokenServiceMock
+            .Setup(x => x.GenerateConversationRoomTokenAsync(conversation.Id, userId, user.Username.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LiveKitRoomToken("jwt-token", "ws://livekit", roomName));
+
+        var response = await _handler.HandleAsync(conversation.Id, userId, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data.Should().NotBeNull();
+        response.Data!.Token.Should().Be("jwt-token");
+        response.Data.RoomName.Should().Be(roomName);
+        response.Data.CurrentParticipants.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenParticipantInLiveKitButNotInCache_ShouldFetchFromDbAndCacheIt()
+    {
+        var userId = UserId.New();
+        var user = ApplicationTestBuilders.CreateUser(userId);
+        var otherUser = ApplicationTestBuilders.CreateUser();
+        var conversation = ApplicationTestBuilders.CreateConversation(userId, otherUser.Id);
+        var participant = ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, userId);
+        var roomName = $"conversation:{conversation.Id}";
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, participant));
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _liveKitTokenServiceMock
+            .Setup(x => x.GenerateConversationRoomTokenAsync(conversation.Id, userId, user.Username.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LiveKitRoomToken("jwt-token", "ws://livekit", roomName));
+
+        _liveKitRoomServiceMock
+            .Setup(x => x.ListConversationParticipantsAsync(conversation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new VoiceChannelParticipant(otherUser.Id, otherUser.Username.Value)]);
+
+        _userRepositoryMock
+            .Setup(x => x.GetManyByIdsAsync(It.IsAny<IReadOnlyList<UserId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([otherUser]);
+
+        var response = await _handler.HandleAsync(conversation.Id, userId, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data!.CurrentParticipants.Should().HaveCount(1);
+        response.Data.CurrentParticipants[0].UserId.Should().Be(otherUser.Id.Value);
+
+        _voiceParticipantCacheMock.Verify(
+            x => x.AddOrUpdateAsync(conversation.Id, It.IsAny<CachedVoiceParticipant>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenStaleParticipantInCache_ShouldRemoveFromCache()
+    {
+        var userId = UserId.New();
+        var user = ApplicationTestBuilders.CreateUser(userId);
+        var staleUserId = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(userId, UserId.New());
+        var participant = ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, userId);
+        var staleParticipant = new CachedVoiceParticipant(staleUserId, "stale", null, null, null, null, null);
+        var roomName = $"conversation:{conversation.Id}";
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation, participant));
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _liveKitTokenServiceMock
+            .Setup(x => x.GenerateConversationRoomTokenAsync(conversation.Id, userId, user.Username.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LiveKitRoomToken("jwt-token", "ws://livekit", roomName));
+
+        _voiceParticipantCacheMock
+            .Setup(x => x.GetAsync(conversation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([staleParticipant]);
+
+        var response = await _handler.HandleAsync(conversation.Id, userId, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+
+        _voiceParticipantCacheMock.Verify(
+            x => x.RemoveAsync(conversation.Id, staleUserId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/tests/Harmonie.Application.Tests/Voice/HandleLiveKitWebhookHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Voice/HandleLiveKitWebhookHandlerTests.cs
@@ -3,10 +3,12 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Features.Voice.HandleLiveKitWebhook;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Voice;
 using Harmonie.Domain.Entities.Guilds;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
 using Moq;
@@ -18,22 +20,31 @@ public sealed class HandleLiveKitWebhookHandlerTests
 {
     private readonly Mock<ILiveKitWebhookReceiver> _webhookReceiverMock;
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
+    private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IVoicePresenceNotifier> _voicePresenceNotifierMock;
     private readonly Mock<IVoiceParticipantCache> _voiceParticipantCacheMock;
+    private readonly Mock<IConversationVoicePresenceNotifier> _conversationVoicePresenceNotifierMock;
+    private readonly Mock<IConversationVoiceParticipantCache> _conversationVoiceParticipantCacheMock;
     private readonly HandleLiveKitWebhookHandler _handler;
 
     public HandleLiveKitWebhookHandlerTests()
     {
         _webhookReceiverMock = new Mock<ILiveKitWebhookReceiver>();
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
+        _conversationRepositoryMock = new Mock<IConversationRepository>();
         _voicePresenceNotifierMock = new Mock<IVoicePresenceNotifier>();
         _voiceParticipantCacheMock = new Mock<IVoiceParticipantCache>();
+        _conversationVoicePresenceNotifierMock = new Mock<IConversationVoicePresenceNotifier>();
+        _conversationVoiceParticipantCacheMock = new Mock<IConversationVoiceParticipantCache>();
 
         _handler = new HandleLiveKitWebhookHandler(
             _webhookReceiverMock.Object,
             _guildChannelRepositoryMock.Object,
+            _conversationRepositoryMock.Object,
             _voicePresenceNotifierMock.Object,
-            _voiceParticipantCacheMock.Object);
+            _voiceParticipantCacheMock.Object,
+            _conversationVoicePresenceNotifierMock.Object,
+            _conversationVoiceParticipantCacheMock.Object);
     }
 
     [Fact]
@@ -592,6 +603,224 @@ public sealed class HandleLiveKitWebhookHandlerTests
             x => x.TryRemoveScreenShareTrackAsync(
                 It.IsAny<GuildChannelId>(), It.IsAny<UserId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    // ─── Conversation voice webhook tests ─────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_WhenConversationParticipantJoined_ShouldAddToCacheAndNotify()
+    {
+        var conversationId = ConversationId.New();
+        var participantUserId = UserId.New();
+        var request = new HandleLiveKitWebhookRequest("{}", "Bearer token");
+        var occurredAt = DateTime.UtcNow;
+        var conversation = Harmonie.Domain.Entities.Conversations.Conversation.Rehydrate(
+            conversationId,
+            Harmonie.Domain.Entities.Conversations.ConversationType.Direct,
+            null,
+            DateTime.UtcNow);
+
+        _webhookReceiverMock
+            .Setup(x => x.Receive(request.RawBody, request.AuthorizationHeader!))
+            .Returns(LiveKitWebhookReceiveResult.Ok(
+                new LiveKitWebhookEvent(
+                    "participant_joined",
+                    $"conversation:{conversationId}",
+                    participantUserId.ToString(),
+                    "alice",
+                    occurredAt)));
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetWithParticipantAsync(conversationId, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationWithParticipant(conversation, null));
+
+        _conversationVoiceParticipantCacheMock
+            .Setup(x => x.AddOrUpdateAsync(conversationId, It.IsAny<CachedVoiceParticipant>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data!.Processed.Should().BeTrue();
+
+        _conversationVoiceParticipantCacheMock.Verify(
+            x => x.AddOrUpdateAsync(conversationId, It.IsAny<CachedVoiceParticipant>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _conversationVoicePresenceNotifierMock.Verify(
+            x => x.NotifyParticipantJoinedAsync(
+                It.Is<ConversationVoiceParticipantJoinedNotification>(n =>
+                    n.ConversationId == conversationId
+                    && n.UserId == participantUserId
+                    && n.JoinedAtUtc == occurredAt),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenConversationParticipantLeft_ShouldClearTracksRemoveAndNotify()
+    {
+        var conversationId = ConversationId.New();
+        var participantUserId = UserId.New();
+        var request = new HandleLiveKitWebhookRequest("{}", "Bearer token");
+        var occurredAt = DateTime.UtcNow;
+        var conversation = Harmonie.Domain.Entities.Conversations.Conversation.Rehydrate(
+            conversationId,
+            Harmonie.Domain.Entities.Conversations.ConversationType.Direct,
+            null,
+            DateTime.UtcNow);
+
+        _webhookReceiverMock
+            .Setup(x => x.Receive(request.RawBody, request.AuthorizationHeader!))
+            .Returns(LiveKitWebhookReceiveResult.Ok(
+                new LiveKitWebhookEvent(
+                    "participant_left",
+                    $"conversation:{conversationId}",
+                    participantUserId.ToString(),
+                    "alice",
+                    occurredAt)));
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetWithParticipantAsync(conversationId, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationWithParticipant(conversation, null));
+
+        _conversationVoiceParticipantCacheMock
+            .Setup(x => x.ClearScreenShareTracksAsync(conversationId, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data!.Processed.Should().BeTrue();
+
+        _conversationVoiceParticipantCacheMock.Verify(
+            x => x.ClearScreenShareTracksAsync(conversationId, participantUserId, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _conversationVoiceParticipantCacheMock.Verify(
+            x => x.RemoveAsync(conversationId, participantUserId, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _conversationVoicePresenceNotifierMock.Verify(
+            x => x.NotifyParticipantLeftAsync(
+                It.Is<ConversationVoiceParticipantLeftNotification>(n =>
+                    n.ConversationId == conversationId
+                    && n.UserId == participantUserId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenConversationScreenShareStarted_ShouldNotifyScreenShareStarted()
+    {
+        var conversationId = ConversationId.New();
+        var participantUserId = UserId.New();
+        var trackSid = "TR_screen_conv_001";
+        var request = new HandleLiveKitWebhookRequest("{}", "Bearer token");
+        var conversation = Harmonie.Domain.Entities.Conversations.Conversation.Rehydrate(
+            conversationId,
+            Harmonie.Domain.Entities.Conversations.ConversationType.Direct,
+            null,
+            DateTime.UtcNow);
+
+        _webhookReceiverMock
+            .Setup(x => x.Receive(request.RawBody, request.AuthorizationHeader!))
+            .Returns(LiveKitWebhookReceiveResult.Ok(
+                new LiveKitWebhookEvent(
+                    "track_published",
+                    $"conversation:{conversationId}",
+                    participantUserId.ToString(),
+                    "alice",
+                    DateTime.UtcNow,
+                    new LiveKitTrackInfo(trackSid, "SCREEN_SHARE", "VIDEO", false, 1920, 1080))));
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetWithParticipantAsync(conversationId, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationWithParticipant(conversation, null));
+
+        _conversationVoiceParticipantCacheMock
+            .Setup(x => x.TryAddScreenShareTrackAsync(conversationId, participantUserId, trackSid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ScreenShareTrackAddResult(true));
+
+        await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        _conversationVoicePresenceNotifierMock.Verify(
+            x => x.NotifyScreenShareStartedAsync(
+                It.Is<ConversationVoiceScreenShareNotification>(n =>
+                    n.ConversationId == conversationId
+                    && n.UserId == participantUserId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenConversationScreenShareStopped_ShouldNotifyScreenShareStopped()
+    {
+        var conversationId = ConversationId.New();
+        var participantUserId = UserId.New();
+        var trackSid = "TR_screen_conv_001";
+        var request = new HandleLiveKitWebhookRequest("{}", "Bearer token");
+        var conversation = Harmonie.Domain.Entities.Conversations.Conversation.Rehydrate(
+            conversationId,
+            Harmonie.Domain.Entities.Conversations.ConversationType.Direct,
+            null,
+            DateTime.UtcNow);
+
+        _webhookReceiverMock
+            .Setup(x => x.Receive(request.RawBody, request.AuthorizationHeader!))
+            .Returns(LiveKitWebhookReceiveResult.Ok(
+                new LiveKitWebhookEvent(
+                    "track_unpublished",
+                    $"conversation:{conversationId}",
+                    participantUserId.ToString(),
+                    "alice",
+                    DateTime.UtcNow,
+                    new LiveKitTrackInfo(trackSid, "SCREEN_SHARE", "VIDEO", false, 1920, 1080))));
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetWithParticipantAsync(conversationId, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationWithParticipant(conversation, null));
+
+        _conversationVoiceParticipantCacheMock
+            .Setup(x => x.TryRemoveScreenShareTrackAsync(conversationId, participantUserId, trackSid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ScreenShareTrackRemoveResult(true));
+
+        await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        _conversationVoicePresenceNotifierMock.Verify(
+            x => x.NotifyScreenShareStoppedAsync(
+                It.Is<ConversationVoiceScreenShareNotification>(n =>
+                    n.ConversationId == conversationId
+                    && n.UserId == participantUserId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenConversationNotFound_ShouldNotProcess()
+    {
+        var conversationId = ConversationId.New();
+        var participantUserId = UserId.New();
+        var request = new HandleLiveKitWebhookRequest("{}", "Bearer token");
+
+        _webhookReceiverMock
+            .Setup(x => x.Receive(request.RawBody, request.AuthorizationHeader!))
+            .Returns(LiveKitWebhookReceiveResult.Ok(
+                new LiveKitWebhookEvent(
+                    "participant_joined",
+                    $"conversation:{conversationId}",
+                    participantUserId.ToString(),
+                    "alice",
+                    DateTime.UtcNow)));
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetWithParticipantAsync(conversationId, participantUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConversationWithParticipant?)null);
+
+        var response = await _handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data!.Processed.Should().BeFalse();
     }
 
 }


### PR DESCRIPTION
## Summary

- Add voice call support for direct and group conversations via LiveKit (`conversation:{conversationId}` room naming)
- Full screen sharing parity with guild voice channels (join/leave/screen share webhooks, SignalR events, in-memory cache)
- Extend webhook handler to route `conversation:` prefix events alongside existing `channel:` prefix

## New endpoints

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/api/conversations/{id}/voice/join` | Join a conversation voice call — returns LiveKit token + current participants |
| `GET` | `/api/conversations/{id}/voice/participants` | List active voice participants in a conversation |

## New SignalR events

- `ConversationVoiceParticipantJoined`
- `ConversationVoiceParticipantLeft`
- `ConversationVoiceScreenShareStarted`
- `ConversationVoiceScreenShareStopped`

## Test plan

- [ ] 490 Application unit tests pass (15 new: `JoinConversationVoiceHandlerTests`, `GetConversationVoiceParticipantsHandlerTests`, conversation webhook scenarios in `HandleLiveKitWebhookHandlerTests`)
- [ ] 465 Integration tests pass (8 new: `JoinConversationVoiceTests`, `GetConversationVoiceParticipantsTests`)
- [ ] Access denied for non-participants (403)
- [ ] Conversation not found (404)
- [ ] Unauthenticated (401)
- [ ] Screen share start/stop routed correctly via webhook

Closes #366