### PR TITLE
fix(conversations): unhide hidden participants when sending a message

### DIFF
--- a/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageHandler.cs
@@ -70,14 +70,14 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
             content = contentResult.Value;
         }
 
-        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(request.ConversationId, currentUserId, cancellationToken);
+        var access = await _conversationRepository.GetByIdWithAllParticipantsAsync(request.ConversationId, currentUserId, cancellationToken);
         if (access is null)
         {
             return ApplicationResponse<SendMessageResponse>.Fail(
                 ApplicationErrorCodes.Conversation.NotFound,
                 "Conversation was not found");
         }
-        if (access.Participant is null)
+        if (access.CallerParticipant is null)
         {
             return ApplicationResponse<SendMessageResponse>.Fail(
                 ApplicationErrorCodes.Conversation.AccessDenied,
@@ -134,9 +134,9 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
         ConversationParticipant[] hiddenParticipants = [];
         if (access.Conversation.Type == ConversationType.Direct)
         {
-            var participants = await _participantRepository.GetByConversationIdAsync(
-                request.ConversationId, cancellationToken);
-            hiddenParticipants = participants.Where(p => p.HiddenAtUtc is not null).ToArray();
+            hiddenParticipants = access.AllParticipants
+                .Where(p => p.HiddenAtUtc is not null)
+                .ToArray();
             foreach (var p in hiddenParticipants)
                 p.Unhide();
         }

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageHandler.cs
@@ -4,6 +4,7 @@ using Harmonie.Application.Services;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.Entities.Conversations;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
@@ -19,6 +20,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
     private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
 
     private readonly IConversationRepository _conversationRepository;
+    private readonly IConversationParticipantRepository _participantRepository;
     private readonly IMessageRepository _conversationMessageRepository;
     private readonly MessageAttachmentResolver _messageAttachmentResolver;
     private readonly IUnitOfWork _unitOfWork;
@@ -29,6 +31,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
 
     public SendMessageHandler(
         IConversationRepository conversationRepository,
+        IConversationParticipantRepository participantRepository,
         IMessageRepository conversationMessageRepository,
         MessageAttachmentResolver messageAttachmentResolver,
         IUnitOfWork unitOfWork,
@@ -38,6 +41,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
         ILogger<SendMessageHandler> logger)
     {
         _conversationRepository = conversationRepository;
+        _participantRepository = participantRepository;
         _conversationMessageRepository = conversationMessageRepository;
         _messageAttachmentResolver = messageAttachmentResolver;
         _unitOfWork = unitOfWork;
@@ -127,8 +131,20 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
                 messageResult.Error ?? "Unable to create conversation message");
         }
 
+        ConversationParticipant[] hiddenParticipants = [];
+        if (access.Conversation.Type == ConversationType.Direct)
+        {
+            var participants = await _participantRepository.GetByConversationIdAsync(
+                request.ConversationId, cancellationToken);
+            hiddenParticipants = participants.Where(p => p.HiddenAtUtc is not null).ToArray();
+            foreach (var p in hiddenParticipants)
+                p.Unhide();
+        }
+
         await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
         await _conversationMessageRepository.AddAsync(messageResult.Value, cancellationToken);
+        if (hiddenParticipants.Length > 0)
+            await _participantRepository.UpdateRangeAsync(hiddenParticipants, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
 
         var messageConversationId = messageResult.Value.ConversationId;

--- a/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Conversations/IConversationRepository.cs
@@ -34,6 +34,13 @@ public sealed record ConversationAccess(
     string? CallerUsername = null,
     string? CallerDisplayName = null);
 
+public sealed record ConversationAccessWithAllParticipants(
+    Conversation Conversation,
+    ConversationParticipant? CallerParticipant,
+    IReadOnlyList<ConversationParticipant> AllParticipants,
+    string? CallerUsername,
+    string? CallerDisplayName);
+
 public sealed record UserConversationSummary(
     ConversationId ConversationId,
     ConversationType Type,
@@ -65,6 +72,11 @@ public interface IConversationRepository
     Task<ConversationAccess?> GetByIdWithParticipantCheckAsync(
         ConversationId conversationId,
         UserId userId,
+        CancellationToken cancellationToken = default);
+
+    Task<ConversationAccessWithAllParticipants?> GetByIdWithAllParticipantsAsync(
+        ConversationId conversationId,
+        UserId callerId,
         CancellationToken cancellationToken = default);
 
     Task<ConversationWithParticipant?> GetWithParticipantAsync(

--- a/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
@@ -298,21 +298,21 @@ public sealed class ConversationRepository : IConversationRepository
         CancellationToken cancellationToken = default)
     {
         const string sql = """
-                           SELECT c.id                AS "ConversationId",
-                                  c.type              AS "Type",
-                                  c.name              AS "Name",
-                                  c.created_at_utc    AS "CreatedAtUtc",
-                                  u_caller.username   AS "CallerUsername",
-                                  u_caller.display_name AS "CallerDisplayName",
-                                  cp.user_id          AS "ParticipantUserId",
-                                  cp.joined_at_utc    AS "JoinedAtUtc",
-                                  cp.hidden_at_utc    AS "HiddenAtUtc"
+                           SELECT c.id               AS "Id",
+                                  c.type             AS "Type",
+                                  c.name             AS "Name",
+                                  c.created_at_utc   AS "CreatedAtUtc",
+                                  u.username         AS "CallerUsername",
+                                  u.display_name     AS "CallerDisplayName"
                            FROM conversations c
-                           JOIN conversation_participants cp ON cp.conversation_id = c.id
-                           LEFT JOIN users u_caller
-                                  ON u_caller.id = @CallerId
-                                 AND u_caller.deleted_at IS NULL
-                           WHERE c.id = @ConversationId
+                           LEFT JOIN users u ON u.id = @CallerId AND u.deleted_at IS NULL
+                           WHERE c.id = @ConversationId;
+
+                           SELECT cp.user_id       AS "UserId",
+                                  cp.joined_at_utc AS "JoinedAtUtc",
+                                  cp.hidden_at_utc AS "HiddenAtUtc"
+                           FROM conversation_participants cp
+                           WHERE cp.conversation_id = @ConversationId
                            """;
 
         var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
@@ -322,20 +322,22 @@ public sealed class ConversationRepository : IConversationRepository
             transaction: _dbSession.Transaction,
             cancellationToken: cancellationToken);
 
-        var rows = (await connection.QueryAsync<ConversationWithAllParticipantsRow>(command)).ToArray();
-        if (rows.Length == 0)
+        using var multi = await connection.QueryMultipleAsync(command);
+        var convRow = await multi.ReadFirstOrDefaultAsync<ConversationWithCallerRow>();
+        if (convRow is null)
             return null;
 
-        var first = rows[0];
-        var conversation = Conversation.Rehydrate(
-            ConversationId.From(first.ConversationId),
-            ParseConversationType(first.Type),
-            first.Name,
-            first.CreatedAtUtc);
+        var participantRows = await multi.ReadAsync<ConversationParticipantRow>();
 
-        var allParticipants = rows.Select(r => ConversationParticipant.Rehydrate(
+        var conversation = Conversation.Rehydrate(
             conversationId,
-            UserId.From(r.ParticipantUserId),
+            ParseConversationType(convRow.Type),
+            convRow.Name,
+            convRow.CreatedAtUtc);
+
+        var allParticipants = participantRows.Select(r => ConversationParticipant.Rehydrate(
+            conversationId,
+            UserId.From(r.UserId),
             r.JoinedAtUtc,
             r.HiddenAtUtc)).ToArray();
 
@@ -345,8 +347,8 @@ public sealed class ConversationRepository : IConversationRepository
             conversation,
             callerParticipant,
             allParticipants,
-            first.CallerUsername,
-            first.CallerDisplayName);
+            convRow.CallerUsername,
+            convRow.CallerDisplayName);
     }
 
     public async Task<ConversationWithParticipant?> GetWithParticipantAsync(
@@ -494,10 +496,8 @@ public sealed class ConversationRepository : IConversationRepository
         public string? DisplayName { get; init; }
     }
 
-    private sealed class ConversationWithAllParticipantsRow
+    private sealed class ConversationWithCallerRow
     {
-        public Guid ConversationId { get; init; }
-
         public string Type { get; init; } = string.Empty;
 
         public string? Name { get; init; }
@@ -507,8 +507,11 @@ public sealed class ConversationRepository : IConversationRepository
         public string? CallerUsername { get; init; }
 
         public string? CallerDisplayName { get; init; }
+    }
 
-        public Guid ParticipantUserId { get; init; }
+    private sealed class ConversationParticipantRow
+    {
+        public Guid UserId { get; init; }
 
         public DateTime JoinedAtUtc { get; init; }
 

--- a/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
@@ -292,6 +292,63 @@ public sealed class ConversationRepository : IConversationRepository
         return new ConversationAccess(conversation, participant, row.Username, row.DisplayName);
     }
 
+    public async Task<ConversationAccessWithAllParticipants?> GetByIdWithAllParticipantsAsync(
+        ConversationId conversationId,
+        UserId callerId,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+                           SELECT c.id                AS "ConversationId",
+                                  c.type              AS "Type",
+                                  c.name              AS "Name",
+                                  c.created_at_utc    AS "CreatedAtUtc",
+                                  u_caller.username   AS "CallerUsername",
+                                  u_caller.display_name AS "CallerDisplayName",
+                                  cp.user_id          AS "ParticipantUserId",
+                                  cp.joined_at_utc    AS "JoinedAtUtc",
+                                  cp.hidden_at_utc    AS "HiddenAtUtc"
+                           FROM conversations c
+                           JOIN conversation_participants cp ON cp.conversation_id = c.id
+                           LEFT JOIN users u_caller
+                                  ON u_caller.id = @CallerId
+                                 AND u_caller.deleted_at IS NULL
+                           WHERE c.id = @ConversationId
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new { ConversationId = conversationId.Value, CallerId = callerId.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        var rows = (await connection.QueryAsync<ConversationWithAllParticipantsRow>(command)).ToArray();
+        if (rows.Length == 0)
+            return null;
+
+        var first = rows[0];
+        var conversation = Conversation.Rehydrate(
+            ConversationId.From(first.ConversationId),
+            ParseConversationType(first.Type),
+            first.Name,
+            first.CreatedAtUtc);
+
+        var allParticipants = rows.Select(r => ConversationParticipant.Rehydrate(
+            conversationId,
+            UserId.From(r.ParticipantUserId),
+            r.JoinedAtUtc,
+            r.HiddenAtUtc)).ToArray();
+
+        var callerParticipant = allParticipants.FirstOrDefault(p => p.UserId == callerId);
+
+        return new ConversationAccessWithAllParticipants(
+            conversation,
+            callerParticipant,
+            allParticipants,
+            first.CallerUsername,
+            first.CallerDisplayName);
+    }
+
     public async Task<ConversationWithParticipant?> GetWithParticipantAsync(
         ConversationId conversationId,
         UserId userId,
@@ -435,6 +492,27 @@ public sealed class ConversationRepository : IConversationRepository
         public string? Username { get; init; }
 
         public string? DisplayName { get; init; }
+    }
+
+    private sealed class ConversationWithAllParticipantsRow
+    {
+        public Guid ConversationId { get; init; }
+
+        public string Type { get; init; } = string.Empty;
+
+        public string? Name { get; init; }
+
+        public DateTime CreatedAtUtc { get; init; }
+
+        public string? CallerUsername { get; init; }
+
+        public string? CallerDisplayName { get; init; }
+
+        public Guid ParticipantUserId { get; init; }
+
+        public DateTime JoinedAtUtc { get; init; }
+
+        public DateTime? HiddenAtUtc { get; init; }
     }
 
     private sealed class ConversationWithParticipantProfileRow

--- a/tests/Harmonie.API.IntegrationTests/Conversations/SendConversationMessageTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/SendConversationMessageTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Harmonie.API.IntegrationTests.Common;
 using Harmonie.Application.Common;
 using Harmonie.Application.Features.Conversations.GetMessages;
+using Harmonie.Application.Features.Conversations.ListConversations;
 using Harmonie.Application.Features.Conversations.SendMessage;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
@@ -117,6 +118,30 @@ public sealed class SendConversationMessageTests : IClassFixture<HarmonieWebAppl
             TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task SendConversationMessage_WhenReceiverHidConversation_ShouldUnhideItForReceiver()
+    {
+        var sender = await AuthTestHelper.RegisterAsync(_client);
+        var receiver = await AuthTestHelper.RegisterAsync(_client);
+
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, sender.AccessToken, receiver.UserId);
+
+        var deleteResponse = await _client.SendAuthorizedDeleteAsync(
+            $"/api/conversations/{conversationId}",
+            receiver.AccessToken);
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var listBefore = await _client.SendAuthorizedGetAsync("/api/conversations", receiver.AccessToken);
+        var beforePayload = await listBefore.Content.ReadFromJsonAsync<ListConversationsResponse>(TestContext.Current.CancellationToken);
+        beforePayload!.Conversations.Should().NotContain(c => c.ConversationId == conversationId);
+
+        await ConversationTestHelper.SendConversationMessageAsync(_client, conversationId, "hey, you back?", sender.AccessToken);
+
+        var listAfter = await _client.SendAuthorizedGetAsync("/api/conversations", receiver.AccessToken);
+        var afterPayload = await listAfter.Content.ReadFromJsonAsync<ListConversationsResponse>(TestContext.Current.CancellationToken);
+        afterPayload!.Conversations.Should().Contain(c => c.ConversationId == conversationId);
     }
 
 }

--- a/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
@@ -8,6 +8,7 @@ using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.Entities.Conversations;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Messages;
@@ -24,6 +25,7 @@ namespace Harmonie.Application.Tests.Messages;
 public sealed class SendConversationMessageHandlerTests
 {
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
+    private readonly Mock<IConversationParticipantRepository> _participantRepositoryMock;
     private readonly Mock<IMessageRepository> _directMessageRepositoryMock;
     private readonly Mock<IUploadedFileRepository> _uploadedFileRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
@@ -37,6 +39,10 @@ public sealed class SendConversationMessageHandlerTests
     public SendConversationMessageHandlerTests()
     {
         _conversationRepositoryMock = new Mock<IConversationRepository>();
+        _participantRepositoryMock = new Mock<IConversationParticipantRepository>();
+        _participantRepositoryMock
+            .Setup(x => x.GetByConversationIdAsync(It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
         _directMessageRepositoryMock = new Mock<IMessageRepository>();
         _uploadedFileRepositoryMock = new Mock<IUploadedFileRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
@@ -69,6 +75,7 @@ public sealed class SendConversationMessageHandlerTests
 
         _handler = new SendMessageHandler(
             _conversationRepositoryMock.Object,
+            _participantRepositoryMock.Object,
             _directMessageRepositoryMock.Object,
             new MessageAttachmentResolver(_uploadedFileRepositoryMock.Object),
             _unitOfWorkMock.Object,
@@ -497,5 +504,43 @@ public sealed class SendConversationMessageHandlerTests
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
         response.Data!.ReplyTo.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenDirectConversationHasHiddenParticipant_ShouldUnhideAndPersist()
+    {
+        var sender = UserId.New();
+        var receiver = UserId.New();
+        var conversation = ApplicationTestBuilders.CreateConversation(sender, receiver);
+
+        var hiddenParticipant = ConversationParticipant.Rehydrate(
+            conversation.Id, receiver, DateTime.UtcNow.AddDays(-1), hiddenAtUtc: DateTime.UtcNow.AddHours(-1));
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, sender, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccess(conversation,
+                Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, sender),
+                CallerUsername: "sender"));
+
+        _participantRepositoryMock
+            .Setup(x => x.GetByConversationIdAsync(conversation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([hiddenParticipant]);
+
+        _directMessageRepositoryMock
+            .Setup(x => x.AddAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var response = await _handler.HandleAsync(
+            new SendConversationMessageInput(conversation.Id, "hey"),
+            sender,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        hiddenParticipant.HiddenAtUtc.Should().BeNull();
+        _participantRepositoryMock.Verify(
+            x => x.UpdateRangeAsync(
+                It.Is<IReadOnlyList<ConversationParticipant>>(list => list.Count == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }

--- a/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
@@ -40,9 +40,6 @@ public sealed class SendConversationMessageHandlerTests
     {
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _participantRepositoryMock = new Mock<IConversationParticipantRepository>();
-        _participantRepositoryMock
-            .Setup(x => x.GetByConversationIdAsync(It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
         _directMessageRepositoryMock = new Mock<IMessageRepository>();
         _uploadedFileRepositoryMock = new Mock<IUploadedFileRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
@@ -94,8 +91,8 @@ public sealed class SendConversationMessageHandlerTests
         var userId = UserId.New();
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversationId, It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((ConversationAccess?)null);
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversationId, It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConversationAccessWithAllParticipants?)null);
 
         var response = await _handler.HandleAsync(
             new SendConversationMessageInput(conversationId, "hello"),
@@ -117,8 +114,8 @@ public sealed class SendConversationMessageHandlerTests
         var conversation = ApplicationTestBuilders.CreateConversation(participantOne, participantTwo);
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: null));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: null, AllParticipants: [], null, null));
 
         var response = await _handler.HandleAsync(
             new SendConversationMessageInput(conversation.Id, "hello"),
@@ -140,8 +137,8 @@ public sealed class SendConversationMessageHandlerTests
         var conversation = ApplicationTestBuilders.CreateConversation(currentUserId, UserId.New());
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, currentUserId)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildAccess(conversation, currentUserId));
 
         var response = await _handler.HandleAsync(
             new SendConversationMessageInput(conversation.Id, rawContent),
@@ -162,8 +159,8 @@ public sealed class SendConversationMessageHandlerTests
         Message? persistedMessage = null;
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, currentUserId), CallerUsername: "sender", CallerDisplayName: "Sender Display"));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildAccess(conversation, currentUserId, callerUsername: "sender", callerDisplayName: "Sender Display"));
 
         _directMessageRepositoryMock
             .Setup(x => x.AddAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))
@@ -205,8 +202,8 @@ public sealed class SendConversationMessageHandlerTests
         var attachment = ApplicationTestBuilders.CreateUploadedFile(uploaderUserId: currentUserId, fileName: "report.pdf", contentType: "application/pdf");
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, currentUserId)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildAccess(conversation, currentUserId));
 
         _uploadedFileRepositoryMock
             .Setup(x => x.GetByIdsAsync(It.IsAny<IReadOnlyCollection<UploadedFileId>>(), It.IsAny<CancellationToken>()))
@@ -239,8 +236,8 @@ public sealed class SendConversationMessageHandlerTests
         var conversation = ApplicationTestBuilders.CreateConversation(currentUserId, UserId.New());
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, currentUserId)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildAccess(conversation, currentUserId));
 
         _directMessageRepositoryMock
             .Setup(x => x.AddAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))
