### PR TITLE
feat(guilds): add HasUnread flag to ListUserGuilds response

### DIFF
--- a/src/Harmonie.Application/Features/Guilds/ListUserGuilds/ListUserGuildsHandler.cs
+++ b/src/Harmonie.Application/Features/Guilds/ListUserGuilds/ListUserGuildsHandler.cs
@@ -39,7 +39,8 @@ public sealed class ListUserGuildsHandler : IAuthenticatedHandler<Unit, ListUser
                             membership.Guild.IconBg)
                         : null,
                     Role: membership.Role.ToString(),
-                    JoinedAtUtc: membership.JoinedAtUtc))
+                    JoinedAtUtc: membership.JoinedAtUtc,
+                    HasUnread: membership.HasUnread))
                 .ToArray());
 
         return ApplicationResponse<ListUserGuildsResponse>.Ok(payload);

--- a/src/Harmonie.Application/Features/Guilds/ListUserGuilds/ListUserGuildsResponse.cs
+++ b/src/Harmonie.Application/Features/Guilds/ListUserGuilds/ListUserGuildsResponse.cs
@@ -12,4 +12,5 @@ public sealed record ListUserGuildsItemResponse(
     Guid? IconFileId,
     GuildIconDto? Icon,
     string Role,
-    DateTime JoinedAtUtc);
+    DateTime JoinedAtUtc,
+    bool HasUnread);

