### PR TITLE
refactor(attachments): align MessageAttachment with message family (#362)

### DIFF
--- a/src/Harmonie.Application/Common/Messages/MessageAttachmentDto.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageAttachmentDto.cs
@@ -18,4 +18,15 @@ public sealed record MessageAttachmentDto(
             attachment.ContentType,
             attachment.SizeBytes);
     }
+
+    public static MessageAttachmentDto FromResolved(ResolvedAttachment resolved)
+    {
+        ArgumentNullException.ThrowIfNull(resolved);
+
+        return new MessageAttachmentDto(
+            resolved.FileId.Value,
+            resolved.FileName,
+            resolved.ContentType,
+            resolved.SizeBytes);
+    }
 }

--- a/src/Harmonie.Application/Common/Messages/MessageAttachmentResolver.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageAttachmentResolver.cs
@@ -1,10 +1,15 @@
 using Harmonie.Application.Interfaces.Uploads;
-using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
 
 namespace Harmonie.Application.Common.Messages;
+
+public sealed record ResolvedAttachment(
+    UploadedFileId FileId,
+    string FileName,
+    string ContentType,
+    long SizeBytes);
 
 public sealed class MessageAttachmentResolver
 {
@@ -21,7 +26,7 @@ public sealed class MessageAttachmentResolver
         CancellationToken cancellationToken = default)
     {
         if (attachmentFileIds is null || attachmentFileIds.Count == 0)
-            return MessageAttachmentResolutionResult.Succeeded(Array.Empty<MessageAttachment>());
+            return MessageAttachmentResolutionResult.Succeeded(Array.Empty<ResolvedAttachment>());
 
         var parsedIds = new List<UploadedFileId>(attachmentFileIds.Count);
         var seenIds = new HashSet<Guid>();
@@ -45,7 +50,7 @@ public sealed class MessageAttachmentResolver
         }
 
         var uploadedFilesById = uploadedFiles.ToDictionary(file => file.Id.Value);
-        var attachments = new List<MessageAttachment>(parsedIds.Count);
+        var attachments = new List<ResolvedAttachment>(parsedIds.Count);
 
         foreach (var parsedId in parsedIds)
         {
@@ -67,7 +72,7 @@ public sealed class MessageAttachmentResolver
                     "Only files uploaded with attachment purpose can be attached to messages.");
             }
 
-            attachments.Add(new MessageAttachment(
+            attachments.Add(new ResolvedAttachment(
                 uploadedFile.Id,
                 uploadedFile.FileName,
                 uploadedFile.ContentType,
@@ -80,12 +85,12 @@ public sealed class MessageAttachmentResolver
 
 public sealed record MessageAttachmentResolutionResult(
     bool Success,
-    IReadOnlyList<MessageAttachment> Attachments,
+    IReadOnlyList<ResolvedAttachment> Attachments,
     string? Error)
 {
-    public static MessageAttachmentResolutionResult Succeeded(IReadOnlyList<MessageAttachment> attachments)
+    public static MessageAttachmentResolutionResult Succeeded(IReadOnlyList<ResolvedAttachment> attachments)
         => new(true, attachments, null);
 
     public static MessageAttachmentResolutionResult Failed(string error)
-        => new(false, Array.Empty<MessageAttachment>(), error);
+        => new(false, Array.Empty<ResolvedAttachment>(), error);
 }

--- a/src/Harmonie.Application/Features/Channels/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
@@ -17,17 +17,20 @@ public sealed class DeleteMessageAttachmentHandler : IAuthenticatedHandler<Delet
 {
     private readonly IGuildChannelRepository _guildChannelRepository;
     private readonly IMessageRepository _messageRepository;
+    private readonly IMessageAttachmentRepository _messageAttachmentRepository;
     private readonly UploadedFileCleanupService _uploadedFileCleanupService;
     private readonly IUnitOfWork _unitOfWork;
 
     public DeleteMessageAttachmentHandler(
         IGuildChannelRepository guildChannelRepository,
         IMessageRepository messageRepository,
+        IMessageAttachmentRepository messageAttachmentRepository,
         UploadedFileCleanupService uploadedFileCleanupService,
         IUnitOfWork unitOfWork)
     {
         _guildChannelRepository = guildChannelRepository;
         _messageRepository = messageRepository;
+        _messageAttachmentRepository = messageAttachmentRepository;
         _uploadedFileCleanupService = uploadedFileCleanupService;
         _unitOfWork = unitOfWork;
     }
@@ -75,19 +78,18 @@ public sealed class DeleteMessageAttachmentHandler : IAuthenticatedHandler<Delet
                 "You can only delete attachments from your own messages");
         }
 
-        var removeAttachmentResult = message.RemoveAttachment(request.AttachmentId);
-        if (removeAttachmentResult.IsFailure)
+        bool deleted;
+        await using (var transaction = await _unitOfWork.BeginAsync(cancellationToken))
+        {
+            deleted = await _messageAttachmentRepository.DeleteAsync(message.Id, request.AttachmentId, cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+        }
+
+        if (!deleted)
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Message.AttachmentNotFound,
-                removeAttachmentResult.Error ?? "Attachment was not found on message");
-        }
-
-        await using (var transaction = await _unitOfWork.BeginAsync(cancellationToken))
-        {
-            await _messageRepository.UpdateAsync(message, cancellationToken);
-            await _messageRepository.RemoveAttachmentAsync(message.Id, request.AttachmentId, cancellationToken);
-            await transaction.CommitAsync(cancellationToken);
+                "Attachment was not found on message");
         }
 
         await _uploadedFileCleanupService.DeleteIfExistsAsync(request.AttachmentId, cancellationToken);

--- a/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageHandler.cs
@@ -19,6 +19,7 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditChannelMessag
 
     private readonly IGuildChannelRepository _guildChannelRepository;
     private readonly IMessageRepository _channelMessageRepository;
+    private readonly IMessageAttachmentRepository _messageAttachmentRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly ITextChannelNotifier _textChannelNotifier;
     private readonly ILogger<EditMessageHandler> _logger;
@@ -26,12 +27,14 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditChannelMessag
     public EditMessageHandler(
         IGuildChannelRepository guildChannelRepository,
         IMessageRepository channelMessageRepository,
+        IMessageAttachmentRepository messageAttachmentRepository,
         IUnitOfWork unitOfWork,
         ITextChannelNotifier textChannelNotifier,
         ILogger<EditMessageHandler> logger)
     {
         _guildChannelRepository = guildChannelRepository;
         _channelMessageRepository = channelMessageRepository;
+        _messageAttachmentRepository = messageAttachmentRepository;
         _unitOfWork = unitOfWork;
         _textChannelNotifier = textChannelNotifier;
         _logger = logger;
@@ -119,12 +122,14 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditChannelMessag
                 message.Content?.Value,
                 updatedAtUtc.Value));
 
+        var attachments = await _messageAttachmentRepository.GetByMessageIdAsync(message.Id, cancellationToken);
+
         return ApplicationResponse<EditMessageResponse>.Ok(new EditMessageResponse(
             MessageId: message.Id.Value,
             ChannelId: messageChannelId.Value,
             AuthorUserId: message.AuthorUserId.Value,
             Content: message.Content?.Value,
-            Attachments: message.Attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
+            Attachments: attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
             CreatedAtUtc: message.CreatedAtUtc,
             UpdatedAtUtc: message.UpdatedAtUtc));
     }

--- a/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesHandler.cs
@@ -84,6 +84,7 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetChannelMessage
             .Select(x =>
             {
                 page.ReactionsByMessageId.TryGetValue(x.Id.Value, out var reactions);
+                page.AttachmentsByMessageId.TryGetValue(x.Id.Value, out var attachments);
                 IReadOnlyList<LinkPreviewDto>? previews = null;
                 page.LinkPreviewsByMessageId?.TryGetValue(x.Id.Value, out previews);
                 var isPinned = page.PinnedMessageIds?.Contains(x.Id.Value) == true;
@@ -96,7 +97,8 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetChannelMessage
                     MessageId: x.Id.Value,
                     AuthorUserId: x.AuthorUserId.Value,
                     Content: x.Content?.Value,
-                    Attachments: x.Attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
+                    Attachments: attachments?.Select(MessageAttachmentDto.FromDomain).ToArray()
+                                 ?? Array.Empty<MessageAttachmentDto>(),
                     Reactions: reactions?.Select(r => new MessageReactionDto(r.Emoji, r.Count, r.ReactedByCaller,
                         r.Users.Select(u => new ReactionUserDto(u.UserId, u.Username, u.DisplayName)).ToArray())).ToArray()
                               ?? Array.Empty<MessageReactionDto>(),

--- a/src/Harmonie.Application/Features/Channels/GetPinnedMessages/GetPinnedMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/GetPinnedMessages/GetPinnedMessagesHandler.cs
@@ -17,16 +17,13 @@ public sealed class GetPinnedMessagesHandler : IAuthenticatedHandler<GetChannelP
 
     private readonly IGuildChannelRepository _guildChannelRepository;
     private readonly IPinnedMessageRepository _pinnedMessageRepository;
-    private readonly IMessageAttachmentRepository _messageAttachmentRepository;
 
     public GetPinnedMessagesHandler(
         IGuildChannelRepository guildChannelRepository,
-        IPinnedMessageRepository pinnedMessageRepository,
-        IMessageAttachmentRepository messageAttachmentRepository)
+        IPinnedMessageRepository pinnedMessageRepository)
     {
         _guildChannelRepository = guildChannelRepository;
         _pinnedMessageRepository = pinnedMessageRepository;
-        _messageAttachmentRepository = messageAttachmentRepository;
     }
 
     public async Task<ApplicationResponse<GetPinnedMessagesResponse>> HandleAsync(
@@ -82,14 +79,10 @@ public sealed class GetPinnedMessagesHandler : IAuthenticatedHandler<GetChannelP
             limit,
             cancellationToken);
 
-        var attachmentsByMessageId = await _messageAttachmentRepository.GetByMessageIdsAsync(
-            page.Items.Select(x => MessageId.From(x.MessageId)).ToArray(),
-            cancellationToken);
-
         var items = page.Items
             .Select(x =>
             {
-                attachmentsByMessageId.TryGetValue(MessageId.From(x.MessageId), out var attachments);
+                page.AttachmentsByMessageId.TryGetValue(MessageId.From(x.MessageId), out var attachments);
                 return new GetPinnedMessagesItemResponse(
                     MessageId: x.MessageId,
                     AuthorUserId: x.AuthorUserId,

--- a/src/Harmonie.Application/Features/Channels/GetPinnedMessages/GetPinnedMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/GetPinnedMessages/GetPinnedMessagesHandler.cs
@@ -4,6 +4,7 @@ using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
 
 namespace Harmonie.Application.Features.Channels.GetPinnedMessages;
@@ -16,13 +17,16 @@ public sealed class GetPinnedMessagesHandler : IAuthenticatedHandler<GetChannelP
 
     private readonly IGuildChannelRepository _guildChannelRepository;
     private readonly IPinnedMessageRepository _pinnedMessageRepository;
+    private readonly IMessageAttachmentRepository _messageAttachmentRepository;
 
     public GetPinnedMessagesHandler(
         IGuildChannelRepository guildChannelRepository,
-        IPinnedMessageRepository pinnedMessageRepository)
+        IPinnedMessageRepository pinnedMessageRepository,
+        IMessageAttachmentRepository messageAttachmentRepository)
     {
         _guildChannelRepository = guildChannelRepository;
         _pinnedMessageRepository = pinnedMessageRepository;
+        _messageAttachmentRepository = messageAttachmentRepository;
     }
 
     public async Task<ApplicationResponse<GetPinnedMessagesResponse>> HandleAsync(
@@ -78,18 +82,27 @@ public sealed class GetPinnedMessagesHandler : IAuthenticatedHandler<GetChannelP
             limit,
             cancellationToken);
 
+        var attachmentsByMessageId = await _messageAttachmentRepository.GetByMessageIdsAsync(
+            page.Items.Select(x => MessageId.From(x.MessageId)).ToArray(),
+            cancellationToken);
+
         var items = page.Items
-            .Select(x => new GetPinnedMessagesItemResponse(
-                MessageId: x.MessageId,
-                AuthorUserId: x.AuthorUserId,
-                AuthorUsername: x.AuthorUsername,
-                AuthorDisplayName: x.AuthorDisplayName,
-                Content: x.Content,
-                Attachments: x.Attachments,
-                CreatedAtUtc: x.CreatedAtUtc,
-                UpdatedAtUtc: x.UpdatedAtUtc,
-                PinnedByUserId: x.PinnedByUserId,
-                PinnedAtUtc: x.PinnedAtUtc))
+            .Select(x =>
+            {
+                attachmentsByMessageId.TryGetValue(MessageId.From(x.MessageId), out var attachments);
+                return new GetPinnedMessagesItemResponse(
+                    MessageId: x.MessageId,
+                    AuthorUserId: x.AuthorUserId,
+                    AuthorUsername: x.AuthorUsername,
+                    AuthorDisplayName: x.AuthorDisplayName,
+                    Content: x.Content,
+                    Attachments: attachments?.Select(MessageAttachmentDto.FromDomain).ToArray()
+                                 ?? Array.Empty<MessageAttachmentDto>(),
+                    CreatedAtUtc: x.CreatedAtUtc,
+                    UpdatedAtUtc: x.UpdatedAtUtc,
+                    PinnedByUserId: x.PinnedByUserId,
+                    PinnedAtUtc: x.PinnedAtUtc);
+            })
             .ToArray();
 
         return ApplicationResponse<GetPinnedMessagesResponse>.Ok(

--- a/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageHandler.cs
@@ -22,6 +22,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessag
 
     private readonly IGuildChannelRepository _guildChannelRepository;
     private readonly IMessageRepository _channelMessageRepository;
+    private readonly IMessageAttachmentRepository _messageAttachmentRepository;
     private readonly MessageAttachmentResolver _messageAttachmentResolver;
     private readonly IUnitOfWork _unitOfWork;
     private readonly ITextChannelNotifier _textChannelNotifier;
@@ -32,6 +33,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessag
     public SendMessageHandler(
         IGuildChannelRepository guildChannelRepository,
         IMessageRepository channelMessageRepository,
+        IMessageAttachmentRepository messageAttachmentRepository,
         MessageAttachmentResolver messageAttachmentResolver,
         IUnitOfWork unitOfWork,
         ITextChannelNotifier textChannelNotifier,
@@ -41,6 +43,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessag
     {
         _guildChannelRepository = guildChannelRepository;
         _channelMessageRepository = channelMessageRepository;
+        _messageAttachmentRepository = messageAttachmentRepository;
         _messageAttachmentResolver = messageAttachmentResolver;
         _unitOfWork = unitOfWork;
         _textChannelNotifier = textChannelNotifier;
@@ -121,24 +124,49 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessag
                     attachmentResolution.Error ?? "Attachments are invalid"));
         }
 
+        if (content is null && attachmentResolution.Attachments.Count == 0)
+        {
+            return ApplicationResponse<SendMessageResponse>.Fail(
+                ApplicationErrorCodes.Message.ContentEmpty,
+                "Message must have content or at least one attachment");
+        }
+
         var messageResult = Message.CreateForChannel(
             request.ChannelId,
             currentUserId,
             content,
-            attachmentResolution.Attachments,
             replyToMessageId);
         if (messageResult.IsFailure || messageResult.Value is null)
         {
-            var errorCode = content is null && attachmentResolution.Attachments.Count == 0
-                ? ApplicationErrorCodes.Message.ContentEmpty
-                : ApplicationErrorCodes.Common.DomainRuleViolation;
             return ApplicationResponse<SendMessageResponse>.Fail(
-                errorCode,
+                ApplicationErrorCodes.Common.DomainRuleViolation,
                 messageResult.Error ?? "Unable to create channel message");
+        }
+
+        var attachments = new List<MessageAttachment>(attachmentResolution.Attachments.Count);
+        for (var i = 0; i < attachmentResolution.Attachments.Count; i++)
+        {
+            var resolved = attachmentResolution.Attachments[i];
+            var attachmentResult = MessageAttachment.Create(
+                messageResult.Value.Id,
+                resolved.FileId,
+                resolved.FileName,
+                resolved.ContentType,
+                resolved.SizeBytes,
+                position: i);
+            if (attachmentResult.IsFailure || attachmentResult.Value is null)
+            {
+                return ApplicationResponse<SendMessageResponse>.Fail(
+                    ApplicationErrorCodes.Common.DomainRuleViolation,
+                    attachmentResult.Error ?? "Unable to create message attachment");
+            }
+            attachments.Add(attachmentResult.Value);
         }
 
         await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
         await _channelMessageRepository.AddAsync(messageResult.Value, cancellationToken);
+        if (attachments.Count > 0)
+            await _messageAttachmentRepository.AddRangeAsync(attachments, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
 
         var messageChannelId = messageResult.Value.ChannelId;
@@ -174,7 +202,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessag
                 ctx.CallerUsername ?? string.Empty,
                 ctx.CallerDisplayName,
                 messageResult.Value.Content?.Value,
-                messageResult.Value.Attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
+                attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
                 replyTo,
                 messageResult.Value.CreatedAtUtc));
 
@@ -199,7 +227,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessag
             ChannelId: messageChannelId.Value,
             AuthorUserId: messageResult.Value.AuthorUserId.Value,
             Content: messageResult.Value.Content?.Value,
-            Attachments: messageResult.Value.Attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
+            Attachments: attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
             ReplyTo: replyTo,
             CreatedAtUtc: messageResult.Value.CreatedAtUtc);
 

--- a/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
@@ -17,6 +17,7 @@ public sealed class DeleteMessageAttachmentHandler : IAuthenticatedHandler<Delet
 {
     private readonly IConversationRepository _conversationRepository;
     private readonly IMessageRepository _conversationMessageRepository;
+    private readonly IMessageAttachmentRepository _messageAttachmentRepository;
     private readonly UploadedFileCleanupService _uploadedFileCleanupService;
     private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<DeleteMessageAttachmentHandler> _logger;
@@ -24,12 +25,14 @@ public sealed class DeleteMessageAttachmentHandler : IAuthenticatedHandler<Delet
     public DeleteMessageAttachmentHandler(
         IConversationRepository conversationRepository,
         IMessageRepository conversationMessageRepository,
+        IMessageAttachmentRepository messageAttachmentRepository,
         UploadedFileCleanupService uploadedFileCleanupService,
         IUnitOfWork unitOfWork,
         ILogger<DeleteMessageAttachmentHandler> logger)
     {
         _conversationRepository = conversationRepository;
         _conversationMessageRepository = conversationMessageRepository;
+        _messageAttachmentRepository = messageAttachmentRepository;
         _uploadedFileCleanupService = uploadedFileCleanupService;
         _unitOfWork = unitOfWork;
         _logger = logger;
@@ -70,19 +73,18 @@ public sealed class DeleteMessageAttachmentHandler : IAuthenticatedHandler<Delet
                 "You can only delete attachments from your own messages");
         }
 
-        var removeAttachmentResult = message.RemoveAttachment(request.AttachmentId);
-        if (removeAttachmentResult.IsFailure)
+        bool deleted;
+        await using (var transaction = await _unitOfWork.BeginAsync(cancellationToken))
+        {
+            deleted = await _messageAttachmentRepository.DeleteAsync(message.Id, request.AttachmentId, cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+        }
+
+        if (!deleted)
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Message.AttachmentNotFound,
-                removeAttachmentResult.Error ?? "Attachment was not found on message");
-        }
-
-        await using (var transaction = await _unitOfWork.BeginAsync(cancellationToken))
-        {
-            await _conversationMessageRepository.UpdateAsync(message, cancellationToken);
-            await _conversationMessageRepository.RemoveAttachmentAsync(message.Id, request.AttachmentId, cancellationToken);
-            await transaction.CommitAsync(cancellationToken);
+                "Attachment was not found on message");
         }
 
         await _uploadedFileCleanupService.DeleteIfExistsAsync(request.AttachmentId, cancellationToken);