@@ -269,8 +266,8 @@ public sealed class SendConversationMessageHandlerTests
         var conversation = ApplicationTestBuilders.CreateConversation(currentUserId, UserId.New());
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, currentUserId)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildAccess(conversation, currentUserId));
 
         _directMessageRepositoryMock
             .Setup(x => x.AddAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))
@@ -299,8 +296,8 @@ public sealed class SendConversationMessageHandlerTests
         var conversation = ApplicationTestBuilders.CreateConversation(currentUserId, UserId.New());
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, currentUserId)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildAccess(conversation, currentUserId));
 
         _directMessageRepositoryMock
             .Setup(x => x.AddAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))
@@ -324,8 +321,8 @@ public sealed class SendConversationMessageHandlerTests
         var targetMessageId = MessageId.New();
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, currentUserId), CallerUsername: "sender", CallerDisplayName: "Sender Display"));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildAccess(conversation, currentUserId, callerUsername: "sender", callerDisplayName: "Sender Display"));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetReplyTargetSummaryAsync(targetMessageId, It.IsAny<CancellationToken>()))
@@ -385,8 +382,8 @@ public sealed class SendConversationMessageHandlerTests
         var targetMessageId = MessageId.New();
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, currentUserId)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildAccess(conversation, currentUserId));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetReplyTargetSummaryAsync(targetMessageId, It.IsAny<CancellationToken>()))
@@ -421,8 +418,8 @@ public sealed class SendConversationMessageHandlerTests
         var targetMessageId = MessageId.New();
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, currentUserId)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildAccess(conversation, currentUserId));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetReplyTargetSummaryAsync(targetMessageId, It.IsAny<CancellationToken>()))
@@ -448,8 +445,8 @@ public sealed class SendConversationMessageHandlerTests
         var deletedAt = DateTime.UtcNow.AddHours(-1);
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, currentUserId)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildAccess(conversation, currentUserId));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetReplyTargetSummaryAsync(targetMessageId, It.IsAny<CancellationToken>()))
@@ -489,8 +486,8 @@ public sealed class SendConversationMessageHandlerTests
         var conversation = ApplicationTestBuilders.CreateConversation(currentUserId, UserId.New());
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, currentUserId)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, currentUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildAccess(conversation, currentUserId));
 
         _directMessageRepositoryMock
             .Setup(x => x.AddAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))
