### PR TITLE
feat(channels): add HasUnread flag to GetGuildChannels response

### DIFF
--- a/src/Harmonie.Application/Features/Guilds/GetGuildChannels/GetGuildChannelsHandler.cs
+++ b/src/Harmonie.Application/Features/Guilds/GetGuildChannels/GetGuildChannelsHandler.cs
@@ -44,15 +44,15 @@ public sealed class GetGuildChannelsHandler : IAuthenticatedHandler<GuildId, Get
                 "You do not have access to this guild");
         }
 
-        var channels = await _guildChannelRepository.GetByGuildIdAsync(guildId, cancellationToken);
+        var result = await _guildChannelRepository.GetByGuildIdWithUnreadAsync(guildId, currentUserId, cancellationToken);
 
         var participantsByChannelId = new Dictionary<Guid, IReadOnlyList<CachedVoiceParticipant>>();
-        foreach (var c in channels.Where(c => c.Type == GuildChannelType.Voice))
+        foreach (var c in result.Channels.Where(c => c.Type == GuildChannelType.Voice))
             participantsByChannelId[c.Id.Value] = await _voiceParticipantCache.GetAsync(c.Id, cancellationToken);
 
         var payload = new GetGuildChannelsResponse(
             GuildId: guildId.Value,
-            Channels: channels.Select(channel =>
+            Channels: result.Channels.Select(channel =>
             {
                 IReadOnlyList<GetGuildChannelsVoiceParticipantResponse>? currentParticipants = null;
                 if (channel.Type == GuildChannelType.Voice && participantsByChannelId.TryGetValue(channel.Id.Value, out var cached))
@@ -75,7 +75,8 @@ public sealed class GetGuildChannelsHandler : IAuthenticatedHandler<GuildId, Get
                     Type: channel.Type.ToString(),
                     IsDefault: channel.IsDefault,
                     Position: channel.Position,
-                    CurrentParticipants: currentParticipants);
+                    CurrentParticipants: currentParticipants,
+                    HasUnread: channel.Type == GuildChannelType.Text && result.UnreadChannelIds.Contains(channel.Id.Value));
             }).ToArray());
 
         return ApplicationResponse<GetGuildChannelsResponse>.Ok(payload);