--- a/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageHandler.cs
@@ -18,6 +18,7 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditConversationM
 
     private readonly IConversationRepository _conversationRepository;
     private readonly IMessageRepository _conversationMessageRepository;
+    private readonly IMessageAttachmentRepository _messageAttachmentRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IConversationMessageNotifier _conversationMessageNotifier;
     private readonly ILogger<EditMessageHandler> _logger;
@@ -25,12 +26,14 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditConversationM
     public EditMessageHandler(
         IConversationRepository conversationRepository,
         IMessageRepository conversationMessageRepository,
+        IMessageAttachmentRepository messageAttachmentRepository,
         IUnitOfWork unitOfWork,
         IConversationMessageNotifier conversationMessageNotifier,
         ILogger<EditMessageHandler> logger)
     {
         _conversationRepository = conversationRepository;
         _conversationMessageRepository = conversationMessageRepository;
+        _messageAttachmentRepository = messageAttachmentRepository;
         _unitOfWork = unitOfWork;
         _conversationMessageNotifier = conversationMessageNotifier;
         _logger = logger;
@@ -109,12 +112,14 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditConversationM
                 message.Content?.Value,
                 updatedAtUtc.Value));
 
+        var attachments = await _messageAttachmentRepository.GetByMessageIdAsync(message.Id, cancellationToken);
+
         return ApplicationResponse<EditMessageResponse>.Ok(new EditMessageResponse(
             MessageId: message.Id.Value,
             ConversationId: messageConversationId.Value,
             AuthorUserId: message.AuthorUserId.Value,
             Content: message.Content?.Value,
-            Attachments: message.Attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
+            Attachments: attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
             CreatedAtUtc: message.CreatedAtUtc,
             UpdatedAtUtc: updatedAtUtc));
     }

--- a/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesHandler.cs
@@ -75,6 +75,7 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetConversationMe
             .Select(x =>
             {
                 page.ReactionsByMessageId.TryGetValue(x.Id.Value, out var reactions);
+                page.AttachmentsByMessageId.TryGetValue(x.Id.Value, out var attachments);
                 IReadOnlyList<LinkPreviewDto>? previews = null;
                 page.LinkPreviewsByMessageId?.TryGetValue(x.Id.Value, out previews);
                 var isPinned = page.PinnedMessageIds?.Contains(x.Id.Value) == true;
@@ -87,7 +88,8 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetConversationMe
                     MessageId: x.Id.Value,
                     AuthorUserId: x.AuthorUserId.Value,
                     Content: x.Content?.Value,
-                    Attachments: x.Attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
+                    Attachments: attachments?.Select(MessageAttachmentDto.FromDomain).ToArray()
+                                 ?? Array.Empty<MessageAttachmentDto>(),
                     Reactions: reactions?.Select(r => new MessageReactionDto(r.Emoji, r.Count, r.ReactedByCaller,
                         r.Users.Select(u => new ReactionUserDto(u.UserId, u.Username, u.DisplayName)).ToArray())).ToArray()
                               ?? Array.Empty<MessageReactionDto>(),

--- a/src/Harmonie.Application/Features/Conversations/GetPinnedMessages/GetPinnedMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetPinnedMessages/GetPinnedMessagesHandler.cs
@@ -16,16 +16,13 @@ public sealed class GetPinnedMessagesHandler : IAuthenticatedHandler<GetConversa
 
     private readonly IConversationRepository _conversationRepository;
     private readonly IPinnedMessageRepository _pinnedMessageRepository;
-    private readonly IMessageAttachmentRepository _messageAttachmentRepository;
 
     public GetPinnedMessagesHandler(
         IConversationRepository conversationRepository,
-        IPinnedMessageRepository pinnedMessageRepository,
-        IMessageAttachmentRepository messageAttachmentRepository)
+        IPinnedMessageRepository pinnedMessageRepository)
     {
         _conversationRepository = conversationRepository;
         _pinnedMessageRepository = pinnedMessageRepository;
-        _messageAttachmentRepository = messageAttachmentRepository;
     }
 
     public async Task<ApplicationResponse<GetConversationPinnedMessagesResponse>> HandleAsync(
@@ -74,14 +71,10 @@ public sealed class GetPinnedMessagesHandler : IAuthenticatedHandler<GetConversa
             limit,
             cancellationToken);
 
-        var attachmentsByMessageId = await _messageAttachmentRepository.GetByMessageIdsAsync(
-            page.Items.Select(x => MessageId.From(x.MessageId)).ToArray(),
-            cancellationToken);
-
         var items = page.Items
             .Select(x =>
             {
-                attachmentsByMessageId.TryGetValue(MessageId.From(x.MessageId), out var attachments);
+                page.AttachmentsByMessageId.TryGetValue(MessageId.From(x.MessageId), out var attachments);
                 return new GetPinnedMessagesItemResponse(
                     MessageId: x.MessageId,
                     AuthorUserId: x.AuthorUserId,

--- a/src/Harmonie.Application/Features/Conversations/GetPinnedMessages/GetPinnedMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetPinnedMessages/GetPinnedMessagesHandler.cs
@@ -3,6 +3,7 @@ using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
 
 namespace Harmonie.Application.Features.Conversations.GetPinnedMessages;
@@ -15,13 +16,16 @@ public sealed class GetPinnedMessagesHandler : IAuthenticatedHandler<GetConversa
 
     private readonly IConversationRepository _conversationRepository;
     private readonly IPinnedMessageRepository _pinnedMessageRepository;
+    private readonly IMessageAttachmentRepository _messageAttachmentRepository;
 
     public GetPinnedMessagesHandler(
         IConversationRepository conversationRepository,
-        IPinnedMessageRepository pinnedMessageRepository)
+        IPinnedMessageRepository pinnedMessageRepository,
+        IMessageAttachmentRepository messageAttachmentRepository)
     {
         _conversationRepository = conversationRepository;
         _pinnedMessageRepository = pinnedMessageRepository;
+        _messageAttachmentRepository = messageAttachmentRepository;
     }
 
     public async Task<ApplicationResponse<GetConversationPinnedMessagesResponse>> HandleAsync(
@@ -70,18 +74,27 @@ public sealed class GetPinnedMessagesHandler : IAuthenticatedHandler<GetConversa
             limit,
             cancellationToken);
 
+        var attachmentsByMessageId = await _messageAttachmentRepository.GetByMessageIdsAsync(
+            page.Items.Select(x => MessageId.From(x.MessageId)).ToArray(),
+            cancellationToken);
+
         var items = page.Items
-            .Select(x => new GetPinnedMessagesItemResponse(
-                MessageId: x.MessageId,
-                AuthorUserId: x.AuthorUserId,
-                AuthorUsername: x.AuthorUsername,
-                AuthorDisplayName: x.AuthorDisplayName,
-                Content: x.Content,
-                Attachments: x.Attachments,
-                CreatedAtUtc: x.CreatedAtUtc,
-                UpdatedAtUtc: x.UpdatedAtUtc,
-                PinnedByUserId: x.PinnedByUserId,
-                PinnedAtUtc: x.PinnedAtUtc))
+            .Select(x =>
+            {
+                attachmentsByMessageId.TryGetValue(MessageId.From(x.MessageId), out var attachments);
+                return new GetPinnedMessagesItemResponse(
+                    MessageId: x.MessageId,
+                    AuthorUserId: x.AuthorUserId,
+                    AuthorUsername: x.AuthorUsername,
+                    AuthorDisplayName: x.AuthorDisplayName,
+                    Content: x.Content,
+                    Attachments: attachments?.Select(MessageAttachmentDto.FromDomain).ToArray()
+                                 ?? Array.Empty<MessageAttachmentDto>(),
+                    CreatedAtUtc: x.CreatedAtUtc,
+                    UpdatedAtUtc: x.UpdatedAtUtc,
+                    PinnedByUserId: x.PinnedByUserId,
+                    PinnedAtUtc: x.PinnedAtUtc);
+            })
             .ToArray();
 
         return ApplicationResponse<GetConversationPinnedMessagesResponse>.Ok(

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageHandler.cs
@@ -22,6 +22,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
     private readonly IConversationRepository _conversationRepository;
     private readonly IConversationParticipantRepository _participantRepository;
     private readonly IMessageRepository _conversationMessageRepository;
+    private readonly IMessageAttachmentRepository _messageAttachmentRepository;
     private readonly MessageAttachmentResolver _messageAttachmentResolver;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IConversationMessageNotifier _conversationMessageNotifier;
@@ -33,6 +34,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
         IConversationRepository conversationRepository,
         IConversationParticipantRepository participantRepository,
         IMessageRepository conversationMessageRepository,
+        IMessageAttachmentRepository messageAttachmentRepository,
         MessageAttachmentResolver messageAttachmentResolver,
         IUnitOfWork unitOfWork,
         IConversationMessageNotifier conversationMessageNotifier,
@@ -43,6 +45,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
         _conversationRepository = conversationRepository;
         _participantRepository = participantRepository;
         _conversationMessageRepository = conversationMessageRepository;
+        _messageAttachmentRepository = messageAttachmentRepository;
         _messageAttachmentResolver = messageAttachmentResolver;
         _unitOfWork = unitOfWork;
         _conversationMessageNotifier = conversationMessageNotifier;
@@ -115,20 +118,43 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
                     attachmentResolution.Error ?? "Attachments are invalid"));
         }
 
+        if (content is null && attachmentResolution.Attachments.Count == 0)
+        {
+            return ApplicationResponse<SendMessageResponse>.Fail(
+                ApplicationErrorCodes.Message.ContentEmpty,
+                "Message must have content or at least one attachment");
+        }
+
         var messageResult = Message.CreateForConversation(
             request.ConversationId,
             currentUserId,
             content,
-            attachmentResolution.Attachments,
             replyToMessageId);
         if (messageResult.IsFailure || messageResult.Value is null)
         {
-            var errorCode = content is null && attachmentResolution.Attachments.Count == 0
-                ? ApplicationErrorCodes.Message.ContentEmpty
-                : ApplicationErrorCodes.Common.DomainRuleViolation;
             return ApplicationResponse<SendMessageResponse>.Fail(
-                errorCode,
+                ApplicationErrorCodes.Common.DomainRuleViolation,
                 messageResult.Error ?? "Unable to create conversation message");
+        }
+
+        var attachments = new List<MessageAttachment>(attachmentResolution.Attachments.Count);
+        for (var i = 0; i < attachmentResolution.Attachments.Count; i++)
+        {
+            var resolved = attachmentResolution.Attachments[i];
+            var attachmentResult = MessageAttachment.Create(
+                messageResult.Value.Id,
+                resolved.FileId,
+                resolved.FileName,
+                resolved.ContentType,
+                resolved.SizeBytes,
+                position: i);
+            if (attachmentResult.IsFailure || attachmentResult.Value is null)
+            {
+                return ApplicationResponse<SendMessageResponse>.Fail(
+                    ApplicationErrorCodes.Common.DomainRuleViolation,
+                    attachmentResult.Error ?? "Unable to create message attachment");
+            }
+            attachments.Add(attachmentResult.Value);
         }
 
         ConversationParticipant[] hiddenParticipants = [];
@@ -143,6 +169,8 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
 
         await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
         await _conversationMessageRepository.AddAsync(messageResult.Value, cancellationToken);
+        if (attachments.Count > 0)
+            await _messageAttachmentRepository.AddRangeAsync(attachments, cancellationToken);
         if (hiddenParticipants.Length > 0)
             await _participantRepository.UpdateRangeAsync(hiddenParticipants, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
@@ -179,7 +207,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
                 access.CallerUsername ?? string.Empty,
                 access.CallerDisplayName,
                 messageResult.Value.Content?.Value,
-                messageResult.Value.Attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
+                attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
                 replyTo,
                 messageResult.Value.CreatedAtUtc));
 