--- a/src/Harmonie.Application/Interfaces/Guilds/IGuildMemberRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Guilds/IGuildMemberRepository.cs
@@ -45,7 +45,8 @@ public interface IGuildMemberRepository
 public sealed record UserGuildMembership(
     Guild Guild,
     GuildRole Role,
-    DateTime JoinedAtUtc);
+    DateTime JoinedAtUtc,
+    bool HasUnread);
 
 public sealed record GuildMemberUserRole(
     GuildRole Role,

--- a/src/Harmonie.Infrastructure/Persistence/Guilds/GuildMemberRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Guilds/GuildMemberRepository.cs
@@ -138,17 +138,43 @@ public sealed class GuildMemberRepository : IGuildMemberRepository
         CancellationToken cancellationToken = default)
     {
         const string sql = """
-                           SELECT g.id AS "GuildId",
-                                  g.name AS "GuildName",
-                                  g.owner_user_id AS "OwnerUserId",
-                                  g.icon_file_id AS "IconFileId",
-                                  g.icon_color AS "IconColor",
-                                  g.icon_name AS "IconName",
-                                  g.icon_bg AS "IconBg",
+                           WITH last_read AS (
+                               SELECT crs.channel_id,
+                                      m.created_at_utc AS boundary_at,
+                                      m.id             AS boundary_id
+                               FROM channel_read_states crs
+                               JOIN messages m ON m.id = crs.last_read_message_id
+                               WHERE crs.user_id = @UserId
+                           )
+                           SELECT g.id             AS "GuildId",
+                                  g.name           AS "GuildName",
+                                  g.owner_user_id  AS "OwnerUserId",
+                                  g.icon_file_id   AS "IconFileId",
+                                  g.icon_color     AS "IconColor",
+                                  g.icon_name      AS "IconName",
+                                  g.icon_bg        AS "IconBg",
                                   g.created_at_utc AS "GuildCreatedAtUtc",
                                   g.updated_at_utc AS "GuildUpdatedAtUtc",
-                                  gm.role AS "Role",
-                                  gm.joined_at_utc AS "JoinedAtUtc"
+                                  gm.role          AS "Role",
+                                  gm.joined_at_utc AS "JoinedAtUtc",
+                                  EXISTS (
+                                      SELECT 1
+                                      FROM guild_channels gc
+                                      LEFT JOIN last_read lr ON lr.channel_id = gc.id
+                                      WHERE gc.guild_id = g.id
+                                        AND gc.type = 1
+                                        AND EXISTS (
+                                            SELECT 1
+                                            FROM messages m
+                                            WHERE m.channel_id = gc.id
+                                              AND m.deleted_at_utc IS NULL
+                                              AND m.author_user_id != @UserId
+                                              AND (
+                                                  lr.boundary_id IS NULL
+                                                  OR (m.created_at_utc, m.id) > (lr.boundary_at, lr.boundary_id)
+                                              )
+                                        )
+                                  ) AS "HasUnread"
                            FROM guild_members gm
                            INNER JOIN guilds g ON g.id = gm.guild_id
                            WHERE gm.user_id = @UserId
@@ -276,7 +302,8 @@ public sealed class GuildMemberRepository : IGuildMemberRepository
         return new UserGuildMembership(
             guild,
             (GuildRole)row.Role,
-            row.JoinedAtUtc);
+            row.JoinedAtUtc,
+            row.HasUnread);
     }
 
     private static GuildMemberUser MapToGuildMemberUser(GuildMemberUserRow row)

--- a/src/Harmonie.Infrastructure/Persistence/Guilds/GuildMemberRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Guilds/GuildMemberRepository.cs
@@ -137,59 +137,53 @@ public sealed class GuildMemberRepository : IGuildMemberRepository
         UserId userId,
         CancellationToken cancellationToken = default)
     {
-        const string sql = """
-                           WITH last_read AS (
-                               SELECT crs.channel_id,
-                                      m.created_at_utc AS boundary_at,
-                                      m.id             AS boundary_id
-                               FROM channel_read_states crs
-                               JOIN messages m ON m.id = crs.last_read_message_id
-                               WHERE crs.user_id = @UserId
-                           )
-                           SELECT g.id             AS "GuildId",
-                                  g.name           AS "GuildName",
-                                  g.owner_user_id  AS "OwnerUserId",
-                                  g.icon_file_id   AS "IconFileId",
-                                  g.icon_color     AS "IconColor",
-                                  g.icon_name      AS "IconName",
-                                  g.icon_bg        AS "IconBg",
-                                  g.created_at_utc AS "GuildCreatedAtUtc",
-                                  g.updated_at_utc AS "GuildUpdatedAtUtc",
-                                  gm.role          AS "Role",
-                                  gm.joined_at_utc AS "JoinedAtUtc",
-                                  EXISTS (
-                                      SELECT 1
-                                      FROM guild_channels gc
-                                      LEFT JOIN last_read lr ON lr.channel_id = gc.id
-                                      WHERE gc.guild_id = g.id
-                                        AND gc.type = 1
-                                        AND EXISTS (
-                                            SELECT 1
-                                            FROM messages m
-                                            WHERE m.channel_id = gc.id
-                                              AND m.deleted_at_utc IS NULL
-                                              AND m.author_user_id != @UserId
-                                              AND (
-                                                  lr.boundary_id IS NULL
-                                                  OR (m.created_at_utc, m.id) > (lr.boundary_at, lr.boundary_id)
-                                              )
-                                        )
-                                  ) AS "HasUnread"
-                           FROM guild_members gm
-                           INNER JOIN guilds g ON g.id = gm.guild_id
-                           WHERE gm.user_id = @UserId
-                           ORDER BY gm.joined_at_utc DESC, gm.guild_id ASC
-                           """;
+        const string membershipsSql = """
+                                     SELECT g.id             AS "GuildId",
+                                            g.name           AS "GuildName",
+                                            g.owner_user_id  AS "OwnerUserId",
+                                            g.icon_file_id   AS "IconFileId",
+                                            g.icon_color     AS "IconColor",
+                                            g.icon_name      AS "IconName",
+                                            g.icon_bg        AS "IconBg",
+                                            g.created_at_utc AS "GuildCreatedAtUtc",
+                                            g.updated_at_utc AS "GuildUpdatedAtUtc",
+                                            gm.role          AS "Role",
+                                            gm.joined_at_utc AS "JoinedAtUtc"
+                                     FROM guild_members gm
+                                     INNER JOIN guilds g ON g.id = gm.guild_id
+                                     WHERE gm.user_id = @UserId
+                                     ORDER BY gm.joined_at_utc DESC, gm.guild_id ASC;
+
+                                     SELECT DISTINCT gc.guild_id AS "GuildId"
+                                     FROM guild_channels gc
+                                     JOIN messages m ON m.channel_id = gc.id
+                                     LEFT JOIN channel_read_states crs
+                                            ON crs.channel_id = gc.id AND crs.user_id = @UserId
+                                     LEFT JOIN messages lrm ON lrm.id = crs.last_read_message_id
+                                     WHERE gc.type = 1
+                                       AND m.deleted_at_utc IS NULL
+                                       AND m.author_user_id != @UserId
+                                       AND (
+                                           crs.last_read_message_id IS NULL
+                                           OR (m.created_at_utc, m.id) > (lrm.created_at_utc, lrm.id)
+                                       )
+                                       AND gc.guild_id IN (
+                                           SELECT guild_id FROM guild_members WHERE user_id = @UserId
+                                       )
+                                     """;
 
         var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
         var command = new CommandDefinition(
-            sql,
+            membershipsSql,
             new { UserId = userId.Value },
             transaction: _dbSession.Transaction,
             cancellationToken: cancellationToken);
 
-        var rows = await connection.QueryAsync<UserGuildMembershipRow>(command);
-        return rows.Select(MapToUserGuildMembership).ToArray();
+        using var multi = await connection.QueryMultipleAsync(command);
+        var rows = await multi.ReadAsync<UserGuildMembershipRow>();
+        var unreadGuildIds = (await multi.ReadAsync<Guid>()).ToHashSet();
+
+        return rows.Select(row => MapToUserGuildMembership(row, unreadGuildIds)).ToArray();
     }
 
     public async Task<IReadOnlyList<GuildMemberUser>> GetGuildMembersAsync(
@@ -279,7 +273,7 @@ public sealed class GuildMemberRepository : IGuildMemberRepository
         return await connection.ExecuteAsync(command);
     }
 
-    private static UserGuildMembership MapToUserGuildMembership(UserGuildMembershipRow row)
+    private static UserGuildMembership MapToUserGuildMembership(UserGuildMembershipRow row, HashSet<Guid> unreadGuildIds)
     {
         if (!Enum.IsDefined(typeof(GuildRole), row.Role))
             throw new InvalidOperationException("Stored guild role is invalid.");
@@ -303,7 +297,7 @@ public sealed class GuildMemberRepository : IGuildMemberRepository
             guild,
             (GuildRole)row.Role,
             row.JoinedAtUtc,
-            row.HasUnread);
+            HasUnread: unreadGuildIds.Contains(row.GuildId));
     }
 
     private static GuildMemberUser MapToGuildMemberUser(GuildMemberUserRow row)

--- a/src/Harmonie.Infrastructure/Rows/Guilds/UserGuildMembershipRow.cs
+++ b/src/Harmonie.Infrastructure/Rows/Guilds/UserGuildMembershipRow.cs
@@ -23,4 +23,6 @@ public sealed class UserGuildMembershipRow
     public short Role { get; init; }
 
     public DateTime JoinedAtUtc { get; init; }
+
+    public bool HasUnread { get; init; }
 }

--- a/src/Harmonie.Infrastructure/Rows/Guilds/UserGuildMembershipRow.cs
+++ b/src/Harmonie.Infrastructure/Rows/Guilds/UserGuildMembershipRow.cs
@@ -23,6 +23,4 @@ public sealed class UserGuildMembershipRow
     public short Role { get; init; }
 
     public DateTime JoinedAtUtc { get; init; }
-
-    public bool HasUnread { get; init; }
 }

--- a/tests/Harmonie.API.IntegrationTests/Guilds/CreateGuildTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/CreateGuildTests.cs
@@ -126,6 +126,68 @@ public sealed class CreateGuildTests : IClassFixture<HarmonieWebApplicationFacto
     }
 
     [Fact]
+    public async Task ListUserGuilds_HasUnread_ShouldReflectUnreadStatePerGuild()
+    {
+        var prefix = Guid.NewGuid().ToString("N")[..8];
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var sender = await AuthTestHelper.RegisterAsync(_client);
+
+        var guildWithUnread = await GuildTestHelper.CreateGuildAsync(_client, $"{prefix}-with-unread", owner.AccessToken);
+        var guildWithoutUnread = await GuildTestHelper.CreateGuildAsync(_client, $"{prefix}-without-unread", owner.AccessToken);
+
+        await GuildTestHelper.InviteMemberAsync(_client, guildWithUnread.GuildId, owner.AccessToken, sender.AccessToken);
+
+        var channelsResponse = await _client.SendAuthorizedGetAsync(
+            $"/api/guilds/{guildWithUnread.GuildId}/channels",
+            sender.AccessToken);
+        channelsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var channels = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
+        var textChannel = channels!.Channels.First(c => c.Type == "Text");
+
+        await ChannelTestHelper.SendChannelMessageAsync(_client, textChannel.ChannelId, "hello", sender.AccessToken);
+
+        var listResponse = await _client.SendAuthorizedGetAsync("/api/guilds", owner.AccessToken);
+        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var list = await listResponse.Content.ReadFromJsonAsync<ListUserGuildsResponse>(TestContext.Current.CancellationToken);
+        list.Should().NotBeNull();
+
+        list!.Guilds.First(g => g.GuildId == guildWithUnread.GuildId).HasUnread.Should().BeTrue();
+        list.Guilds.First(g => g.GuildId == guildWithoutUnread.GuildId).HasUnread.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ListUserGuilds_HasUnread_ShouldBeFalseAfterAcknowledge()
+    {
+        var prefix = Guid.NewGuid().ToString("N")[..8];
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var sender = await AuthTestHelper.RegisterAsync(_client);
+
+        var guild = await GuildTestHelper.CreateGuildAsync(_client, $"{prefix}-ack-guild", owner.AccessToken);
+        await GuildTestHelper.InviteMemberAsync(_client, guild.GuildId, owner.AccessToken, sender.AccessToken);
+
+        var channelsResponse = await _client.SendAuthorizedGetAsync(
+            $"/api/guilds/{guild.GuildId}/channels",
+            sender.AccessToken);
+        var channels = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
+        var textChannel = channels!.Channels.First(c => c.Type == "Text");
+
+        var message = await ChannelTestHelper.SendChannelMessageAsync(_client, textChannel.ChannelId, "hi", sender.AccessToken);
+
+        var ackResponse = await _client.SendAuthorizedPostAsync(
+            $"/api/channels/{textChannel.ChannelId}/ack",
+            new { lastReadMessageId = message.MessageId },
+            owner.AccessToken);
+        ackResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var listResponse = await _client.SendAuthorizedGetAsync("/api/guilds", owner.AccessToken);
+        var list = await listResponse.Content.ReadFromJsonAsync<ListUserGuildsResponse>(TestContext.Current.CancellationToken);
+
+        list!.Guilds.First(g => g.GuildId == guild.GuildId).HasUnread.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task CreateGuild_WithIconFields_ShouldPersistIconData()
     {
         var owner = await AuthTestHelper.RegisterAsync(_client);

--- a/tests/Harmonie.API.IntegrationTests/RealTime/ConnectionTrackerTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/RealTime/ConnectionTrackerTests.cs
@@ -84,7 +84,7 @@ public sealed class ConnectionTrackerTests : IDisposable
             .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[]
             {
-                new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow)
+                new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow, HasUnread: false)
             });
 
         await _tracker.HandleConnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);
@@ -161,7 +161,7 @@ public sealed class ConnectionTrackerTests : IDisposable
             .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[]
             {
-                new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow)
+                new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow, HasUnread: false)
             });
 
         await _tracker.HandleConnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);
@@ -204,7 +204,7 @@ public sealed class ConnectionTrackerTests : IDisposable
             .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[]
             {
-                new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow)
+                new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow, HasUnread: false)
             });
 
         await _tracker.HandleConnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);
@@ -251,7 +251,7 @@ public sealed class ConnectionTrackerTests : IDisposable
             .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[]
             {
-                new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow)
+                new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow, HasUnread: false)
             });
 
         await _tracker.HandleConnectedAsync(userId, "conn-1", TestContext.Current.CancellationToken);

--- a/tests/Harmonie.Application.Tests/Guilds/ListUserGuildsHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Guilds/ListUserGuildsHandlerTests.cs
@@ -50,11 +50,12 @@ public sealed class ListUserGuildsHandlerTests
             "Guild Alpha",
             GuildRole.Admin,
             DateTime.UtcNow.AddDays(-2),
+            hasUnread: true,
             iconFileId: UploadedFileId.From(Guid.Parse("0be76be9-ae27-4961-a4a5-835e1f77387b")),
             iconColor: "#7C3AED",
             iconName: "sword",
             iconBg: "#1F2937");
-        var guildTwo = CreateMembership("Guild Beta", GuildRole.Member, DateTime.UtcNow.AddDays(-1));
+        var guildTwo = CreateMembership("Guild Beta", GuildRole.Member, DateTime.UtcNow.AddDays(-1), hasUnread: false);
 
         _guildMemberRepositoryMock
             .Setup(x => x.GetUserGuildMembershipsAsync(userId, It.IsAny<CancellationToken>()))
@@ -71,15 +72,18 @@ public sealed class ListUserGuildsHandlerTests
         response.Data.Guilds[0].Icon.Should().NotBeNull();
         response.Data.Guilds[0].Icon!.Name.Should().Be("sword");
         response.Data.Guilds[0].Role.Should().Be("Admin");
+        response.Data.Guilds[0].HasUnread.Should().BeTrue();
         response.Data.Guilds[1].Name.Should().Be("Guild Beta");
         response.Data.Guilds[1].Icon.Should().BeNull();
         response.Data.Guilds[1].Role.Should().Be("Member");
+        response.Data.Guilds[1].HasUnread.Should().BeFalse();
     }
 
     private static UserGuildMembership CreateMembership(
         string guildName,
         GuildRole role,
         DateTime joinedAtUtc,
+        bool hasUnread = false,
         UploadedFileId? iconFileId = null,
         string? iconColor = null,
         string? iconName = null,
@@ -100,6 +104,6 @@ public sealed class ListUserGuildsHandlerTests
             iconName: iconName,
             iconBg: iconBg);
 
-        return new UserGuildMembership(guild, role, joinedAtUtc);
+        return new UserGuildMembership(guild, role, joinedAtUtc, hasUnread);
     }
 }

--- a/tests/Harmonie.Application.Tests/Users/UpdateUserStatusHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Users/UpdateUserStatusHandlerTests.cs
@@ -118,7 +118,7 @@ public sealed class UpdateUserStatusHandlerTests
             .Setup(x => x.GetUserGuildMembershipsAsync(user.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[]
             {
-                new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow)
+                new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow, HasUnread: false)
             });
 
         var response = await _handler.HandleAsync(request, user.Id, TestContext.Current.CancellationToken);
@@ -153,7 +153,7 @@ public sealed class UpdateUserStatusHandlerTests
             .Setup(x => x.GetUserGuildMembershipsAsync(user.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[]
             {
-                new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow)
+                new UserGuildMembership(guild, Domain.Enums.GuildRole.Member, DateTime.UtcNow, HasUnread: false)
             });
 
         var response = await _handler.HandleAsync(request, user.Id, TestContext.Current.CancellationToken);


### PR DESCRIPTION
## Summary

- Add `HasUnread` (bool) to `ListUserGuildsItemResponse` so clients can display an unread indicator per guild without fetching channels first
- SQL uses a CTE to resolve last-read boundaries in one pass, then a double `EXISTS` (outer short-circuits at first unread channel, inner at first unread message) backed by `idx_messages_channel_created_active`
- No schema migration required — derives unread state from the existing `channel_read_states` table

## Test plan

- [ ] Guild with a message sent by another user → `HasUnread = true`
- [ ] Guild with no messages → `HasUnread = false`
- [ ] Guild after owner acknowledges the last message → `HasUnread = false`
- [ ] Own messages not counted as unread
- [ ] All existing tests pass (490 unit + 467 integration)

Closes #373