--- a/src/Harmonie.Application/Features/Guilds/GetGuildChannels/GetGuildChannelsResponse.cs
+++ b/src/Harmonie.Application/Features/Guilds/GetGuildChannels/GetGuildChannelsResponse.cs
@@ -10,7 +10,8 @@ public sealed record GetGuildChannelsItemResponse(
     string Type,
     bool IsDefault,
     int Position,
-    IReadOnlyList<GetGuildChannelsVoiceParticipantResponse>? CurrentParticipants);
+    IReadOnlyList<GetGuildChannelsVoiceParticipantResponse>? CurrentParticipants,
+    bool HasUnread);
 
 public sealed record GetGuildChannelsVoiceParticipantResponse(
     Guid UserId,

--- a/src/Harmonie.Application/Interfaces/Channels/IGuildChannelRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Channels/IGuildChannelRepository.cs
@@ -27,6 +27,10 @@ public sealed record ChannelWithParticipant(
     ChannelParticipantProfile? Participant,
     string GuildName);
 
+public sealed record GuildChannelsWithUnread(
+    IReadOnlyList<GuildChannel> Channels,
+    HashSet<Guid> UnreadChannelIds);
+
 public interface IGuildChannelRepository
 {
     Task<GuildChannel?> GetByIdAsync(
@@ -44,6 +48,11 @@ public interface IGuildChannelRepository
 
     Task<IReadOnlyList<GuildChannel>> GetByGuildIdAsync(
         GuildId guildId,
+        CancellationToken cancellationToken = default);
+
+    Task<GuildChannelsWithUnread> GetByGuildIdWithUnreadAsync(
+        GuildId guildId,
+        UserId userId,
         CancellationToken cancellationToken = default);
 
     Task UpdateAsync(

--- a/src/Harmonie.Infrastructure/Persistence/Channels/GuildChannelRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Channels/GuildChannelRepository.cs
@@ -118,6 +118,55 @@ public sealed class GuildChannelRepository : IGuildChannelRepository
         return rows.Select(MapToGuildChannel).ToArray();
     }
 
+    public async Task<GuildChannelsWithUnread> GetByGuildIdWithUnreadAsync(
+        GuildId guildId,
+        UserId userId,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+                           SELECT id AS "Id",
+                                  guild_id AS "GuildId",
+                                  name AS "Name",
+                                  type AS "Type",
+                                  is_default AS "IsDefault",
+                                  position AS "Position",
+                                  created_at_utc AS "CreatedAtUtc"
+                           FROM guild_channels
+                           WHERE guild_id = @GuildId
+                           ORDER BY position ASC, created_at_utc ASC, id ASC;
+
+                           SELECT DISTINCT m.channel_id AS "ChannelId"
+                           FROM messages m
+                           JOIN guild_channels gc ON gc.id = m.channel_id
+                                                  AND gc.guild_id = @GuildId
+                                                  AND gc.type = 1
+                           LEFT JOIN channel_read_states crs
+                                  ON crs.channel_id = m.channel_id AND crs.user_id = @UserId
+                           LEFT JOIN messages lrm ON lrm.id = crs.last_read_message_id
+                           WHERE m.deleted_at_utc IS NULL
+                             AND m.author_user_id != @UserId
+                             AND (
+                                 crs.last_read_message_id IS NULL
+                                 OR (m.created_at_utc, m.id) > (lrm.created_at_utc, lrm.id)
+                             )
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new { GuildId = guildId.Value, UserId = userId.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        using var multi = await connection.QueryMultipleAsync(command);
+        var rows = await multi.ReadAsync<GuildChannelRow>();
+        var unreadChannelIds = (await multi.ReadAsync<Guid>()).ToHashSet();
+
+        return new GuildChannelsWithUnread(
+            rows.Select(MapToGuildChannel).ToArray(),
+            unreadChannelIds);
+    }
+
     public async Task UpdateAsync(
         GuildChannel channel,
         CancellationToken cancellationToken = default)

--- a/tests/Harmonie.API.IntegrationTests/Guilds/GuildChannelsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Guilds/GuildChannelsTests.cs
@@ -6,6 +6,7 @@ using Harmonie.API.IntegrationTests.Common;
 using Harmonie.Application.Common;
 using Harmonie.Application.Features.Guilds.CreateChannel;
 using Harmonie.Application.Features.Guilds.CreateGuild;
+using Harmonie.Application.Features.Guilds.GetGuildChannels;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 
@@ -209,6 +210,76 @@ public sealed class GuildChannelsTests : IClassFixture<HarmonieWebApplicationFac
         var error = await createChannelResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.DomainRuleViolation);
+    }
+
+    [Fact]
+    public async Task GetGuildChannels_HasUnread_ShouldBeTrueWhenOtherUserSentMessage()
+    {
+        var prefix = Guid.NewGuid().ToString("N")[..8];
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var sender = await AuthTestHelper.RegisterAsync(_client);
+
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, $"{prefix}-guild");
+        await GuildTestHelper.InviteMemberAsync(_client, guildId, owner.AccessToken, sender.AccessToken);
+
+        var channelsResponse = await _client.SendAuthorizedGetAsync($"/api/guilds/{guildId}/channels", owner.AccessToken);
+        var channels = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
+        var textChannel = channels!.Channels.First(c => c.Type == "Text");
+
+        await ChannelTestHelper.SendChannelMessageAsync(_client, textChannel.ChannelId, "hello", sender.AccessToken);
+
+        var response = await _client.SendAuthorizedGetAsync($"/api/guilds/{guildId}/channels", owner.AccessToken);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
+        payload!.Channels.First(c => c.Type == "Text").HasUnread.Should().BeTrue();
+        payload.Channels.First(c => c.Type == "Voice").HasUnread.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetGuildChannels_HasUnread_ShouldBeFalseAfterAcknowledge()
+    {
+        var prefix = Guid.NewGuid().ToString("N")[..8];
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var sender = await AuthTestHelper.RegisterAsync(_client);
+
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, $"{prefix}-guild");
+        await GuildTestHelper.InviteMemberAsync(_client, guildId, owner.AccessToken, sender.AccessToken);
+
+        var channelsResponse = await _client.SendAuthorizedGetAsync($"/api/guilds/{guildId}/channels", owner.AccessToken);
+        var channels = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
+        var textChannel = channels!.Channels.First(c => c.Type == "Text");
+
+        var message = await ChannelTestHelper.SendChannelMessageAsync(_client, textChannel.ChannelId, "hi", sender.AccessToken);
+
+        var ackResponse = await _client.SendAuthorizedPostAsync(
+            $"/api/channels/{textChannel.ChannelId}/ack",
+            new { lastReadMessageId = message.MessageId },
+            owner.AccessToken);
+        ackResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var response = await _client.SendAuthorizedGetAsync($"/api/guilds/{guildId}/channels", owner.AccessToken);
+        var payload = await response.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
+        payload!.Channels.First(c => c.Type == "Text").HasUnread.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetGuildChannels_HasUnread_ShouldBeFalseForOwnMessages()
+    {
+        var prefix = Guid.NewGuid().ToString("N")[..8];
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, $"{prefix}-guild");
+
+        var channelsResponse = await _client.SendAuthorizedGetAsync($"/api/guilds/{guildId}/channels", owner.AccessToken);
+        var channels = await channelsResponse.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
+        var textChannel = channels!.Channels.First(c => c.Type == "Text");
+
+        await ChannelTestHelper.SendChannelMessageAsync(_client, textChannel.ChannelId, "my own message", owner.AccessToken);
+
+        var response = await _client.SendAuthorizedGetAsync($"/api/guilds/{guildId}/channels", owner.AccessToken);
+        var payload = await response.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
+        payload!.Channels.First(c => c.Type == "Text").HasUnread.Should().BeFalse();
     }
 
     private async Task<HttpResponseMessage> SendAuthorizedPostRawAsync(

--- a/tests/Harmonie.Application.Tests/Channels/GetGuildChannelsHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Channels/GetGuildChannelsHandlerTests.cs
@@ -86,8 +86,8 @@ public sealed class GetGuildChannelsHandlerTests
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
 
         _guildChannelRepositoryMock
-            .Setup(x => x.GetByGuildIdAsync(guild.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync([textChannel, voiceChannel]);
+            .Setup(x => x.GetByGuildIdWithUnreadAsync(guild.Id, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildChannelsWithUnread([textChannel, voiceChannel], []));
 
         var response = await _handler.HandleAsync(guild.Id, userId, TestContext.Current.CancellationToken);
 
@@ -97,8 +97,10 @@ public sealed class GetGuildChannelsHandlerTests
         response.Data!.GuildId.Should().Be(guild.Id.Value);
         response.Data.Channels.Should().HaveCount(2);
         response.Data.Channels[0].Type.Should().Be("Text");
+        response.Data.Channels[0].HasUnread.Should().BeFalse();
         response.Data.Channels[0].CurrentParticipants.Should().BeNull();
         response.Data.Channels[1].Type.Should().Be("Voice");
+        response.Data.Channels[1].HasUnread.Should().BeFalse();
         response.Data.Channels[1].CurrentParticipants.Should().NotBeNull().And.BeEmpty();
     }
 
@@ -124,8 +126,8 @@ public sealed class GetGuildChannelsHandlerTests
             .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
 
         _guildChannelRepositoryMock
-            .Setup(x => x.GetByGuildIdAsync(guild.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync([voiceChannel]);
+            .Setup(x => x.GetByGuildIdWithUnreadAsync(guild.Id, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildChannelsWithUnread([voiceChannel], []));
 
         _voiceParticipantCacheMock
             .Setup(x => x.GetAsync(voiceChannel.Id, It.IsAny<CancellationToken>()))
@@ -149,6 +151,33 @@ public sealed class GetGuildChannelsHandlerTests
         p.AvatarColor.Should().Be("#ff0000");
         p.AvatarIcon.Should().Be("star");
         p.AvatarBg.Should().Be("#000000");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithUnreadTextChannel_ShouldSetHasUnreadTrue()
+    {
+        var guild = ApplicationTestBuilders.CreateGuild();
+        var userId = UserId.New();
+        var textChannel = CreateChannel(guild.Id, "general", GuildChannelType.Text, true, 0);
+        var voiceChannel = CreateChannel(guild.Id, "General Voice", GuildChannelType.Voice, true, 1);
+
+        _guildRepositoryMock
+            .Setup(x => x.GetWithCallerRoleAsync(guild.Id, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildAccessContext(guild, GuildRole.Member));
+
+        _guildChannelRepositoryMock
+            .Setup(x => x.GetByGuildIdWithUnreadAsync(guild.Id, userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildChannelsWithUnread(
+                [textChannel, voiceChannel],
+                [textChannel.Id.Value]));
+
+        var response = await _handler.HandleAsync(guild.Id, userId, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data!.Channels[0].Type.Should().Be("Text");
+        response.Data.Channels[0].HasUnread.Should().BeTrue();
+        response.Data.Channels[1].Type.Should().Be("Voice");
+        response.Data.Channels[1].HasUnread.Should().BeFalse();
     }
 
     private static GuildChannel CreateChannel(


### PR DESCRIPTION
## Summary

- Add `HasUnread` (bool) to `GetGuildChannelsItemResponse` so clients can display unread indicators per text channel
- New method `GetByGuildIdWithUnreadAsync` on `IGuildChannelRepository` — existing `GetByGuildIdAsync` callers (ReorderChannels, SignalR, LiveKit) are untouched
- Two flat queries via Dapper `QueryMultiple` in a single round-trip: first returns channels unchanged, second returns distinct unread channel IDs; `HasUnread` resolved via `HashSet.Contains` in O(1)
- Voice channels always return `HasUnread = false`

## Test plan

- [ ] Text channel with message from another user → `HasUnread = true`
- [ ] Voice channel → `HasUnread = false` regardless
- [ ] After acknowledge → `HasUnread = false`
- [ ] Own messages → `HasUnread = false`
- [ ] All existing tests pass (491 unit + 470 integration)

Closes #372