@@ -203,7 +231,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
             ConversationId: messageConversationId.Value,
             AuthorUserId: messageResult.Value.AuthorUserId.Value,
             Content: messageResult.Value.Content?.Value,
-            Attachments: messageResult.Value.Attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
+            Attachments: attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
             ReplyTo: replyTo,
             CreatedAtUtc: messageResult.Value.CreatedAtUtc));
     }

--- a/src/Harmonie.Application/Interfaces/Messages/IMessageAttachmentRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Messages/IMessageAttachmentRepository.cs
@@ -1,0 +1,25 @@
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Uploads;
+
+namespace Harmonie.Application.Interfaces.Messages;
+
+public interface IMessageAttachmentRepository
+{
+    Task<IReadOnlyDictionary<MessageId, IReadOnlyList<MessageAttachment>>> GetByMessageIdsAsync(
+        IReadOnlyCollection<MessageId> messageIds,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<MessageAttachment>> GetByMessageIdAsync(
+        MessageId messageId,
+        CancellationToken cancellationToken = default);
+
+    Task AddRangeAsync(
+        IEnumerable<MessageAttachment> attachments,
+        CancellationToken cancellationToken = default);
+
+    Task<bool> DeleteAsync(
+        MessageId messageId,
+        UploadedFileId fileId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Harmonie.Application/Interfaces/Messages/IMessageRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Messages/IMessageRepository.cs
@@ -7,6 +7,7 @@ using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
 
+
 namespace Harmonie.Application.Interfaces.Messages;
 
 public sealed record ReplyTargetSummary(
@@ -33,11 +34,6 @@ public interface IMessageRepository
 
     Task UpdateAsync(
         Message message,
-        CancellationToken cancellationToken = default);
-
-    Task RemoveAttachmentAsync(
-        MessageId messageId,
-        UploadedFileId attachmentFileId,
         CancellationToken cancellationToken = default);
 
     Task SoftDeleteAsync(
@@ -71,6 +67,7 @@ public sealed record MessagePage(
     IReadOnlyList<Message> Items,
     MessageCursor? NextCursor,
     IReadOnlyDictionary<Guid, IReadOnlyList<MessageReactionSummary>> ReactionsByMessageId,
+    IReadOnlyDictionary<Guid, IReadOnlyList<MessageAttachment>> AttachmentsByMessageId,
     IReadOnlyDictionary<Guid, IReadOnlyList<LinkPreviewDto>>? LinkPreviewsByMessageId = null,
     IReadOnlySet<Guid>? PinnedMessageIds = null,
     IReadOnlyDictionary<Guid, ReplyPreviewDto>? ReplyPreviewsByTargetMessageId = null,

--- a/src/Harmonie.Application/Interfaces/Messages/IPinnedMessageRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Messages/IPinnedMessageRepository.cs
@@ -37,6 +37,7 @@ public sealed record PinnedMessagesCursor(
 
 public sealed record PinnedMessagesPage(
     IReadOnlyList<PinnedMessageSummary> Items,
+    IReadOnlyDictionary<MessageId, IReadOnlyList<MessageAttachment>> AttachmentsByMessageId,
     PinnedMessagesCursor? NextCursor);
 
 public sealed record PinnedMessageSummary(

--- a/src/Harmonie.Application/Interfaces/Messages/IPinnedMessageRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Messages/IPinnedMessageRepository.cs
@@ -1,4 +1,3 @@
-using Harmonie.Application.Common.Messages;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Conversations;
@@ -46,7 +45,6 @@ public sealed record PinnedMessageSummary(
     string AuthorUsername,
     string? AuthorDisplayName,
     string? Content,
-    IReadOnlyList<MessageAttachmentDto> Attachments,
     DateTime CreatedAtUtc,
     DateTime? UpdatedAtUtc,
     Guid PinnedByUserId,

--- a/src/Harmonie.Domain/Entities/Messages/Message.cs
+++ b/src/Harmonie.Domain/Entities/Messages/Message.cs
@@ -2,7 +2,6 @@ using Harmonie.Domain.Common;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
-using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
 
 namespace Harmonie.Domain.Entities.Messages;
@@ -19,8 +18,6 @@ public sealed class Message : Entity<MessageId>
 
     public MessageId? ReplyToMessageId { get; private set; }
 
-    public IReadOnlyList<MessageAttachment> Attachments { get; private set; } = Array.Empty<MessageAttachment>();
-
     public DateTime? DeletedAtUtc { get; private set; }
 
     private Message(
@@ -30,7 +27,6 @@ public sealed class Message : Entity<MessageId>
         UserId authorUserId,
         MessageId? replyToMessageId,
         MessageContent? content,
-        IReadOnlyList<MessageAttachment> attachments,
         DateTime createdAtUtc,
         DateTime? updatedAtUtc,
         DateTime? deletedAtUtc)
@@ -41,7 +37,6 @@ public sealed class Message : Entity<MessageId>
         AuthorUserId = authorUserId;
         ReplyToMessageId = replyToMessageId;
         Content = content;
-        Attachments = attachments.ToArray();
         CreatedAtUtc = createdAtUtc;
         UpdatedAtUtc = updatedAtUtc;
         DeletedAtUtc = deletedAtUtc;
@@ -51,19 +46,12 @@ public sealed class Message : Entity<MessageId>
         GuildChannelId channelId,
         UserId authorUserId,
         MessageContent? content,
-        IReadOnlyList<MessageAttachment>? attachments = null,
         MessageId? replyToMessageId = null)
     {
         if (channelId is null)
             return Result.Failure<Message>("Channel ID is required");
         if (authorUserId is null)
             return Result.Failure<Message>("Author user ID is required");
-        if (attachments is null)
-            attachments = Array.Empty<MessageAttachment>();
-        if (attachments.Any(attachment => attachment is null))
-            return Result.Failure<Message>("Message attachments are invalid");
-        if (content is null && attachments.Count == 0)
-            return Result.Failure<Message>("Message must have content or at least one attachment");
 
         return Result.Success(new Message(
             MessageId.New(),
@@ -72,7 +60,6 @@ public sealed class Message : Entity<MessageId>
             authorUserId,
             replyToMessageId,
             content,
-            attachments,
             DateTime.UtcNow,
             updatedAtUtc: null,
             deletedAtUtc: null));
@@ -82,19 +69,12 @@ public sealed class Message : Entity<MessageId>
         ConversationId conversationId,
         UserId authorUserId,
         MessageContent? content,
-        IReadOnlyList<MessageAttachment>? attachments = null,
         MessageId? replyToMessageId = null)
     {
         if (conversationId is null)
             return Result.Failure<Message>("Conversation ID is required");
         if (authorUserId is null)
             return Result.Failure<Message>("Author user ID is required");
-        if (attachments is null)
-            attachments = Array.Empty<MessageAttachment>();
-        if (attachments.Any(attachment => attachment is null))
-            return Result.Failure<Message>("Message attachments are invalid");
-        if (content is null && attachments.Count == 0)
-            return Result.Failure<Message>("Message must have content or at least one attachment");
 
         return Result.Success(new Message(
             MessageId.New(),
@@ -103,7 +83,6 @@ public sealed class Message : Entity<MessageId>
             authorUserId,
             replyToMessageId,
             content,
-            attachments,
             DateTime.UtcNow,
             updatedAtUtc: null,
             deletedAtUtc: null));
@@ -112,23 +91,6 @@ public sealed class Message : Entity<MessageId>
     public Result UpdateContent(MessageContent newContent)
     {
         Content = newContent;
-        MarkAsUpdated();
-        return Result.Success();
-    }
-
-    public Result RemoveAttachment(UploadedFileId attachmentFileId)
-    {
-        if (attachmentFileId is null)
-            return Result.Failure("Attachment file ID is required");
-
-        var remainingAttachments = Attachments
-            .Where(attachment => attachment.FileId != attachmentFileId)
-            .ToArray();
-
-        if (remainingAttachments.Length == Attachments.Count)
-            return Result.Failure("Attachment was not found on message");
-
-        Attachments = remainingAttachments;
         MarkAsUpdated();
         return Result.Success();
     }
@@ -152,8 +114,7 @@ public sealed class Message : Entity<MessageId>
         MessageContent? content,
         DateTime createdAtUtc,
         DateTime? updatedAtUtc,
-        DateTime? deletedAtUtc,
-        IReadOnlyList<MessageAttachment>? attachments = null)
+        DateTime? deletedAtUtc)
     {
         ArgumentNullException.ThrowIfNull(id);
         ArgumentNullException.ThrowIfNull(authorUserId);
@@ -168,7 +129,6 @@ public sealed class Message : Entity<MessageId>
             authorUserId,
             replyToMessageId,
             content,
-            attachments ?? Array.Empty<MessageAttachment>(),
             createdAtUtc,
             updatedAtUtc,
             deletedAtUtc);

--- a/src/Harmonie.Domain/Entities/Messages/MessageAttachment.cs
+++ b/src/Harmonie.Domain/Entities/Messages/MessageAttachment.cs
@@ -1,9 +1,87 @@
+using Harmonie.Domain.Common;
+using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Uploads;
 
 namespace Harmonie.Domain.Entities.Messages;
 
-public sealed record MessageAttachment(
-    UploadedFileId FileId,
-    string FileName,
-    string ContentType,
-    long SizeBytes);
+public sealed class MessageAttachment
+{
+    public MessageId MessageId { get; }
+
+    public UploadedFileId FileId { get; }
+
+    public string FileName { get; }
+
+    public string ContentType { get; }
+
+    public long SizeBytes { get; }
+
+    public int Position { get; }
+
+    private MessageAttachment(
+        MessageId messageId,
+        UploadedFileId fileId,
+        string fileName,
+        string contentType,
+        long sizeBytes,
+        int position)
+    {
+        MessageId = messageId;
+        FileId = fileId;
+        FileName = fileName;
+        ContentType = contentType;
+        SizeBytes = sizeBytes;
+        Position = position;
+    }
+
+    public static Result<MessageAttachment> Create(
+        MessageId messageId,
+        UploadedFileId fileId,
+        string fileName,
+        string contentType,
+        long sizeBytes,
+        int position)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+            return Result.Failure<MessageAttachment>("Attachment file name is required");
+
+        if (string.IsNullOrWhiteSpace(contentType))
+            return Result.Failure<MessageAttachment>("Attachment content type is required");
+
+        if (sizeBytes <= 0)
+            return Result.Failure<MessageAttachment>("Attachment size must be greater than zero");
+
+        if (position < 0)
+            return Result.Failure<MessageAttachment>("Attachment position cannot be negative");
+
+        return Result.Success(new MessageAttachment(
+            messageId,
+            fileId,
+            fileName,
+            contentType,
+            sizeBytes,
+            position));
+    }
+
+    public static MessageAttachment Rehydrate(
+        MessageId messageId,
+        UploadedFileId fileId,
+        string fileName,
+        string contentType,
+        long sizeBytes,
+        int position)
+    {
+        ArgumentNullException.ThrowIfNull(messageId);
+        ArgumentNullException.ThrowIfNull(fileId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(contentType);
+
+        if (sizeBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(sizeBytes), "Attachment size must be greater than zero.");
+
+        if (position < 0)
+            throw new ArgumentOutOfRangeException(nameof(position), "Attachment position cannot be negative.");
+
+        return new MessageAttachment(messageId, fileId, fileName, contentType, sizeBytes, position);
+    }
+}

--- a/src/Harmonie.Infrastructure/DependencyInjection.cs
+++ b/src/Harmonie.Infrastructure/DependencyInjection.cs
@@ -80,6 +80,7 @@ public static class DependencyInjection
         services.AddScoped<IConversationParticipantRepository, ConversationParticipantRepository>();
         services.AddScoped<IUploadedFileRepository, UploadedFileRepository>();
         services.AddScoped<IMessageReactionRepository, MessageReactionRepository>();
+        services.AddScoped<IMessageAttachmentRepository, MessageAttachmentRepository>();
         services.AddScoped<IPinnedMessageRepository, PinnedMessageRepository>();
         services.AddScoped<ILinkPreviewRepository, LinkPreviewRepository>();
         services.AddScoped<IChannelReadStateRepository, ChannelReadStateRepository>();

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessageAttachmentRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessageAttachmentRepository.cs
@@ -1,0 +1,152 @@
+using Dapper;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Uploads;
+using Harmonie.Infrastructure.Persistence.Common;
+using Harmonie.Infrastructure.Rows.Messages;
+
+namespace Harmonie.Infrastructure.Persistence.Messages;
+
+internal sealed class MessageAttachmentRepository : IMessageAttachmentRepository
+{
+    private readonly DbSession _dbSession;
+
+    public MessageAttachmentRepository(DbSession dbSession)
+    {
+        _dbSession = dbSession;
+    }
+
+    public async Task<IReadOnlyDictionary<MessageId, IReadOnlyList<MessageAttachment>>> GetByMessageIdsAsync(
+        IReadOnlyCollection<MessageId> messageIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (messageIds.Count == 0)
+            return new Dictionary<MessageId, IReadOnlyList<MessageAttachment>>();
+
+        const string sql = """
+                           SELECT ma.message_id AS "MessageId",
+                                  ma.position AS "Position",
+                                  uf.id AS "UploadedFileId",
+                                  uf.filename AS "FileName",
+                                  uf.content_type AS "ContentType",
+                                  uf.size_bytes AS "SizeBytes"
+                           FROM message_attachments ma
+                           INNER JOIN uploaded_files uf ON uf.id = ma.uploaded_file_id
+                           WHERE ma.message_id = ANY(@MessageIds)
+                           ORDER BY ma.message_id, ma.position
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new { MessageIds = messageIds.Select(id => id.Value).ToArray() },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        var rows = await connection.QueryAsync<MessageAttachmentRow>(command);
+
+        return rows
+            .GroupBy(row => row.MessageId)
+            .ToDictionary(
+                group => MessageId.From(group.Key),
+                group => (IReadOnlyList<MessageAttachment>)group
+                    .OrderBy(row => row.Position)
+                    .Select(MapRow)
+                    .ToArray());
+    }
+
+    public async Task<IReadOnlyList<MessageAttachment>> GetByMessageIdAsync(
+        MessageId messageId,
+        CancellationToken cancellationToken = default)
+    {
+        var byMessageId = await GetByMessageIdsAsync([messageId], cancellationToken);
+        return byMessageId.TryGetValue(messageId, out var attachments)
+            ? attachments
+            : Array.Empty<MessageAttachment>();
+    }
+
+    public async Task AddRangeAsync(
+        IEnumerable<MessageAttachment> attachments,
+        CancellationToken cancellationToken = default)
+    {
+        var attachmentList = attachments as IReadOnlyCollection<MessageAttachment> ?? attachments.ToArray();
+        if (attachmentList.Count == 0)
+            return;
+
+        const string sql = """
+                           INSERT INTO message_attachments (
+                               message_id,
+                               uploaded_file_id,
+                               position)
+                           VALUES (
+                               @MessageId,
+                               @UploadedFileId,
+                               @Position)
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            attachmentList.Select(attachment => new
+            {
+                MessageId = attachment.MessageId.Value,
+                UploadedFileId = attachment.FileId.Value,
+                attachment.Position
+            }),
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        await connection.ExecuteAsync(command);
+    }
+
+    public async Task<bool> DeleteAsync(
+        MessageId messageId,
+        UploadedFileId fileId,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+                           DELETE FROM message_attachments
+                           WHERE message_id = @MessageId
+                             AND uploaded_file_id = @UploadedFileId
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new
+            {
+                MessageId = messageId.Value,
+                UploadedFileId = fileId.Value
+            },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        var rowsAffected = await connection.ExecuteAsync(command);
+        return rowsAffected > 0;
+    }
+
+    internal static MessageAttachment MapRow(MessageAttachmentRow row)
+    {
+        return MessageAttachment.Rehydrate(
+            MessageId.From(row.MessageId),
+            UploadedFileId.From(row.UploadedFileId),
+            row.FileName,
+            row.ContentType,
+            row.SizeBytes,
+            row.Position);
+    }
+
+    internal static IReadOnlyDictionary<Guid, IReadOnlyList<MessageAttachment>> BuildByMessageIdDictionary(
+        IEnumerable<MessageAttachmentRow> rows)
+    {
+        return rows
+            .GroupBy(row => row.MessageId)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyList<MessageAttachment>)group
+                    .OrderBy(row => row.Position)
+                    .Select(MapRow)
+                    .ToArray());
+    }
+}

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessagePaginationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessagePaginationRepository.cs
@@ -192,7 +192,7 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
         var pageRows = hasMore ? rows.Take(limit).ToArray() : rows;
         var pageMessageIds = new HashSet<Guid>(pageRows.Select(row => row.Id));
 
-        var attachmentsByMessageId = MessageRepositoryHelpers.BuildAttachmentsDictionary(
+        var attachmentsByMessageId = MessageAttachmentRepository.BuildByMessageIdDictionary(
             attachmentRows.Where(r => pageMessageIds.Contains(r.MessageId)));
         var reactionsByMessageId = MessageRepositoryHelpers.BuildReactionsDictionary(
             reactionRows.Where(r => pageMessageIds.Contains(r.MessageId)),
@@ -217,7 +217,7 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
                     r.DeletedAtUtc));
 
         var items = pageRows
-            .Select(row => MessageRepositoryHelpers.MapToMessage(row, attachmentsByMessageId))
+            .Select(row => MessageRepositoryHelpers.MapToMessage(row))
             .OrderBy(x => x.CreatedAtUtc)
             .ThenBy(x => x.Id.Value)
             .ToArray();
@@ -240,7 +240,7 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
                 readStateRow.ReadAtUtc);
         }
 
-        return new MessagePage(items, nextCursor, reactionsByMessageId, linkPreviewsByMessageId, pinnedMessageIds, replyPreviewsByTargetMessageId, lastReadState);
+        return new MessagePage(items, nextCursor, reactionsByMessageId, attachmentsByMessageId, linkPreviewsByMessageId, pinnedMessageIds, replyPreviewsByTargetMessageId, lastReadState);
     }
 
     public async Task<MessagePage> GetConversationPageAsync(
@@ -414,7 +414,7 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
         var pageRows = hasMore ? rows.Take(limit).ToArray() : rows;
         var pageMessageIds = new HashSet<Guid>(pageRows.Select(row => row.Id));
 
-        var attachmentsByMessageId = MessageRepositoryHelpers.BuildAttachmentsDictionary(
+        var attachmentsByMessageId = MessageAttachmentRepository.BuildByMessageIdDictionary(
             attachmentRows.Where(r => pageMessageIds.Contains(r.MessageId)));
         var reactionsByMessageId = MessageRepositoryHelpers.BuildReactionsDictionary(
             reactionRows.Where(r => pageMessageIds.Contains(r.MessageId)),
@@ -439,7 +439,7 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
                     r.DeletedAtUtc));
 
         var items = pageRows
-            .Select(row => MessageRepositoryHelpers.MapToMessage(row, attachmentsByMessageId))
+            .Select(row => MessageRepositoryHelpers.MapToMessage(row))
             .OrderBy(x => x.CreatedAtUtc)
             .ThenBy(x => x.Id.Value)
             .ToArray();
@@ -462,7 +462,7 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
                 readStateRow.ReadAtUtc);
         }
 
-        return new MessagePage(items, nextCursor, reactionsByMessageId, linkPreviewsByMessageId, pinnedMessageIds, replyPreviewsByTargetMessageId, lastReadState);
+        return new MessagePage(items, nextCursor, reactionsByMessageId, attachmentsByMessageId, linkPreviewsByMessageId, pinnedMessageIds, replyPreviewsByTargetMessageId, lastReadState);
     }
 
     private sealed class ReadStateRow

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepository.cs
@@ -5,7 +5,6 @@ using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
-using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
 using Harmonie.Infrastructure.Persistence.Common;
 using Harmonie.Infrastructure.Rows.Messages;