@@ -513,18 +510,18 @@ public sealed class SendConversationMessageHandlerTests
         var receiver = UserId.New();
         var conversation = ApplicationTestBuilders.CreateConversation(sender, receiver);
 
+        var senderParticipant = ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, sender);
         var hiddenParticipant = ConversationParticipant.Rehydrate(
             conversation.Id, receiver, DateTime.UtcNow.AddDays(-1), hiddenAtUtc: DateTime.UtcNow.AddHours(-1));
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, sender, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation,
-                Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, sender),
-                CallerUsername: "sender"));
-
-        _participantRepositoryMock
-            .Setup(x => x.GetByConversationIdAsync(conversation.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync([hiddenParticipant]);
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, sender, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(
+                conversation,
+                CallerParticipant: senderParticipant,
+                AllParticipants: [senderParticipant, hiddenParticipant],
+                CallerUsername: "sender",
+                CallerDisplayName: null));
 
         _directMessageRepositoryMock
             .Setup(x => x.AddAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))
@@ -542,5 +539,20 @@ public sealed class SendConversationMessageHandlerTests
                 It.Is<IReadOnlyList<ConversationParticipant>>(list => list.Count == 1),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    private static ConversationAccessWithAllParticipants BuildAccess(
+        Conversation conversation,
+        UserId callerId,
+        string? callerUsername = null,
+        string? callerDisplayName = null)
+    {
+        var callerParticipant = ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, callerId);
+        return new ConversationAccessWithAllParticipants(
+            conversation,
+            CallerParticipant: callerParticipant,
+            AllParticipants: [callerParticipant],
+            callerUsername,
+            callerDisplayName);
     }
 }


### PR DESCRIPTION
## Summary

- When user B sends a message in a direct conversation that user A has hidden, `SendMessageHandler` now calls `Unhide()` on all hidden participants and persists via `UpdateRangeAsync` inside the same transaction as the message insert
- Scoped to direct conversations only — group conversations have no hide semantics
- Aligns with the existing pattern in `OpenConversationHandler` (lines 102-114)

## Root cause

`GetByIdWithParticipantCheckAsync` returns the caller's participant even when `hidden_at_utc` is set (LEFT JOIN). The handler only checked `access.Participant is null` but never read `HiddenAtUtc`, so hidden participants were never reactivated on incoming messages.

## Test plan

- [ ] Unit test: hidden participant gets `Unhide()` called and `UpdateRangeAsync` is invoked
- [ ] Integration test: receiver hides conversation → sender sends message → conversation reappears in receiver's list
- [ ] All existing tests pass (492 unit + 474 integration)

Closes #375