### PR TITLE
feat(conversations): add HasUnread flag to ListConversations response

### DIFF
--- a/src/Harmonie.Application/Features/Conversations/ListConversations/ListConversationsHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/ListConversations/ListConversationsHandler.cs
@@ -44,7 +44,8 @@ public sealed class ListConversationsHandler : IAuthenticatedHandler<Unit, ListC
                                 Avatar: avatar);
                         })
                         .ToArray(),
-                    CreatedAtUtc: conversation.CreatedAtUtc))
+                    CreatedAtUtc: conversation.CreatedAtUtc,
+                    HasUnread: conversation.HasUnread))
                 .ToArray());
 
         return ApplicationResponse<ListConversationsResponse>.Ok(payload);

--- a/src/Harmonie.Application/Features/Conversations/ListConversations/ListConversationsResponse.cs
+++ b/src/Harmonie.Application/Features/Conversations/ListConversations/ListConversationsResponse.cs
@@ -10,7 +10,8 @@ public sealed record ListConversationsItemResponse(
     string Type,
     string? Name,
     IReadOnlyList<ListConversationsParticipantDto> Participants,
-    DateTime CreatedAtUtc);
+    DateTime CreatedAtUtc,
+    bool HasUnread);
 
 public sealed record ListConversationsParticipantDto(
     Guid UserId,

--- a/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
@@ -39,7 +39,8 @@ public sealed record UserConversationSummary(
     ConversationType Type,
     string? Name,
     IReadOnlyList<ConversationParticipantSummary> Participants,
-    DateTime CreatedAtUtc);
+    DateTime CreatedAtUtc,
+    bool HasUnread);
 
 public interface IConversationRepository
 {

--- a/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
@@ -183,7 +183,23 @@ public sealed class ConversationRepository : IConversationRepository
                            WHERE cp1.user_id = @UserId
                              AND cp1.hidden_at_utc IS NULL
                              AND u.deleted_at IS NULL
-                           ORDER BY c.created_at_utc DESC, c.id ASC, cp2.user_id ASC
+                           ORDER BY c.created_at_utc DESC, c.id ASC, cp2.user_id ASC;
+
+                           SELECT DISTINCT m.conversation_id AS "ConversationId"
+                           FROM messages m
+                           LEFT JOIN conversation_read_states crs
+                                  ON crs.conversation_id = m.conversation_id AND crs.user_id = @UserId
+                           LEFT JOIN messages lrm ON lrm.id = crs.last_read_message_id
+                           WHERE m.conversation_id IN (
+                               SELECT conversation_id FROM conversation_participants
+                               WHERE user_id = @UserId AND hidden_at_utc IS NULL
+                           )
+                             AND m.deleted_at_utc IS NULL
+                             AND m.author_user_id != @UserId
+                             AND (
+                                 crs.last_read_message_id IS NULL
+                                 OR (m.created_at_utc, m.id) > (lrm.created_at_utc, lrm.id)
+                             )
                            """;
 
         var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
@@ -193,7 +209,9 @@ public sealed class ConversationRepository : IConversationRepository
             transaction: _dbSession.Transaction,
             cancellationToken: cancellationToken);
 
-        var rows = await connection.QueryAsync<UserConversationSummaryRow>(command);
+        using var multi = await connection.QueryMultipleAsync(command);
+        var rows = await multi.ReadAsync<UserConversationSummaryRow>();
+        var unreadConversationIds = (await multi.ReadAsync<Guid>()).ToHashSet();
 
         return rows
             .GroupBy(r => r.ConversationId)
@@ -221,7 +239,8 @@ public sealed class ConversationRepository : IConversationRepository
                     type,
                     first.Name,
                     participants,
-                    first.CreatedAtUtc);
+                    first.CreatedAtUtc,
+                    HasUnread: unreadConversationIds.Contains(first.ConversationId));
             })
             .ToArray();
     }

--- a/tests/Harmonie.API.IntegrationTests/Conversations/ConversationEndpointsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/ConversationEndpointsTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using FluentAssertions;
 using Harmonie.API.IntegrationTests.Common;
 using Harmonie.Application.Common;
+using Harmonie.Application.Features.Conversations.AcknowledgeRead;
 using Harmonie.Application.Features.Conversations.ListConversations;
 using Harmonie.Application.Features.Conversations.OpenConversation;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -168,5 +169,55 @@ public sealed class ConversationEndpointsTests : IClassFixture<HarmonieWebApplic
         var response = await _client.GetAsync("/api/conversations", TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ListConversations_HasUnread_ShouldBeTrueWhenOtherUserSentMessage()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var target = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, target.UserId);
+
+        await ConversationTestHelper.SendConversationMessageAsync(_client, conversationId, "hey", target.AccessToken);
+
+        var listResponse = await _client.SendAuthorizedGetAsync("/api/conversations", caller.AccessToken);
+        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var list = await listResponse.Content.ReadFromJsonAsync<ListConversationsResponse>(TestContext.Current.CancellationToken);
+        list!.Conversations.First(c => c.ConversationId == conversationId).HasUnread.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ListConversations_HasUnread_ShouldBeFalseAfterAcknowledge()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var target = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, target.UserId);
+
+        var message = await ConversationTestHelper.SendConversationMessageAsync(_client, conversationId, "hey", target.AccessToken);
+
+        var ackResponse = await _client.SendAuthorizedPostAsync(
+            $"/api/conversations/{conversationId}/ack",
+            new AcknowledgeReadRequest(message.MessageId),
+            caller.AccessToken);
+        ackResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var listResponse = await _client.SendAuthorizedGetAsync("/api/conversations", caller.AccessToken);
+        var list = await listResponse.Content.ReadFromJsonAsync<ListConversationsResponse>(TestContext.Current.CancellationToken);
+        list!.Conversations.First(c => c.ConversationId == conversationId).HasUnread.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ListConversations_HasUnread_ShouldBeFalseForOwnMessages()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var target = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, target.UserId);
+
+        await ConversationTestHelper.SendConversationMessageAsync(_client, conversationId, "my own message", caller.AccessToken);
+
+        var listResponse = await _client.SendAuthorizedGetAsync("/api/conversations", caller.AccessToken);
+        var list = await listResponse.Content.ReadFromJsonAsync<ListConversationsResponse>(TestContext.Current.CancellationToken);
+        list!.Conversations.First(c => c.ConversationId == conversationId).HasUnread.Should().BeFalse();
     }
 }

--- a/tests/Harmonie.Application.Tests/Conversations/ListConversationsHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/ListConversationsHandlerTests.cs
@@ -63,13 +63,15 @@ public sealed class ListConversationsHandlerTests
                     ConversationType.Direct,
                     null,
                     [new ConversationParticipantSummary(bobId, usernameBob.Value!, null, null, null, null, null)],
-                    secondCreatedAt),
+                    secondCreatedAt,
+                    HasUnread: true),
                 new UserConversationSummary(
                     ConversationId.New(),
                     ConversationType.Direct,
                     null,
                     [new ConversationParticipantSummary(aliceId, usernameAlice.Value!, null, null, null, null, null)],
-                    firstCreatedAt)
+                    firstCreatedAt,
+                    HasUnread: false)
             ]);
 
         var response = await _handler.HandleAsync(Unit.Value, userId, TestContext.Current.CancellationToken);
@@ -80,7 +82,9 @@ public sealed class ListConversationsHandlerTests
         response.Data!.Conversations.Should().HaveCount(2);
         response.Data.Conversations[0].Participants.Should().ContainSingle(p => p.Username == "bob");
         response.Data.Conversations[0].CreatedAtUtc.Should().Be(secondCreatedAt);
+        response.Data.Conversations[0].HasUnread.Should().BeTrue();
         response.Data.Conversations[1].Participants.Should().ContainSingle(p => p.Username == "alice");
         response.Data.Conversations[1].CreatedAtUtc.Should().Be(firstCreatedAt);
+        response.Data.Conversations[1].HasUnread.Should().BeFalse();
     }
 }


### PR DESCRIPTION
## Summary

- Add `HasUnread` (bool) to `ListConversationsItemResponse` so clients can display unread indicators per conversation
- Two flat queries via Dapper `QueryMultiple` in a single round-trip: first returns conversation rows unchanged, second returns distinct conversation IDs with unread messages; `HasUnread` resolved via `HashSet.Contains` in O(1)
- Scoped to non-hidden conversations (`hidden_at_utc IS NULL`) to match the main query filter
- Own messages never count as unread

## Test plan

- [ ] Conversation with message from the other user → `HasUnread = true`
- [ ] After acknowledge → `HasUnread = false`
- [ ] Own messages → `HasUnread = false`
- [ ] All existing tests pass (491 unit + 473 integration)

Closes #374