@@ -81,33 +80,6 @@ internal sealed class MessageRepository : IMessageRepository
             cancellationToken: cancellationToken);
 
         await connection.ExecuteAsync(command);
-
-        if (message.Attachments.Count == 0)
-            return;
-
-        const string attachmentSql = """
-                                     INSERT INTO message_attachments (
-                                         message_id,
-                                         uploaded_file_id,
-                                         position)
-                                     VALUES (
-                                         @MessageId,
-                                         @UploadedFileId,
-                                         @Position)
-                                     """;
-
-        var attachmentCommand = new CommandDefinition(
-            attachmentSql,
-            message.Attachments.Select((attachment, index) => new
-            {
-                MessageId = message.Id.Value,
-                UploadedFileId = attachment.FileId.Value,
-                Position = index
-            }),
-            transaction: _dbSession.Transaction,
-            cancellationToken: cancellationToken);
-
-        await connection.ExecuteAsync(attachmentCommand);
     }
 
     public async Task<Message?> GetByIdAsync(
@@ -140,9 +112,7 @@ internal sealed class MessageRepository : IMessageRepository
         if (row is null)
             return null;
 
-        var attachmentsByMessageId = await MessageRepositoryHelpers.GetAttachmentsByMessageIdsAsync(
-            _dbSession, [row.Id], cancellationToken);
-        return MessageRepositoryHelpers.MapToMessage(row, attachmentsByMessageId);
+        return MessageRepositoryHelpers.MapToMessage(row);
     }
 
     public async Task UpdateAsync(
@@ -325,28 +295,4 @@ internal sealed class MessageRepository : IMessageRepository
         return await connection.ExecuteAsync(command);
     }
 
-    public async Task RemoveAttachmentAsync(
-        MessageId messageId,
-        UploadedFileId attachmentFileId,
-        CancellationToken cancellationToken = default)
-    {
-        const string sql = """
-                           DELETE FROM message_attachments
-                           WHERE message_id = @MessageId
-                             AND uploaded_file_id = @UploadedFileId
-                           """;
-
-        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
-        var command = new CommandDefinition(
-            sql,
-            new
-            {
-                MessageId = messageId.Value,
-                UploadedFileId = attachmentFileId.Value
-            },
-            transaction: _dbSession.Transaction,
-            cancellationToken: cancellationToken);
-
-        await connection.ExecuteAsync(command);
-    }
 }

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepositoryHelpers.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepositoryHelpers.cs
@@ -1,80 +1,16 @@
-using Dapper;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
-using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
-using Harmonie.Infrastructure.Persistence.Common;
 using Harmonie.Infrastructure.Rows.Messages;
 
 namespace Harmonie.Infrastructure.Persistence.Messages;
 
 internal static class MessageRepositoryHelpers
 {
-    internal static async Task<IReadOnlyDictionary<Guid, IReadOnlyList<MessageAttachment>>> GetAttachmentsByMessageIdsAsync(
-        DbSession dbSession,
-        IReadOnlyCollection<Guid> messageIds,
-        CancellationToken cancellationToken)
-    {
-        if (messageIds.Count == 0)
-            return new Dictionary<Guid, IReadOnlyList<MessageAttachment>>();
-
-        const string sql = """
-                           SELECT ma.message_id AS "MessageId",
-                                  ma.position AS "Position",
-                                  uf.id AS "UploadedFileId",
-                                  uf.filename AS "FileName",
-                                  uf.content_type AS "ContentType",
-                                  uf.size_bytes AS "SizeBytes"
-                           FROM message_attachments ma
-                           INNER JOIN uploaded_files uf ON uf.id = ma.uploaded_file_id
-                           WHERE ma.message_id = ANY(@MessageIds)
-                           ORDER BY ma.message_id, ma.position
-                           """;
-
-        var connection = await dbSession.GetOpenConnectionAsync(cancellationToken);
-        var command = new CommandDefinition(
-            sql,
-            new { MessageIds = messageIds.ToArray() },
-            transaction: dbSession.Transaction,
-            cancellationToken: cancellationToken);
-
-        var rows = await connection.QueryAsync<MessageAttachmentRow>(command);
-
-        return rows
-            .GroupBy(row => row.MessageId)
-            .ToDictionary(
-                group => group.Key,
-                group => (IReadOnlyList<MessageAttachment>)group
-                    .OrderBy(row => row.Position)
-                    .Select(row => new MessageAttachment(
-                        UploadedFileId.From(row.UploadedFileId),
-                        row.FileName,
-                        row.ContentType,
-                        row.SizeBytes))
-                    .ToArray());
-    }
-
-    internal static IReadOnlyDictionary<Guid, IReadOnlyList<MessageAttachment>> BuildAttachmentsDictionary(
-        IEnumerable<MessageAttachmentRow> rows)
-    {
-        return rows
-            .GroupBy(row => row.MessageId)
-            .ToDictionary(
-                group => group.Key,
-                group => (IReadOnlyList<MessageAttachment>)group
-                    .OrderBy(row => row.Position)
-                    .Select(row => new MessageAttachment(
-                        UploadedFileId.From(row.UploadedFileId),
-                        row.FileName,
-                        row.ContentType,
-                        row.SizeBytes))
-                    .ToArray());
-    }
-
     internal static IReadOnlyDictionary<Guid, IReadOnlyList<MessageReactionSummary>> BuildReactionsDictionary(
         IEnumerable<ReactionSummaryRow> summaryRows,
         IEnumerable<ReactionUserRow> userRows)
@@ -107,9 +43,7 @@ internal static class MessageRepositoryHelpers
                     .ToArray());
     }
 
-    internal static Message MapToMessage(
-        MessageRow row,
-        IReadOnlyDictionary<Guid, IReadOnlyList<MessageAttachment>> attachmentsByMessageId)
+    internal static Message MapToMessage(MessageRow row)
     {
         MessageContent? messageContent = null;
         if (row.Content is not null)
@@ -129,7 +63,6 @@ internal static class MessageRepositoryHelpers
         MessageId? replyToMessageId = row.ReplyToMessageId.HasValue
             ? MessageId.From(row.ReplyToMessageId.Value)
             : null;
-        attachmentsByMessageId.TryGetValue(row.Id, out var attachments);
 
         return Message.Rehydrate(
             MessageId.From(row.Id),
@@ -140,8 +73,7 @@ internal static class MessageRepositoryHelpers
             messageContent,
             row.CreatedAtUtc,
             row.UpdatedAtUtc,
-            row.DeletedAtUtc,
-            attachments);
+            row.DeletedAtUtc);
     }
 
     internal static IReadOnlyDictionary<Guid, IReadOnlyList<LinkPreviewDto>> BuildLinkPreviewsDictionary(

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessageSearchRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessageSearchRepository.cs
@@ -41,69 +41,94 @@ internal sealed class MessageSearchRepository : IMessageSearchRepository
         parameters.Add("SearchText", query.SearchText);
         parameters.Add("Take", take);
 
-        var sqlBuilder = new StringBuilder(
+        var predicateBuilder = new StringBuilder(
             """
-            WITH search_query AS (
-                SELECT websearch_to_tsquery('simple', @SearchText) AS ts_query
-            )
-            SELECT m.id AS "MessageId",
-                   m.channel_id AS "ChannelId",
-                   gc.name AS "ChannelName",
-                   m.author_user_id AS "AuthorUserId",
-                   u.username AS "AuthorUsername",
-                   u.display_name AS "AuthorDisplayName",
-                   u.avatar_file_id AS "AuthorAvatarFileId",
-                   u.avatar_color AS "AuthorAvatarColor",
-                   u.avatar_icon AS "AuthorAvatarIcon",
-                   u.avatar_bg AS "AuthorAvatarBg",
-                   m.content AS "Content",
-                   m.created_at_utc AS "CreatedAtUtc",
-                   m.updated_at_utc AS "UpdatedAtUtc"
-            FROM messages m
-            INNER JOIN guild_channels gc ON gc.id = m.channel_id
-            INNER JOIN users u ON u.id = m.author_user_id
-            CROSS JOIN search_query sq
             WHERE gc.guild_id = @GuildId
               AND m.deleted_at_utc IS NULL
               AND u.deleted_at IS NULL
               AND m.search_vector @@ sq.ts_query
             """);
-        sqlBuilder.AppendLine();
+        predicateBuilder.AppendLine();
 
         if (query.ChannelId is not null)
         {
-            sqlBuilder.AppendLine("  AND m.channel_id = @ChannelId");
+            predicateBuilder.AppendLine("  AND m.channel_id = @ChannelId");
             parameters.Add("ChannelId", query.ChannelId.Value);
         }
 
         if (query.AuthorId is not null)
         {
-            sqlBuilder.AppendLine("  AND m.author_user_id = @AuthorId");
+            predicateBuilder.AppendLine("  AND m.author_user_id = @AuthorId");
             parameters.Add("AuthorId", query.AuthorId.Value);
         }
 
         if (query.BeforeCreatedAtUtc.HasValue)
         {
-            sqlBuilder.AppendLine("  AND m.created_at_utc <= @BeforeCreatedAtUtc");
+            predicateBuilder.AppendLine("  AND m.created_at_utc <= @BeforeCreatedAtUtc");
             parameters.Add("BeforeCreatedAtUtc", query.BeforeCreatedAtUtc.Value);
         }
 
         if (query.AfterCreatedAtUtc.HasValue)
         {
-            sqlBuilder.AppendLine("  AND m.created_at_utc >= @AfterCreatedAtUtc");
+            predicateBuilder.AppendLine("  AND m.created_at_utc >= @AfterCreatedAtUtc");
             parameters.Add("AfterCreatedAtUtc", query.AfterCreatedAtUtc.Value);
         }
 
         if (query.Cursor is not null)
         {
-            sqlBuilder.AppendLine("  AND (m.created_at_utc, m.id) < (@CursorCreatedAtUtc, @CursorMessageId)");
+            predicateBuilder.AppendLine("  AND (m.created_at_utc, m.id) < (@CursorCreatedAtUtc, @CursorMessageId)");
             parameters.Add("CursorCreatedAtUtc", query.Cursor.CreatedAtUtc);
             parameters.Add("CursorMessageId", query.Cursor.MessageId.Value);
         }
 
-        sqlBuilder.AppendLine("ORDER BY m.created_at_utc DESC, m.id DESC");
-        sqlBuilder.AppendLine("LIMIT @Take");
-        var sql = sqlBuilder.ToString();
+        var predicate = predicateBuilder.ToString();
+        const string orderLimit = "ORDER BY m.created_at_utc DESC, m.id DESC\nLIMIT @Take";
+
+        var sql = $"""
+                   WITH search_query AS (
+                       SELECT websearch_to_tsquery('simple', @SearchText) AS ts_query
+                   )
+                   SELECT m.id AS "MessageId",
+                          m.channel_id AS "ChannelId",
+                          gc.name AS "ChannelName",
+                          m.author_user_id AS "AuthorUserId",
+                          u.username AS "AuthorUsername",
+                          u.display_name AS "AuthorDisplayName",
+                          u.avatar_file_id AS "AuthorAvatarFileId",
+                          u.avatar_color AS "AuthorAvatarColor",
+                          u.avatar_icon AS "AuthorAvatarIcon",
+                          u.avatar_bg AS "AuthorAvatarBg",
+                          m.content AS "Content",
+                          m.created_at_utc AS "CreatedAtUtc",
+                          m.updated_at_utc AS "UpdatedAtUtc"
+                   FROM messages m
+                   INNER JOIN guild_channels gc ON gc.id = m.channel_id
+                   INNER JOIN users u ON u.id = m.author_user_id
+                   CROSS JOIN search_query sq
+                   {predicate}
+                   {orderLimit};
+
+                   WITH search_query AS (
+                       SELECT websearch_to_tsquery('simple', @SearchText) AS ts_query
+                   )
+                   SELECT ma.message_id AS "MessageId",
+                          ma.position AS "Position",
+                          uf.id AS "UploadedFileId",
+                          uf.filename AS "FileName",
+                          uf.content_type AS "ContentType",
+                          uf.size_bytes AS "SizeBytes"
+                   FROM message_attachments ma
+                   INNER JOIN uploaded_files uf ON uf.id = ma.uploaded_file_id
+                   WHERE ma.message_id IN (
+                       SELECT m.id
+                       FROM messages m
+                       INNER JOIN guild_channels gc ON gc.id = m.channel_id
+                       INNER JOIN users u ON u.id = m.author_user_id
+                       CROSS JOIN search_query sq
+                       {predicate}
+                       {orderLimit})
+                   ORDER BY ma.message_id, ma.position;
+                   """;
 
         var command = new CommandDefinition(
             sql,
@@ -111,12 +136,15 @@ internal sealed class MessageSearchRepository : IMessageSearchRepository
             transaction: _dbSession.Transaction,
             cancellationToken: cancellationToken);
 
-        var rows = (await connection.QueryAsync<ChannelMessageSearchRow>(command)).ToArray();
+        using var multi = await connection.QueryMultipleAsync(command);
+        var rows = (await multi.ReadAsync<ChannelMessageSearchRow>()).ToArray();
+        var attachmentRows = (await multi.ReadAsync<Harmonie.Infrastructure.Rows.Messages.MessageAttachmentRow>()).ToArray();
+
         var hasMore = rows.Length > limit;
         var pageRows = hasMore ? rows.Take(limit).ToArray() : rows;
-        var attachmentsByMessageId = await FetchAttachmentsAsync(
-            pageRows.Select(row => row.MessageId).ToArray(),
-            cancellationToken);
+        var pageMessageIds = new HashSet<Guid>(pageRows.Select(r => r.MessageId));
+        var attachmentsByMessageId = MessageAttachmentRepository.BuildByMessageIdDictionary(
+            attachmentRows.Where(r => pageMessageIds.Contains(r.MessageId)));
 
         var items = pageRows
             .Select(row => MapToSearchGuildMessagesItem(row, attachmentsByMessageId))
@@ -150,53 +178,77 @@ internal sealed class MessageSearchRepository : IMessageSearchRepository
         parameters.Add("SearchText", query.SearchText);
         parameters.Add("Take", take);
 
-        var sqlBuilder = new StringBuilder(
+        var predicateBuilder = new StringBuilder(
             """
-            WITH search_query AS (
-                SELECT websearch_to_tsquery('simple', @SearchText) AS ts_query
-            )
-            SELECT m.id AS "MessageId",
-                   m.author_user_id AS "AuthorUserId",
-                   u.username AS "AuthorUsername",
-                   u.display_name AS "AuthorDisplayName",
-                   u.avatar_file_id AS "AuthorAvatarFileId",
-                   u.avatar_color AS "AuthorAvatarColor",
-                   u.avatar_icon AS "AuthorAvatarIcon",
-                   u.avatar_bg AS "AuthorAvatarBg",
-                   m.content AS "Content",
-                   m.created_at_utc AS "CreatedAtUtc",
-                   m.updated_at_utc AS "UpdatedAtUtc"
-            FROM messages m
-            INNER JOIN users u ON u.id = m.author_user_id
-            CROSS JOIN search_query sq
             WHERE m.conversation_id = @ConversationId
               AND m.deleted_at_utc IS NULL
               AND m.search_vector @@ sq.ts_query
             """);
-        sqlBuilder.AppendLine();
+        predicateBuilder.AppendLine();
 
         if (query.BeforeCreatedAtUtc.HasValue)
         {
-            sqlBuilder.AppendLine("  AND m.created_at_utc <= @BeforeCreatedAtUtc");
+            predicateBuilder.AppendLine("  AND m.created_at_utc <= @BeforeCreatedAtUtc");
             parameters.Add("BeforeCreatedAtUtc", query.BeforeCreatedAtUtc.Value);
         }
 
         if (query.AfterCreatedAtUtc.HasValue)
         {
-            sqlBuilder.AppendLine("  AND m.created_at_utc >= @AfterCreatedAtUtc");
+            predicateBuilder.AppendLine("  AND m.created_at_utc >= @AfterCreatedAtUtc");
             parameters.Add("AfterCreatedAtUtc", query.AfterCreatedAtUtc.Value);
         }
 
         if (query.Cursor is not null)
         {
-            sqlBuilder.AppendLine("  AND (m.created_at_utc, m.id) < (@CursorCreatedAtUtc, @CursorMessageId)");
+            predicateBuilder.AppendLine("  AND (m.created_at_utc, m.id) < (@CursorCreatedAtUtc, @CursorMessageId)");
             parameters.Add("CursorCreatedAtUtc", query.Cursor.CreatedAtUtc);
             parameters.Add("CursorMessageId", query.Cursor.MessageId.Value);
         }
 
-        sqlBuilder.AppendLine("ORDER BY m.created_at_utc DESC, m.id DESC");
-        sqlBuilder.AppendLine("LIMIT @Take");
-        var sql = sqlBuilder.ToString();
+        var predicate = predicateBuilder.ToString();
+        const string orderLimit = "ORDER BY m.created_at_utc DESC, m.id DESC\nLIMIT @Take";
+
+        var sql = $"""
+                   WITH search_query AS (
+                       SELECT websearch_to_tsquery('simple', @SearchText) AS ts_query
+                   )
+                   SELECT m.id AS "MessageId",
+                          m.author_user_id AS "AuthorUserId",
+                          u.username AS "AuthorUsername",
+                          u.display_name AS "AuthorDisplayName",
+                          u.avatar_file_id AS "AuthorAvatarFileId",
+                          u.avatar_color AS "AuthorAvatarColor",
+                          u.avatar_icon AS "AuthorAvatarIcon",
+                          u.avatar_bg AS "AuthorAvatarBg",
+                          m.content AS "Content",
+                          m.created_at_utc AS "CreatedAtUtc",
+                          m.updated_at_utc AS "UpdatedAtUtc"
+                   FROM messages m
+                   INNER JOIN users u ON u.id = m.author_user_id
+                   CROSS JOIN search_query sq
+                   {predicate}
+                   {orderLimit};
+
+                   WITH search_query AS (
+                       SELECT websearch_to_tsquery('simple', @SearchText) AS ts_query
+                   )
+                   SELECT ma.message_id AS "MessageId",
+                          ma.position AS "Position",
+                          uf.id AS "UploadedFileId",
+                          uf.filename AS "FileName",
+                          uf.content_type AS "ContentType",
+                          uf.size_bytes AS "SizeBytes"
+                   FROM message_attachments ma
+                   INNER JOIN uploaded_files uf ON uf.id = ma.uploaded_file_id
+                   WHERE ma.message_id IN (
+                       SELECT m.id
+                       FROM messages m
+                       INNER JOIN users u ON u.id = m.author_user_id
+                       CROSS JOIN search_query sq
+                       {predicate}
+                       {orderLimit})
+                   ORDER BY ma.message_id, ma.position;
+                   """;
 
         var command = new CommandDefinition(
             sql,
@@ -204,12 +256,15 @@ internal sealed class MessageSearchRepository : IMessageSearchRepository
             transaction: _dbSession.Transaction,
             cancellationToken: cancellationToken);
 
-        var rows = (await connection.QueryAsync<ConversationMessageSearchRow>(command)).ToArray();
+        using var multi = await connection.QueryMultipleAsync(command);
+        var rows = (await multi.ReadAsync<ConversationMessageSearchRow>()).ToArray();
+        var attachmentRows = (await multi.ReadAsync<Harmonie.Infrastructure.Rows.Messages.MessageAttachmentRow>()).ToArray();
+
         var hasMore = rows.Length > limit;
         var pageRows = hasMore ? rows.Take(limit).ToArray() : rows;
-        var attachmentsByMessageId = await FetchAttachmentsAsync(
-            pageRows.Select(row => row.MessageId).ToArray(),
-            cancellationToken);
+        var pageMessageIds = new HashSet<Guid>(pageRows.Select(r => r.MessageId));
+        var attachmentsByMessageId = MessageAttachmentRepository.BuildByMessageIdDictionary(
+            attachmentRows.Where(r => pageMessageIds.Contains(r.MessageId)));
 
         var items = pageRows
             .Select(row => MapToSearchConversationMessagesItem(row, attachmentsByMessageId))
@@ -223,37 +278,6 @@ internal sealed class MessageSearchRepository : IMessageSearchRepository
         }
 
         return new SearchConversationMessagesPage(items, nextCursor);
-    }
-
-    private async Task<IReadOnlyDictionary<Guid, IReadOnlyList<MessageAttachment>>> FetchAttachmentsAsync(
-        IReadOnlyCollection<Guid> messageIds,
-        CancellationToken cancellationToken)
-    {
-        if (messageIds.Count == 0)
-            return new Dictionary<Guid, IReadOnlyList<MessageAttachment>>();
-
-        const string sql = """
-                           SELECT ma.message_id AS "MessageId",
-                                  ma.position AS "Position",
-                                  uf.id AS "UploadedFileId",
-                                  uf.filename AS "FileName",
-                                  uf.content_type AS "ContentType",
-                                  uf.size_bytes AS "SizeBytes"
-                           FROM message_attachments ma
-                           INNER JOIN uploaded_files uf ON uf.id = ma.uploaded_file_id
-                           WHERE ma.message_id = ANY(@MessageIds)
-                           ORDER BY ma.message_id, ma.position
-                           """;
-
-        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
-        var command = new CommandDefinition(
-            sql,
-            new { MessageIds = messageIds.ToArray() },
-            transaction: _dbSession.Transaction,
-            cancellationToken: cancellationToken);
-
-        var rows = await connection.QueryAsync<Harmonie.Infrastructure.Rows.Messages.MessageAttachmentRow>(command);
-        return MessageAttachmentRepository.BuildByMessageIdDictionary(rows);
     }
 
     private static SearchGuildMessagesItem MapToSearchGuildMessagesItem(

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessageSearchRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessageSearchRepository.cs
@@ -114,8 +114,7 @@ internal sealed class MessageSearchRepository : IMessageSearchRepository
         var rows = (await connection.QueryAsync<ChannelMessageSearchRow>(command)).ToArray();
         var hasMore = rows.Length > limit;
         var pageRows = hasMore ? rows.Take(limit).ToArray() : rows;
-        var attachmentsByMessageId = await MessageRepositoryHelpers.GetAttachmentsByMessageIdsAsync(
-            _dbSession,
+        var attachmentsByMessageId = await FetchAttachmentsAsync(
             pageRows.Select(row => row.MessageId).ToArray(),
             cancellationToken);
 
@@ -208,8 +207,7 @@ internal sealed class MessageSearchRepository : IMessageSearchRepository
         var rows = (await connection.QueryAsync<ConversationMessageSearchRow>(command)).ToArray();
         var hasMore = rows.Length > limit;
         var pageRows = hasMore ? rows.Take(limit).ToArray() : rows;
-        var attachmentsByMessageId = await MessageRepositoryHelpers.GetAttachmentsByMessageIdsAsync(
-            _dbSession,
+        var attachmentsByMessageId = await FetchAttachmentsAsync(
             pageRows.Select(row => row.MessageId).ToArray(),
             cancellationToken);
 
@@ -225,6 +223,37 @@ internal sealed class MessageSearchRepository : IMessageSearchRepository
         }
 
         return new SearchConversationMessagesPage(items, nextCursor);
+    }
+
+    private async Task<IReadOnlyDictionary<Guid, IReadOnlyList<MessageAttachment>>> FetchAttachmentsAsync(
+        IReadOnlyCollection<Guid> messageIds,
+        CancellationToken cancellationToken)
+    {
+        if (messageIds.Count == 0)
+            return new Dictionary<Guid, IReadOnlyList<MessageAttachment>>();
+
+        const string sql = """
+                           SELECT ma.message_id AS "MessageId",
+                                  ma.position AS "Position",
+                                  uf.id AS "UploadedFileId",
+                                  uf.filename AS "FileName",
+                                  uf.content_type AS "ContentType",
+                                  uf.size_bytes AS "SizeBytes"
+                           FROM message_attachments ma
+                           INNER JOIN uploaded_files uf ON uf.id = ma.uploaded_file_id
+                           WHERE ma.message_id = ANY(@MessageIds)
+                           ORDER BY ma.message_id, ma.position
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new { MessageIds = messageIds.ToArray() },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        var rows = await connection.QueryAsync<Harmonie.Infrastructure.Rows.Messages.MessageAttachmentRow>(command);
+        return MessageAttachmentRepository.BuildByMessageIdDictionary(rows);
     }
 
     private static SearchGuildMessagesItem MapToSearchGuildMessagesItem(

--- a/src/Harmonie.Infrastructure/Persistence/Messages/PinnedMessageRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/PinnedMessageRepository.cs
@@ -1,5 +1,4 @@
 using Dapper;
-using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Channels;
@@ -137,6 +136,24 @@ public sealed class PinnedMessageRepository : IPinnedMessageRepository
                      AND {cursorCondition}
                    ORDER BY pm.pinned_at_utc DESC, pm.message_id DESC
                    LIMIT @Take;
+
+                   SELECT ma.message_id AS ""MessageId"",
+                          ma.position AS ""Position"",
+                          uf.id AS ""UploadedFileId"",
+                          uf.filename AS ""FileName"",
+                          uf.content_type AS ""ContentType"",
+                          uf.size_bytes AS ""SizeBytes""
+                   FROM message_attachments ma
+                   INNER JOIN uploaded_files uf ON uf.id = ma.uploaded_file_id
+                   WHERE ma.message_id IN (
+                       SELECT pm.message_id
+                       FROM pinned_messages pm
+                       INNER JOIN messages m ON m.id = pm.message_id
+                       WHERE m.{context.Filter}
+                         AND {cursorCondition}
+                       ORDER BY pm.pinned_at_utc DESC, pm.message_id DESC
+                       LIMIT @Take)
+                   ORDER BY ma.message_id, ma.position;
                    ";
 
         var command = new CommandDefinition(
@@ -145,13 +162,24 @@ public sealed class PinnedMessageRepository : IPinnedMessageRepository
             transaction: _dbSession.Transaction,
             cancellationToken: cancellationToken);
 
-        var rows = (await connection.QueryAsync<PinnedMessageWithContentRow>(command)).ToArray();
+        using var multi = await connection.QueryMultipleAsync(command);
+        var rows = (await multi.ReadAsync<PinnedMessageWithContentRow>()).ToArray();
+        var attachmentRows = (await multi.ReadAsync<MessageAttachmentRow>()).ToArray();
 
         if (rows.Length == 0)
-            return new PinnedMessagesPage(Array.Empty<PinnedMessageSummary>(), null);
+            return new PinnedMessagesPage(
+                Array.Empty<PinnedMessageSummary>(),
+                new Dictionary<MessageId, IReadOnlyList<MessageAttachment>>(),
+                null);
 
         var hasMore = rows.Length > limit;
         var pageRows = hasMore ? rows.Take(limit).ToArray() : rows;
+        var pageMessageIds = new HashSet<Guid>(pageRows.Select(r => r.Id));
+
+        var attachmentsByMessageIdGuid = MessageAttachmentRepository.BuildByMessageIdDictionary(
+            attachmentRows.Where(r => pageMessageIds.Contains(r.MessageId)));
+        var attachmentsByMessageId = attachmentsByMessageIdGuid
+            .ToDictionary(kvp => MessageId.From(kvp.Key), kvp => kvp.Value);
 
         var items = pageRows
             .Select(row => new PinnedMessageSummary(
@@ -173,7 +201,7 @@ public sealed class PinnedMessageRepository : IPinnedMessageRepository
             nextCursor = new PinnedMessagesCursor(lastRow.PinnedAtUtc, lastRow.Id);
         }
 
-        return new PinnedMessagesPage(items, nextCursor);
+        return new PinnedMessagesPage(items, attachmentsByMessageId, nextCursor);
     }
 
 }

--- a/src/Harmonie.Infrastructure/Persistence/Messages/PinnedMessageRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/PinnedMessageRepository.cs
@@ -153,28 +153,17 @@ public sealed class PinnedMessageRepository : IPinnedMessageRepository
         var hasMore = rows.Length > limit;
         var pageRows = hasMore ? rows.Take(limit).ToArray() : rows;
 
-        var messageIds = pageRows.Select(r => r.Id).ToArray();
-        var attachmentsByMessageId = await MessageRepositoryHelpers.GetAttachmentsByMessageIdsAsync(
-            _dbSession, messageIds, cancellationToken);
-
         var items = pageRows
-            .Select(row =>
-            {
-                attachmentsByMessageId.TryGetValue(row.Id, out var attachments);
-                return new PinnedMessageSummary(
-                    MessageId: row.Id,
-                    AuthorUserId: row.AuthorUserId,
-                    AuthorUsername: row.AuthorUsername ?? string.Empty,
-                    AuthorDisplayName: row.AuthorDisplayName,
-                    Content: row.DeletedAtUtc is null ? row.Content : null,
-                    Attachments: attachments?.Select(a => new MessageAttachmentDto(
-                        a.FileId.Value, a.FileName, a.ContentType, a.SizeBytes)).ToArray()
-                        ?? Array.Empty<MessageAttachmentDto>(),
-                    CreatedAtUtc: row.CreatedAtUtc,
-                    UpdatedAtUtc: row.UpdatedAtUtc,
-                    PinnedByUserId: row.PinnedByUserId,
-                    PinnedAtUtc: row.PinnedAtUtc);
-            })
+            .Select(row => new PinnedMessageSummary(
+                MessageId: row.Id,
+                AuthorUserId: row.AuthorUserId,
+                AuthorUsername: row.AuthorUsername ?? string.Empty,
+                AuthorDisplayName: row.AuthorDisplayName,
+                Content: row.DeletedAtUtc is null ? row.Content : null,
+                CreatedAtUtc: row.CreatedAtUtc,
+                UpdatedAtUtc: row.UpdatedAtUtc,
+                PinnedByUserId: row.PinnedByUserId,
+                PinnedAtUtc: row.PinnedAtUtc))
             .ToArray();
 
         PinnedMessagesCursor? nextCursor = null;

--- a/tests/Harmonie.Application.Tests/Common/ApplicationTestBuilders.cs
+++ b/tests/Harmonie.Application.Tests/Common/ApplicationTestBuilders.cs
@@ -109,8 +109,7 @@ internal static class ApplicationTestBuilders
             content: contentResult.Value,
             createdAtUtc: createdAtUtc ?? DateTime.UtcNow,
             updatedAtUtc: null,
-            deletedAtUtc: null,
-            attachments: attachments);
+            deletedAtUtc: null);
     }
 
     public static Message CreateConversationMessage(
@@ -134,8 +133,7 @@ internal static class ApplicationTestBuilders
             content: contentResult.Value,
             createdAtUtc: createdAtUtc ?? DateTime.UtcNow.AddMinutes(-1),
             updatedAtUtc: null,
-            deletedAtUtc: null,
-            attachments: attachments);
+            deletedAtUtc: null);
     }
 
     public static Conversation CreateConversation(UserId user1Id, UserId user2Id)

--- a/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageAttachmentHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageAttachmentHandlerTests.cs
@@ -7,8 +7,6 @@ using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Tests.Common;
-using Harmonie.Domain.Entities.Messages;
-using Harmonie.Domain.Entities.Uploads;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Uploads;
@@ -24,6 +22,7 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
 {
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IMessageRepository> _conversationMessageRepositoryMock;
+    private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
     private readonly Mock<IUploadedFileRepository> _uploadedFileRepositoryMock;
     private readonly Mock<IObjectStorageService> _objectStorageServiceMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
@@ -34,6 +33,7 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
     {
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _conversationMessageRepositoryMock = new Mock<IMessageRepository>();
+        _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
         _uploadedFileRepositoryMock = new Mock<IUploadedFileRepository>();
         _objectStorageServiceMock = new Mock<IObjectStorageService>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
@@ -44,6 +44,7 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
         _handler = new DeleteMessageAttachmentHandler(
             _conversationRepositoryMock.Object,
             _conversationMessageRepositoryMock.Object,
+            _messageAttachmentRepositoryMock.Object,
             new UploadedFileCleanupService(
                 _uploadedFileRepositoryMock.Object,
                 _objectStorageServiceMock.Object,
@@ -100,7 +101,7 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
         var participantTwo = UserId.New();
         var conversation = ApplicationTestBuilders.CreateConversation(participantOne, participantTwo);
         var attachmentId = UploadedFileId.New();
-        var message = ApplicationTestBuilders.CreateConversationMessage(conversation.Id, participantTwo, content: "hello", attachments: [new MessageAttachment(attachmentId, "notes.txt", "text/plain", 12)]);
+        var message = ApplicationTestBuilders.CreateConversationMessage(conversation.Id, participantTwo, content: "hello");
 
         _conversationRepositoryMock
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
@@ -123,8 +124,7 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
         var participantOne = UserId.New();
         var participantTwo = UserId.New();
         var conversation = ApplicationTestBuilders.CreateConversation(participantOne, participantTwo);
-        var otherAttachmentId = UploadedFileId.New();
-        var message = ApplicationTestBuilders.CreateConversationMessage(conversation.Id, participantOne, content: "hello", attachments: [new MessageAttachment(otherAttachmentId, "notes.txt", "text/plain", 12)]);
+        var message = ApplicationTestBuilders.CreateConversationMessage(conversation.Id, participantOne, content: "hello");
         var missingAttachmentId = UploadedFileId.New();
 
         _conversationRepositoryMock
@@ -134,6 +134,10 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
         _conversationMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
+
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.DeleteAsync(message.Id, missingAttachmentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
 
         var response = await _handler.HandleAsync(
             new DeleteConversationMessageAttachmentInput(conversation.Id, message.Id, missingAttachmentId),
@@ -152,67 +156,47 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
         var participantTwo = UserId.New();
         var conversation = ApplicationTestBuilders.CreateConversation(participantOne, participantTwo);
         var attachmentId = UploadedFileId.New();
-        var message = ApplicationTestBuilders.CreateConversationMessage(conversation.Id, participantOne, content: "hello", attachments: [new MessageAttachment(attachmentId, "notes.txt", "text/plain", 12)]);
+        var message = ApplicationTestBuilders.CreateConversationMessage(conversation.Id, participantOne, content: "hello");
         var uploadedFile = ApplicationTestBuilders.CreateUploadedFile(id: attachmentId, uploaderUserId: participantOne, fileName: "notes.txt", contentType: "text/plain", sizeBytes: 12, storageKey: "attachments/file.txt");
-        var sequence = new MockSequence();
 
         _conversationRepositoryMock
-            .InSequence(sequence)
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
 
         _conversationMessageRepositoryMock
-            .InSequence(sequence)
             .Setup(x => x.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
         _unitOfWorkMock
-            .InSequence(sequence)
             .Setup(x => x.BeginAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(_transactionMock.Object);
 
-        _conversationMessageRepositoryMock
-            .InSequence(sequence)
-            .Setup(x => x.UpdateAsync(
-                It.Is<Message>(updatedMessage =>
-                    updatedMessage.Id == message.Id
-                    && updatedMessage.Attachments.All(attachment => attachment.FileId != attachmentId)),
-                It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-
-        _conversationMessageRepositoryMock
-            .InSequence(sequence)
-            .Setup(x => x.RemoveAttachmentAsync(message.Id, attachmentId, It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.DeleteAsync(message.Id, attachmentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         _transactionMock
-            .InSequence(sequence)
             .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         _uploadedFileRepositoryMock
-            .InSequence(sequence)
             .Setup(x => x.GetByIdAsync(attachmentId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(uploadedFile);
 
         _objectStorageServiceMock
-            .InSequence(sequence)
             .Setup(x => x.DeleteIfExistsAsync(uploadedFile.StorageKey, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         _uploadedFileRepositoryMock
-            .InSequence(sequence)
             .Setup(x => x.DeleteAsync(attachmentId, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         var response = await _handler.HandleAsync(new DeleteConversationMessageAttachmentInput(conversation.Id, message.Id, attachmentId), participantOne, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
-        message.Attachments.Should().BeEmpty();
         _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
-        _conversationMessageRepositoryMock.Verify(
-            x => x.RemoveAttachmentAsync(message.Id, attachmentId, It.IsAny<CancellationToken>()),
+        _messageAttachmentRepositoryMock.Verify(
+            x => x.DeleteAsync(message.Id, attachmentId, It.IsAny<CancellationToken>()),
             Times.Once);
     }
-
 }

--- a/tests/Harmonie.Application.Tests/Messages/DeleteMessageAttachmentHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/DeleteMessageAttachmentHandlerTests.cs
@@ -8,11 +8,8 @@ using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Guilds;
-using Harmonie.Domain.Entities.Messages;
-using Harmonie.Domain.Entities.Uploads;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
-using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
@@ -27,6 +24,7 @@ public sealed class DeleteMessageAttachmentHandlerTests
 {
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IMessageRepository> _messageRepositoryMock;
+    private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
     private readonly Mock<IUploadedFileRepository> _uploadedFileRepositoryMock;
     private readonly Mock<IObjectStorageService> _objectStorageServiceMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
@@ -37,6 +35,7 @@ public sealed class DeleteMessageAttachmentHandlerTests
     {
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
         _messageRepositoryMock = new Mock<IMessageRepository>();
+        _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
         _uploadedFileRepositoryMock = new Mock<IUploadedFileRepository>();
         _objectStorageServiceMock = new Mock<IObjectStorageService>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
@@ -47,6 +46,7 @@ public sealed class DeleteMessageAttachmentHandlerTests
         _handler = new DeleteMessageAttachmentHandler(
             _guildChannelRepositoryMock.Object,
             _messageRepositoryMock.Object,
+            _messageAttachmentRepositoryMock.Object,
             new UploadedFileCleanupService(
                 _uploadedFileRepositoryMock.Object,
                 _objectStorageServiceMock.Object,
@@ -80,7 +80,7 @@ public sealed class DeleteMessageAttachmentHandlerTests
         var callerId = UserId.New();
         var authorId = UserId.New();
         var attachmentId = UploadedFileId.New();
-        var message = ApplicationTestBuilders.CreateChannelMessage(channel.Id, authorId, content: "hello", attachments: [new MessageAttachment(attachmentId, "notes.txt", "text/plain", 12)]);
+        var message = ApplicationTestBuilders.CreateChannelMessage(channel.Id, authorId, content: "hello");
 
         _guildChannelRepositoryMock
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
@@ -103,8 +103,7 @@ public sealed class DeleteMessageAttachmentHandlerTests
         var channel = ApplicationTestBuilders.CreateChannel();
         var authorId = UserId.New();
         var attachmentId = UploadedFileId.New();
-        var otherAttachmentId = UploadedFileId.New();
-        var message = ApplicationTestBuilders.CreateChannelMessage(channel.Id, authorId, content: "hello", attachments: [new MessageAttachment(otherAttachmentId, "notes.txt", "text/plain", 12)]);
+        var message = ApplicationTestBuilders.CreateChannelMessage(channel.Id, authorId, content: "hello");
 
         _guildChannelRepositoryMock
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, authorId, It.IsAny<CancellationToken>()))
@@ -113,6 +112,10 @@ public sealed class DeleteMessageAttachmentHandlerTests
         _messageRepositoryMock
             .Setup(x => x.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
+
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.DeleteAsync(message.Id, attachmentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
 
         var response = await _handler.HandleAsync(new DeleteChannelMessageAttachmentInput(channel.Id, message.Id, attachmentId), authorId, TestContext.Current.CancellationToken);
 
@@ -127,67 +130,47 @@ public sealed class DeleteMessageAttachmentHandlerTests
         var channel = ApplicationTestBuilders.CreateChannel();
         var authorId = UserId.New();
         var attachmentId = UploadedFileId.New();
-        var message = ApplicationTestBuilders.CreateChannelMessage(channel.Id, authorId, content: "hello", attachments: [new MessageAttachment(attachmentId, "notes.txt", "text/plain", 12)]);
+        var message = ApplicationTestBuilders.CreateChannelMessage(channel.Id, authorId, content: "hello");
         var uploadedFile = ApplicationTestBuilders.CreateUploadedFile(id: attachmentId, uploaderUserId: authorId, fileName: "notes.txt", contentType: "text/plain", sizeBytes: 12, storageKey: "attachments/file.txt");
-        var sequence = new MockSequence();
 
         _guildChannelRepositoryMock
-            .InSequence(sequence)
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, authorId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
 
         _messageRepositoryMock
-            .InSequence(sequence)
             .Setup(x => x.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
         _unitOfWorkMock
-            .InSequence(sequence)
             .Setup(x => x.BeginAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(_transactionMock.Object);
 
-        _messageRepositoryMock
-            .InSequence(sequence)
-            .Setup(x => x.UpdateAsync(
-                It.Is<Message>(updatedMessage =>
-                    updatedMessage.Id == message.Id
-                    && updatedMessage.Attachments.All(attachment => attachment.FileId != attachmentId)),
-                It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-
-        _messageRepositoryMock
-            .InSequence(sequence)
-            .Setup(x => x.RemoveAttachmentAsync(message.Id, attachmentId, It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.DeleteAsync(message.Id, attachmentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         _transactionMock
-            .InSequence(sequence)
             .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         _uploadedFileRepositoryMock
-            .InSequence(sequence)
             .Setup(x => x.GetByIdAsync(attachmentId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(uploadedFile);
 
         _objectStorageServiceMock
-            .InSequence(sequence)
             .Setup(x => x.DeleteIfExistsAsync(uploadedFile.StorageKey, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         _uploadedFileRepositoryMock
-            .InSequence(sequence)
             .Setup(x => x.DeleteAsync(attachmentId, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         var response = await _handler.HandleAsync(new DeleteChannelMessageAttachmentInput(channel.Id, message.Id, attachmentId), authorId, TestContext.Current.CancellationToken);
 
         response.Success.Should().BeTrue();
-        message.Attachments.Should().BeEmpty();
         _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
-        _messageRepositoryMock.Verify(
-            x => x.RemoveAttachmentAsync(message.Id, attachmentId, It.IsAny<CancellationToken>()),
+        _messageAttachmentRepositoryMock.Verify(
+            x => x.DeleteAsync(message.Id, attachmentId, It.IsAny<CancellationToken>()),
             Times.Once);
     }
-
 }

--- a/tests/Harmonie.Application.Tests/Messages/EditConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/EditConversationMessageHandlerTests.cs
@@ -20,6 +20,7 @@ public sealed class EditConversationMessageHandlerTests
 {
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IMessageRepository> _directMessageRepositoryMock;
+    private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IConversationMessageNotifier> _directMessageNotifierMock;
@@ -29,6 +30,7 @@ public sealed class EditConversationMessageHandlerTests
     {
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _directMessageRepositoryMock = new Mock<IMessageRepository>();
+        _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
         _directMessageNotifierMock = new Mock<IConversationMessageNotifier>();
@@ -39,9 +41,14 @@ public sealed class EditConversationMessageHandlerTests
             .Setup(x => x.NotifyMessageUpdatedAsync(It.IsAny<ConversationMessageUpdatedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.GetByMessageIdAsync(It.IsAny<MessageId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<MessageAttachment>());
+
         _handler = new EditMessageHandler(
             _conversationRepositoryMock.Object,
             _directMessageRepositoryMock.Object,
+            _messageAttachmentRepositoryMock.Object,
             _unitOfWorkMock.Object,
             _directMessageNotifierMock.Object,
             NullLogger<EditMessageHandler>.Instance);

--- a/tests/Harmonie.Application.Tests/Messages/EditMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/EditMessageHandlerTests.cs
@@ -22,6 +22,7 @@ public sealed class EditMessageHandlerTests
 {
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IMessageRepository> _channelMessageRepositoryMock;
+    private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<ITextChannelNotifier> _textChannelNotifierMock;
@@ -41,9 +42,15 @@ public sealed class EditMessageHandlerTests
             .Setup(x => x.NotifyMessageUpdatedAsync(It.IsAny<TextChannelMessageUpdatedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
+        _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.GetByMessageIdAsync(It.IsAny<MessageId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<MessageAttachment>());
+
         _handler = new EditMessageHandler(
             _guildChannelRepositoryMock.Object,
             _channelMessageRepositoryMock.Object,
+            _messageAttachmentRepositoryMock.Object,
             _unitOfWorkMock.Object,
             _textChannelNotifierMock.Object,
             NullLogger<EditMessageHandler>.Instance);

--- a/tests/Harmonie.Application.Tests/Messages/GetChannelPinnedMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetChannelPinnedMessagesHandlerTests.cs
@@ -19,22 +19,16 @@ public sealed class GetChannelPinnedMessagesHandlerTests
 {
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IPinnedMessageRepository> _pinnedMessageRepositoryMock;
-    private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
     private readonly GetPinnedMessagesHandler _handler;
 
     public GetChannelPinnedMessagesHandlerTests()
     {
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
         _pinnedMessageRepositoryMock = new Mock<IPinnedMessageRepository>();
-        _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
-        _messageAttachmentRepositoryMock
-            .Setup(x => x.GetByMessageIdsAsync(It.IsAny<IReadOnlyCollection<MessageId>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<MessageId, IReadOnlyList<MessageAttachment>>());
 
         _handler = new GetPinnedMessagesHandler(
             _guildChannelRepositoryMock.Object,
-            _pinnedMessageRepositoryMock.Object,
-            _messageAttachmentRepositoryMock.Object);
+            _pinnedMessageRepositoryMock.Object);
     }
 
     [Fact]
@@ -95,7 +89,10 @@ public sealed class GetChannelPinnedMessagesHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
 
-        var emptyPage = new PinnedMessagesPage(Array.Empty<PinnedMessageSummary>(), null);
+        var emptyPage = new PinnedMessagesPage(
+            Array.Empty<PinnedMessageSummary>(),
+            new Dictionary<MessageId, IReadOnlyList<MessageAttachment>>(),
+            null);
         _pinnedMessageRepositoryMock
             .Setup(x => x.GetPinnedMessagesAsync(channel.Id, callerId, null, It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(emptyPage);
@@ -134,7 +131,10 @@ public sealed class GetChannelPinnedMessagesHandlerTests
             .Setup(x => x.GetWithCallerRoleAsync(channel.Id, callerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChannelAccessContext(channel, GuildRole.Member));
 
-        var page = new PinnedMessagesPage(summaries, null);
+        var page = new PinnedMessagesPage(
+            summaries,
+            new Dictionary<MessageId, IReadOnlyList<MessageAttachment>>(),
+            null);
         _pinnedMessageRepositoryMock
             .Setup(x => x.GetPinnedMessagesAsync(channel.Id, callerId, null, It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(page);

--- a/tests/Harmonie.Application.Tests/Messages/GetChannelPinnedMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetChannelPinnedMessagesHandlerTests.cs
@@ -1,13 +1,14 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
-using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Channels.GetPinnedMessages;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Guilds;
+using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
 using Moq;
 using Xunit;
@@ -18,16 +19,22 @@ public sealed class GetChannelPinnedMessagesHandlerTests
 {
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IPinnedMessageRepository> _pinnedMessageRepositoryMock;
+    private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
     private readonly GetPinnedMessagesHandler _handler;
 
     public GetChannelPinnedMessagesHandlerTests()
     {
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
         _pinnedMessageRepositoryMock = new Mock<IPinnedMessageRepository>();
+        _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.GetByMessageIdsAsync(It.IsAny<IReadOnlyCollection<MessageId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<MessageId, IReadOnlyList<MessageAttachment>>());
 
         _handler = new GetPinnedMessagesHandler(
             _guildChannelRepositoryMock.Object,
-            _pinnedMessageRepositoryMock.Object);
+            _pinnedMessageRepositoryMock.Object,
+            _messageAttachmentRepositoryMock.Object);
     }
 
     [Fact]
@@ -113,14 +120,12 @@ public sealed class GetChannelPinnedMessagesHandlerTests
                 MessageId: Guid.NewGuid(), AuthorUserId: Guid.NewGuid(),
                 AuthorUsername: "second_user", AuthorDisplayName: "Second",
                 Content: "second",
-                Attachments: Array.Empty<MessageAttachmentDto>(),
                 CreatedAtUtc: now.AddMinutes(-2), UpdatedAtUtc: null,
                 PinnedByUserId: Guid.NewGuid(), PinnedAtUtc: now.AddMinutes(-1)),
             new PinnedMessageSummary(
                 MessageId: Guid.NewGuid(), AuthorUserId: Guid.NewGuid(),
                 AuthorUsername: "first_user", AuthorDisplayName: "First",
                 Content: "first",
-                Attachments: Array.Empty<MessageAttachmentDto>(),
                 CreatedAtUtc: now.AddMinutes(-10), UpdatedAtUtc: null,
                 PinnedByUserId: Guid.NewGuid(), PinnedAtUtc: now)
         };

--- a/tests/Harmonie.Application.Tests/Messages/GetConversationMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetConversationMessagesHandlerTests.cs
@@ -110,7 +110,8 @@ public sealed class GetConversationMessagesHandlerTests
             .ReturnsAsync(new MessagePage(
                 [second, first],
                 nextCursor,
-                new Dictionary<Guid, IReadOnlyList<MessageReactionSummary>>()));
+                new Dictionary<Guid, IReadOnlyList<MessageReactionSummary>>(),
+                new Dictionary<Guid, IReadOnlyList<MessageAttachment>>()));
 
         var response = await _handler.HandleAsync(
             new GetConversationMessagesInput(conversation.Id, Limit: 50),
@@ -157,6 +158,7 @@ public sealed class GetConversationMessagesHandlerTests
                 [message],
                 null,
                 new Dictionary<Guid, IReadOnlyList<MessageReactionSummary>>(),
+                new Dictionary<Guid, IReadOnlyList<MessageAttachment>>(),
                 previews));
 
         var response = await _handler.HandleAsync(
@@ -197,7 +199,8 @@ public sealed class GetConversationMessagesHandlerTests
             .ReturnsAsync(new MessagePage(
                 [message],
                 null,
-                new Dictionary<Guid, IReadOnlyList<MessageReactionSummary>>()));
+                new Dictionary<Guid, IReadOnlyList<MessageReactionSummary>>(),
+                new Dictionary<Guid, IReadOnlyList<MessageAttachment>>()));
 
         var response = await _handler.HandleAsync(
             new GetConversationMessagesInput(conversation.Id, Limit: 50),
@@ -251,6 +254,7 @@ public sealed class GetConversationMessagesHandlerTests
                 [message],
                 null,
                 new Dictionary<Guid, IReadOnlyList<MessageReactionSummary>>(),
+                new Dictionary<Guid, IReadOnlyList<MessageAttachment>>(),
                 ReplyPreviewsByTargetMessageId: replyPreviews));
 
         var response = await _handler.HandleAsync(

--- a/tests/Harmonie.Application.Tests/Messages/GetConversationPinnedMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetConversationPinnedMessagesHandlerTests.cs
@@ -18,22 +18,16 @@ public sealed class GetConversationPinnedMessagesHandlerTests
 {
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IPinnedMessageRepository> _pinnedMessageRepositoryMock;
-    private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
     private readonly GetPinnedMessagesHandler _handler;
 
     public GetConversationPinnedMessagesHandlerTests()
     {
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _pinnedMessageRepositoryMock = new Mock<IPinnedMessageRepository>();
-        _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
-        _messageAttachmentRepositoryMock
-            .Setup(x => x.GetByMessageIdsAsync(It.IsAny<IReadOnlyCollection<MessageId>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<MessageId, IReadOnlyList<MessageAttachment>>());
 
         _handler = new GetPinnedMessagesHandler(
             _conversationRepositoryMock.Object,
-            _pinnedMessageRepositoryMock.Object,
-            _messageAttachmentRepositoryMock.Object);
+            _pinnedMessageRepositoryMock.Object);
     }
 
     [Fact]
@@ -79,7 +73,10 @@ public sealed class GetConversationPinnedMessagesHandlerTests
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participant, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(conversation, participantObj));
 
-        var emptyPage = new PinnedMessagesPage(Array.Empty<PinnedMessageSummary>(), null);
+        var emptyPage = new PinnedMessagesPage(
+            Array.Empty<PinnedMessageSummary>(),
+            new Dictionary<MessageId, IReadOnlyList<MessageAttachment>>(),
+            null);
         _pinnedMessageRepositoryMock
             .Setup(x => x.GetPinnedMessagesAsync(conversation.Id, participant, null, It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(emptyPage);
@@ -113,7 +110,10 @@ public sealed class GetConversationPinnedMessagesHandlerTests
             .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participant, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationAccess(conversation, participantObj));
 
-        var page = new PinnedMessagesPage(summaries, null);
+        var page = new PinnedMessagesPage(
+            summaries,
+            new Dictionary<MessageId, IReadOnlyList<MessageAttachment>>(),
+            null);
         _pinnedMessageRepositoryMock
             .Setup(x => x.GetPinnedMessagesAsync(conversation.Id, participant, null, It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(page);

--- a/tests/Harmonie.Application.Tests/Messages/GetConversationPinnedMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetConversationPinnedMessagesHandlerTests.cs
@@ -1,12 +1,13 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
-using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Conversations.GetPinnedMessages;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Conversations;
+using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
 using Moq;
 using Xunit;
@@ -17,16 +18,22 @@ public sealed class GetConversationPinnedMessagesHandlerTests
 {
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IPinnedMessageRepository> _pinnedMessageRepositoryMock;
+    private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
     private readonly GetPinnedMessagesHandler _handler;
 
     public GetConversationPinnedMessagesHandlerTests()
     {
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _pinnedMessageRepositoryMock = new Mock<IPinnedMessageRepository>();
+        _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.GetByMessageIdsAsync(It.IsAny<IReadOnlyCollection<MessageId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<MessageId, IReadOnlyList<MessageAttachment>>());
 
         _handler = new GetPinnedMessagesHandler(
             _conversationRepositoryMock.Object,
-            _pinnedMessageRepositoryMock.Object);
+            _pinnedMessageRepositoryMock.Object,
+            _messageAttachmentRepositoryMock.Object);
     }
 
     [Fact]
@@ -98,7 +105,6 @@ public sealed class GetConversationPinnedMessagesHandlerTests
                 MessageId: Guid.NewGuid(), AuthorUserId: participant.Value,
                 AuthorUsername: "dm_user", AuthorDisplayName: "DM User",
                 Content: "pinned dm",
-                Attachments: Array.Empty<MessageAttachmentDto>(),
                 CreatedAtUtc: now, UpdatedAtUtc: null,
                 PinnedByUserId: participant.Value, PinnedAtUtc: now)
         };

--- a/tests/Harmonie.Application.Tests/Messages/GetMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetMessagesHandlerTests.cs
@@ -110,7 +110,8 @@ public sealed class GetMessagesHandlerTests
             .ReturnsAsync(new MessagePage(
                 [second, first],
                 nextCursor,
-                new Dictionary<Guid, IReadOnlyList<MessageReactionSummary>>()));
+                new Dictionary<Guid, IReadOnlyList<MessageReactionSummary>>(),
+                new Dictionary<Guid, IReadOnlyList<MessageAttachment>>()));
 
         var response = await _handler.HandleAsync(
             new GetChannelMessagesInput(channel.Id, Limit: 50),
@@ -157,6 +158,7 @@ public sealed class GetMessagesHandlerTests
                 [message],
                 null,
                 new Dictionary<Guid, IReadOnlyList<MessageReactionSummary>>(),
+                new Dictionary<Guid, IReadOnlyList<MessageAttachment>>(),
                 previews));
 
         var response = await _handler.HandleAsync(
@@ -198,7 +200,8 @@ public sealed class GetMessagesHandlerTests
             .ReturnsAsync(new MessagePage(
                 [message],
                 null,
-                new Dictionary<Guid, IReadOnlyList<MessageReactionSummary>>()));
+                new Dictionary<Guid, IReadOnlyList<MessageReactionSummary>>(),
+                new Dictionary<Guid, IReadOnlyList<MessageAttachment>>()));
 
         var response = await _handler.HandleAsync(
             new GetChannelMessagesInput(channel.Id, Limit: 50),
@@ -251,6 +254,7 @@ public sealed class GetMessagesHandlerTests
                 [message],
                 null,
                 new Dictionary<Guid, IReadOnlyList<MessageReactionSummary>>(),
+                new Dictionary<Guid, IReadOnlyList<MessageAttachment>>(),
                 ReplyPreviewsByTargetMessageId: replyPreviews));
 
         var response = await _handler.HandleAsync(

--- a/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
@@ -27,6 +27,7 @@ public sealed class SendConversationMessageHandlerTests
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IConversationParticipantRepository> _participantRepositoryMock;
     private readonly Mock<IMessageRepository> _directMessageRepositoryMock;
+    private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
     private readonly Mock<IUploadedFileRepository> _uploadedFileRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
@@ -70,10 +71,13 @@ public sealed class SendConversationMessageHandlerTests
         _serviceScopeFactoryMock.Setup(f => f.CreateScope())
             .Returns(scopeMock.Object);
 
+        _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
+
         _handler = new SendMessageHandler(
             _conversationRepositoryMock.Object,
             _participantRepositoryMock.Object,
             _directMessageRepositoryMock.Object,
+            _messageAttachmentRepositoryMock.Object,
             new MessageAttachmentResolver(_uploadedFileRepositoryMock.Object),
             _unitOfWorkMock.Object,
             _directMessageNotifierMock.Object,
@@ -215,6 +219,12 @@ public sealed class SendConversationMessageHandlerTests
             .Callback<Message, CancellationToken>((message, _) => persistedMessage = message)
             .Returns(Task.CompletedTask);
 
+        IReadOnlyCollection<MessageAttachment>? persistedAttachments = null;
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.AddRangeAsync(It.IsAny<IEnumerable<MessageAttachment>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<MessageAttachment>, CancellationToken>((items, _) => persistedAttachments = items.ToArray())
+            .Returns(Task.CompletedTask);
+
         var response = await _handler.HandleAsync(
             new SendConversationMessageInput(conversation.Id, "hello dm", [attachment.Id]),
             currentUserId,
@@ -225,8 +235,9 @@ public sealed class SendConversationMessageHandlerTests
         response.Data!.Attachments.Should().ContainSingle();
         response.Data.Attachments[0].FileId.Should().Be(attachment.Id.Value);
         persistedMessage.Should().NotBeNull();
-        persistedMessage!.Attachments.Should().ContainSingle();
-        persistedMessage.Attachments[0].FileId.Should().Be(attachment.Id);
+        persistedAttachments.Should().NotBeNull();
+        persistedAttachments!.Should().ContainSingle();
+        persistedAttachments!.First().FileId.Should().Be(attachment.Id);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/SendMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SendMessageHandlerTests.cs
@@ -28,6 +28,7 @@ public sealed class SendMessageHandlerTests
 {
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IMessageRepository> _channelMessageRepositoryMock;
+    private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
     private readonly Mock<IUploadedFileRepository> _uploadedFileRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
@@ -70,9 +71,12 @@ public sealed class SendMessageHandlerTests
         _serviceScopeFactoryMock.Setup(f => f.CreateScope())
             .Returns(scopeMock.Object);
 
+        _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
+
         _handler = new SendMessageHandler(
             _guildChannelRepositoryMock.Object,
             _channelMessageRepositoryMock.Object,
+            _messageAttachmentRepositoryMock.Object,
             new MessageAttachmentResolver(_uploadedFileRepositoryMock.Object),
             _unitOfWorkMock.Object,
             _textChannelNotifierMock.Object,
@@ -184,6 +188,12 @@ public sealed class SendMessageHandlerTests
             .Callback<Message, CancellationToken>((message, _) => persistedMessage = message)
             .Returns(Task.CompletedTask);
 
+        IReadOnlyCollection<MessageAttachment>? persistedAttachments = null;
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.AddRangeAsync(It.IsAny<IEnumerable<MessageAttachment>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<MessageAttachment>, CancellationToken>((items, _) => persistedAttachments = items.ToArray())
+            .Returns(Task.CompletedTask);
+
         var response = await _handler.HandleAsync(
             new SendChannelMessageInput(channel.Id, null, [attachment.Id]),
             userId,
@@ -196,7 +206,8 @@ public sealed class SendMessageHandlerTests
         response.Data.Attachments.Should().ContainSingle();
         persistedMessage.Should().NotBeNull();
         persistedMessage!.Content.Should().BeNull();
-        persistedMessage.Attachments.Should().ContainSingle();
+        persistedAttachments.Should().NotBeNull();
+        persistedAttachments!.Should().ContainSingle();
         _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Once);
         _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -264,6 +275,12 @@ public sealed class SendMessageHandlerTests
             .Callback<Message, CancellationToken>((message, _) => persistedMessage = message)
             .Returns(Task.CompletedTask);
 
+        IReadOnlyCollection<MessageAttachment>? persistedAttachments = null;
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.AddRangeAsync(It.IsAny<IEnumerable<MessageAttachment>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<MessageAttachment>, CancellationToken>((items, _) => persistedAttachments = items.ToArray())
+            .Returns(Task.CompletedTask);
+
         var response = await _handler.HandleAsync(
             new SendChannelMessageInput(channel.Id, "message with file", [attachment.Id]),
             userId,
@@ -274,8 +291,9 @@ public sealed class SendMessageHandlerTests
         response.Data!.Attachments.Should().ContainSingle();
         response.Data.Attachments[0].FileId.Should().Be(attachment.Id.Value);
         persistedMessage.Should().NotBeNull();
-        persistedMessage!.Attachments.Should().ContainSingle();
-        persistedMessage.Attachments[0].FileId.Should().Be(attachment.Id);
+        persistedAttachments.Should().NotBeNull();
+        persistedAttachments!.Should().ContainSingle();
+        persistedAttachments!.First().FileId.Should().Be(attachment.Id);
     }
 
     [Fact]

--- a/tests/Harmonie.Domain.Tests/MessageTests.cs
+++ b/tests/Harmonie.Domain.Tests/MessageTests.cs
@@ -137,36 +137,16 @@ public sealed class MessageTests
     }
 
     [Fact]
-    public void CreateForChannel_WithNullContentAndOneAttachment_ShouldSucceedWithNullContent()
-    {
-        var attachment = new MessageAttachment(
-            UploadedFileId.New(),
-            "photo.png",
-            "image/png",
-            1024);
-
-        var result = Message.CreateForChannel(
-            GuildChannelId.New(),
-            UserId.New(),
-            content: null,
-            attachments: [attachment]);
-
-        result.IsSuccess.Should().BeTrue();
-        result.Value.Should().NotBeNull();
-        result.Value!.Content.Should().BeNull();
-        result.Value.Attachments.Should().ContainSingle();
-    }
-
-    [Fact]
-    public void CreateForChannel_WithNullContentAndNoAttachments_ShouldFail()
+    public void CreateForChannel_WithNullContent_ShouldSucceed()
     {
         var result = Message.CreateForChannel(
             GuildChannelId.New(),
             UserId.New(),
             content: null);
 
-        result.IsFailure.Should().BeTrue();
-        result.Error.Should().Contain("content or at least one attachment");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Content.Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
Closes #362.

## Summary

- Promote `MessageAttachment` to a `sealed class` with `Create`/`Rehydrate`, matching `MessageReaction`/`PinnedMessage`. Composite identity (`MessageId`, `UploadedFileId`), no surrogate ID.
- New `IMessageAttachmentRepository` (batched-only APIs) is the single source of truth for attachment persistence; bodies of the old helpers move into it.
- `Message` no longer carries attachments: `Attachments` property, `RemoveAttachment` method, and the "content OR attachment" check all removed. `Create`/`Rehydrate` no longer take an `attachments` parameter.
- The "content OR attachment" precondition moves to the `SendMessage` handlers (it was never a true invariant — `RemoveAttachment` already allowed empty messages).
- Read handlers (`GetMessages`, `GetPinnedMessages`) merge attachments at DTO mapping time, mirroring the existing reaction/link-preview pattern. `MessagePage` exposes `AttachmentsByMessageId` so the pagination multi-query keeps batching attachments in the same round-trip.
- 6 metadata-only handlers (`AddReaction`, `RemoveReaction`, `PinMessage`, `UnpinMessage`, `AcknowledgeRead`, `DeleteMessage`) no longer trigger an attachment load when fetching the message.
- `MessageAttachmentResolver` now returns a transport `ResolvedAttachment`; the handler builds `MessageAttachment.Create(message.Id, ...)` after the message is created.

## Test plan

- [x] `dotnet test tests/Harmonie.Domain.Tests/` (175 passed)
- [x] `dotnet test tests/Harmonie.Application.Tests/` (492 passed)
- [x] `dotnet test tests/Harmonie.API.IntegrationTests/` (474 passed)
- [ ] Manual smoke: send a message with attachments, edit it, delete one attachment, verify response payloads
- [ ] Manual smoke: list channel/conversation messages and pinned messages, verify attachments still render