### PR TITLE
refactor(domain): unify Message parent reference behind a MessageScope value object

### DIFF
--- a/src/Harmonie.Application/Features/Channels/AcknowledgeRead/AcknowledgeReadHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/AcknowledgeRead/AcknowledgeReadHandler.cs
@@ -63,7 +63,7 @@ public sealed class AcknowledgeReadHandler : IAuthenticatedHandler<AcknowledgeCh
         if (request.MessageId is not null)
         {
             var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-            if (message is null || message.ChannelId != request.ChannelId)
+            if (message is null || !message.Scope.Matches(request.ChannelId))
             {
                 return ApplicationResponse<bool>.Fail(
                     ApplicationErrorCodes.Message.NotFound,
@@ -83,7 +83,7 @@ public sealed class AcknowledgeReadHandler : IAuthenticatedHandler<AcknowledgeCh
             resolvedMessageId = latestMessageId;
         }
 
-        var state = MessageReadState.CreateForChannel(currentUserId, request.ChannelId, resolvedMessageId);
+        var state = MessageReadState.Create(currentUserId, new MessageScope.Channel(request.ChannelId), resolvedMessageId);
         if (state.IsFailure || state.Value is null)
         {
             return ApplicationResponse<bool>.Fail(

--- a/src/Harmonie.Application/Features/Channels/AddReaction/AddReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/AddReaction/AddReactionHandler.cs
@@ -68,8 +68,7 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ChannelAddReactio
         }
 
         var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        var messageChannelId = message?.ChannelId;
-        if (message is null || messageChannelId is null || messageChannelId != request.ChannelId)
+        if (message is null || !message.Scope.Matches(request.ChannelId))
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Reaction.MessageNotFound,

--- a/src/Harmonie.Application/Features/Channels/DeleteMessage/DeleteMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/DeleteMessage/DeleteMessageHandler.cs
@@ -63,8 +63,7 @@ public sealed class DeleteMessageHandler : IAuthenticatedHandler<DeleteChannelMe
         }
 
         var message = await _channelMessageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        var messageChannelId = message?.ChannelId;
-        if (message is null || messageChannelId is null || messageChannelId != request.ChannelId)
+        if (message is null || !message.Scope.Matches(request.ChannelId))
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Message.NotFound,

--- a/src/Harmonie.Application/Features/Channels/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
@@ -63,8 +63,7 @@ public sealed class DeleteMessageAttachmentHandler : IAuthenticatedHandler<Delet
         }
 
         var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        var messageChannelId = message?.ChannelId;
-        if (message is null || messageChannelId is null || messageChannelId != request.ChannelId)
+        if (message is null || !message.Scope.Matches(request.ChannelId))
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Message.NotFound,

--- a/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageHandler.cs
@@ -77,8 +77,7 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditChannelMessag
         }
 
         var message = await _channelMessageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        var messageChannelId = message?.ChannelId;
-        if (message is null || messageChannelId is null || messageChannelId != request.ChannelId)
+        if (message is null || !message.Scope.Matches(request.ChannelId))
         {
             return ApplicationResponse<EditMessageResponse>.Fail(
                 ApplicationErrorCodes.Message.NotFound,
@@ -91,6 +90,8 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditChannelMessag
                 ApplicationErrorCodes.Message.EditForbidden,
                 "You can only edit your own messages");
         }
+
+        var messageChannelId = ((MessageScope.Channel)message.Scope).ChannelId;
 
         var updateResult = message.UpdateContent(contentResult.Value);
         if (updateResult.IsFailure)

--- a/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageHandler.cs
@@ -91,7 +91,7 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditChannelMessag
                 "You can only edit your own messages");
         }
 
-        var messageChannelId = ((MessageScope.Channel)message.Scope).ChannelId;
+        var messageChannelId = request.ChannelId;
 
         var updateResult = message.UpdateContent(contentResult.Value);
         if (updateResult.IsFailure)

--- a/src/Harmonie.Application/Features/Channels/GetReactionUsers/GetReactionUsersHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/GetReactionUsers/GetReactionUsersHandler.cs
@@ -82,8 +82,7 @@ public sealed class GetReactionUsersHandler : IAuthenticatedHandler<GetChannelRe
         }
 
         var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        var messageChannelId = message?.ChannelId;
-        if (message is null || messageChannelId is null || messageChannelId != request.ChannelId)
+        if (message is null || !message.Scope.Matches(request.ChannelId))
         {
             return ApplicationResponse<GetReactionUsersResponse>.Fail(
                 ApplicationErrorCodes.Reaction.MessageNotFound,

--- a/src/Harmonie.Application/Features/Channels/PinMessage/PinMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/PinMessage/PinMessageHandler.cs
@@ -68,8 +68,7 @@ public sealed class PinMessageHandler : IAuthenticatedHandler<ChannelPinMessageI
         }
 
         var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        var messageChannelId = message?.ChannelId;
-        if (message is null || messageChannelId is null || messageChannelId != request.ChannelId)
+        if (message is null || !message.Scope.Matches(request.ChannelId))
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Pin.MessageNotFound,

--- a/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionHandler.cs
@@ -67,8 +67,7 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ChannelRemoveR
         }
 
         var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        var messageChannelId = message?.ChannelId;
-        if (message is null || messageChannelId is null || messageChannelId != request.ChannelId)
+        if (message is null || !message.Scope.Matches(request.ChannelId))
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Reaction.MessageNotFound,

--- a/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageHandler.cs
@@ -100,7 +100,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessag
         {
             var targetMessageId = MessageId.From(request.ReplyToMessageId.Value);
             replyTargetSummary = await _messageRepository.GetReplyTargetSummaryAsync(targetMessageId, cancellationToken);
-            if (replyTargetSummary is null || replyTargetSummary.ChannelId != request.ChannelId)
+            if (replyTargetSummary is null || !replyTargetSummary.Scope.Matches(request.ChannelId))
             {
                 return ApplicationResponse<SendMessageResponse>.Fail(
                     ApplicationErrorCodes.Message.NotFound,
@@ -131,8 +131,8 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessag
                 "Message must have content or at least one attachment");
         }
 
-        var messageResult = Message.CreateForChannel(
-            request.ChannelId,
+        var messageResult = Message.Create(
+            new MessageScope.Channel(request.ChannelId),
             currentUserId,
             content,
             replyToMessageId);
@@ -169,13 +169,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessag
             await _messageAttachmentRepository.AddRangeAsync(attachments, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
 
-        var messageChannelId = messageResult.Value.ChannelId;
-        if (messageChannelId is null)
-        {
-            return ApplicationResponse<SendMessageResponse>.Fail(
-                ApplicationErrorCodes.Common.InvalidState,
-                "Channel message creation succeeded but channel ID is missing");
-        }
+        var messageChannelId = request.ChannelId;
 
         ReplyPreviewDto? replyTo = null;
         if (replyTargetSummary is not null)

--- a/src/Harmonie.Application/Features/Channels/UnpinMessage/UnpinMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/UnpinMessage/UnpinMessageHandler.cs
@@ -67,8 +67,7 @@ public sealed class UnpinMessageHandler : IAuthenticatedHandler<ChannelUnpinMess
         }
 
         var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        var messageChannelId = message?.ChannelId;
-        if (message is null || messageChannelId is null || messageChannelId != request.ChannelId)
+        if (message is null || !message.Scope.Matches(request.ChannelId))
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Pin.MessageNotFound,

--- a/src/Harmonie.Application/Features/Conversations/AcknowledgeRead/AcknowledgeReadHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/AcknowledgeRead/AcknowledgeReadHandler.cs
@@ -54,7 +54,7 @@ public sealed class AcknowledgeReadHandler : IAuthenticatedHandler<AcknowledgeCo
         if (request.MessageId is not null)
         {
             var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-            if (message is null || message.ConversationId != request.ConversationId)
+            if (message is null || !message.Scope.Matches(request.ConversationId))
             {
                 return ApplicationResponse<bool>.Fail(
                     ApplicationErrorCodes.Message.NotFound,
@@ -74,7 +74,7 @@ public sealed class AcknowledgeReadHandler : IAuthenticatedHandler<AcknowledgeCo
             resolvedMessageId = latestMessageId;
         }
 
-        var state = MessageReadState.CreateForConversation(currentUserId, request.ConversationId, resolvedMessageId);
+        var state = MessageReadState.Create(currentUserId, new MessageScope.Conversation(request.ConversationId), resolvedMessageId);
         if (state.IsFailure || state.Value is null)
         {
             return ApplicationResponse<bool>.Fail(

--- a/src/Harmonie.Application/Features/Conversations/AddReaction/AddReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/AddReaction/AddReactionHandler.cs
@@ -59,8 +59,7 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ConversationAddRe
         }
 
         var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        var messageConversationId = message?.ConversationId;
-        if (message is null || messageConversationId is null || messageConversationId != request.ConversationId)
+        if (message is null || !message.Scope.Matches(request.ConversationId))
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Reaction.MessageNotFound,

--- a/src/Harmonie.Application/Features/Conversations/DeleteMessage/DeleteMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteMessage/DeleteMessageHandler.cs
@@ -55,8 +55,7 @@ public sealed class DeleteMessageHandler : IAuthenticatedHandler<DeleteConversat
         }
 
         var message = await _conversationMessageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        var messageConversationId = message?.ConversationId;
-        if (message is null || messageConversationId is null || messageConversationId != request.ConversationId)
+        if (message is null || !message.Scope.Matches(request.ConversationId))
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Message.NotFound,

--- a/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
@@ -58,8 +58,7 @@ public sealed class DeleteMessageAttachmentHandler : IAuthenticatedHandler<Delet
         }
 
         var message = await _conversationMessageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        var messageConversationId = message?.ConversationId;
-        if (message is null || messageConversationId is null || messageConversationId != request.ConversationId)
+        if (message is null || !message.Scope.Matches(request.ConversationId))
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Message.NotFound,

--- a/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageHandler.cs
@@ -68,8 +68,7 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditConversationM
         }
 
         var message = await _conversationMessageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        var messageConversationId = message?.ConversationId;
-        if (message is null || messageConversationId is null || messageConversationId != request.ConversationId)
+        if (message is null || !message.Scope.Matches(request.ConversationId))
         {
             return ApplicationResponse<EditMessageResponse>.Fail(
                 ApplicationErrorCodes.Message.NotFound,
@@ -82,6 +81,8 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditConversationM
                 ApplicationErrorCodes.Message.EditForbidden,
                 "You can only edit your own messages");
         }
+
+        var messageConversationId = ((MessageScope.Conversation)message.Scope).ConversationId;
 
         var updateResult = message.UpdateContent(contentResult.Value);
         if (updateResult.IsFailure)

--- a/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageHandler.cs
@@ -82,7 +82,7 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditConversationM
                 "You can only edit your own messages");
         }
 
-        var messageConversationId = ((MessageScope.Conversation)message.Scope).ConversationId;
+        var messageConversationId = request.ConversationId;
 
         var updateResult = message.UpdateContent(contentResult.Value);
         if (updateResult.IsFailure)

--- a/src/Harmonie.Application/Features/Conversations/GetReactionUsers/GetReactionUsersHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetReactionUsers/GetReactionUsersHandler.cs
@@ -73,8 +73,7 @@ public sealed class GetReactionUsersHandler : IAuthenticatedHandler<GetConversat
         }
 
         var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        var messageConversationId = message?.ConversationId;
-        if (message is null || messageConversationId is null || messageConversationId != request.ConversationId)
+        if (message is null || !message.Scope.Matches(request.ConversationId))
         {
             return ApplicationResponse<GetReactionUsersResponse>.Fail(
                 ApplicationErrorCodes.Reaction.MessageNotFound,

--- a/src/Harmonie.Application/Features/Conversations/PinMessage/PinMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/PinMessage/PinMessageHandler.cs
@@ -60,8 +60,7 @@ public sealed class PinMessageHandler : IAuthenticatedHandler<ConversationPinMes
         }
 
         var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        var messageConversationId = message?.ConversationId;
-        if (message is null || messageConversationId is null || messageConversationId != request.ConversationId)
+        if (message is null || !message.Scope.Matches(request.ConversationId))
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Pin.MessageNotFound,

--- a/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionHandler.cs
@@ -58,8 +58,7 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ConversationRe
         }
 
         var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        var messageConversationId = message?.ConversationId;
-        if (message is null || messageConversationId is null || messageConversationId != request.ConversationId)
+        if (message is null || !message.Scope.Matches(request.ConversationId))
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Reaction.MessageNotFound,

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageHandler.cs
@@ -94,7 +94,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
         {
             var targetMessageId = MessageId.From(request.ReplyToMessageId.Value);
             replyTargetSummary = await _messageRepository.GetReplyTargetSummaryAsync(targetMessageId, cancellationToken);
-            if (replyTargetSummary is null || replyTargetSummary.ConversationId != request.ConversationId)
+            if (replyTargetSummary is null || !replyTargetSummary.Scope.Matches(request.ConversationId))
             {
                 return ApplicationResponse<SendMessageResponse>.Fail(
                     ApplicationErrorCodes.Message.NotFound,
@@ -125,8 +125,8 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
                 "Message must have content or at least one attachment");
         }
 
-        var messageResult = Message.CreateForConversation(
-            request.ConversationId,
+        var messageResult = Message.Create(
+            new MessageScope.Conversation(request.ConversationId),
             currentUserId,
             content,
             replyToMessageId);
@@ -175,13 +175,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
             await _participantRepository.UpdateRangeAsync(hiddenParticipants, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
 
-        var messageConversationId = messageResult.Value.ConversationId;
-        if (messageConversationId is null)
-        {
-            return ApplicationResponse<SendMessageResponse>.Fail(
-                ApplicationErrorCodes.Common.InvalidState,
-                "Conversation message creation succeeded but conversation ID is missing");
-        }
+        var messageConversationId = request.ConversationId;
 
         ReplyPreviewDto? replyTo = null;
         if (replyTargetSummary is not null)

--- a/src/Harmonie.Application/Features/Conversations/UnpinMessage/UnpinMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/UnpinMessage/UnpinMessageHandler.cs
@@ -59,8 +59,7 @@ public sealed class UnpinMessageHandler : IAuthenticatedHandler<ConversationUnpi
         }
 
         var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        var messageConversationId = message?.ConversationId;
-        if (message is null || messageConversationId is null || messageConversationId != request.ConversationId)
+        if (message is null || !message.Scope.Matches(request.ConversationId))
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Pin.MessageNotFound,

--- a/src/Harmonie.Application/Interfaces/Messages/IMessageRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Messages/IMessageRepository.cs
@@ -12,8 +12,7 @@ namespace Harmonie.Application.Interfaces.Messages;
 
 public sealed record ReplyTargetSummary(
     MessageId MessageId,
-    GuildChannelId? ChannelId,
-    ConversationId? ConversationId,
+    MessageScope Scope,
     UserId AuthorUserId,
     string AuthorUsername,
     string? AuthorDisplayName,

--- a/src/Harmonie.Domain/Entities/Messages/Message.cs
+++ b/src/Harmonie.Domain/Entities/Messages/Message.cs
@@ -8,9 +8,7 @@ namespace Harmonie.Domain.Entities.Messages;
 
 public sealed class Message : Entity<MessageId>
 {
-    public GuildChannelId? ChannelId { get; private set; }
-
-    public ConversationId? ConversationId { get; private set; }
+    public MessageScope Scope { get; private set; }
 
     public UserId AuthorUserId { get; private set; }
 
@@ -22,8 +20,7 @@ public sealed class Message : Entity<MessageId>
 
     private Message(
         MessageId id,
-        GuildChannelId? channelId,
-        ConversationId? conversationId,
+        MessageScope scope,
         UserId authorUserId,
         MessageId? replyToMessageId,
         MessageContent? content,
@@ -32,8 +29,7 @@ public sealed class Message : Entity<MessageId>
         DateTime? deletedAtUtc)
     {
         Id = id;
-        ChannelId = channelId;
-        ConversationId = conversationId;
+        Scope = scope;
         AuthorUserId = authorUserId;
         ReplyToMessageId = replyToMessageId;
         Content = content;
@@ -42,44 +38,20 @@ public sealed class Message : Entity<MessageId>
         DeletedAtUtc = deletedAtUtc;
     }
 
-    public static Result<Message> CreateForChannel(
-        GuildChannelId channelId,
+    public static Result<Message> Create(
+        MessageScope scope,
         UserId authorUserId,
         MessageContent? content,
         MessageId? replyToMessageId = null)
     {
-        if (channelId is null)
-            return Result.Failure<Message>("Channel ID is required");
+        if (scope is null)
+            return Result.Failure<Message>("Message scope is required");
         if (authorUserId is null)
             return Result.Failure<Message>("Author user ID is required");
 
         return Result.Success(new Message(
             MessageId.New(),
-            channelId,
-            conversationId: null,
-            authorUserId,
-            replyToMessageId,
-            content,
-            DateTime.UtcNow,
-            updatedAtUtc: null,
-            deletedAtUtc: null));
-    }
-
-    public static Result<Message> CreateForConversation(
-        ConversationId conversationId,
-        UserId authorUserId,
-        MessageContent? content,
-        MessageId? replyToMessageId = null)
-    {
-        if (conversationId is null)
-            return Result.Failure<Message>("Conversation ID is required");
-        if (authorUserId is null)
-            return Result.Failure<Message>("Author user ID is required");
-
-        return Result.Success(new Message(
-            MessageId.New(),
-            channelId: null,
-            conversationId,
+            scope,
             authorUserId,
             replyToMessageId,
             content,
@@ -107,8 +79,7 @@ public sealed class Message : Entity<MessageId>
 
     public static Message Rehydrate(
         MessageId id,
-        GuildChannelId? channelId,
-        ConversationId? conversationId,
+        MessageScope scope,
         UserId authorUserId,
         MessageId? replyToMessageId,
         MessageContent? content,
@@ -117,15 +88,12 @@ public sealed class Message : Entity<MessageId>
         DateTime? deletedAtUtc)
     {
         ArgumentNullException.ThrowIfNull(id);
+        ArgumentNullException.ThrowIfNull(scope);
         ArgumentNullException.ThrowIfNull(authorUserId);
-
-        if ((channelId is null) == (conversationId is null))
-            throw new ArgumentException("Exactly one parent reference is required.", nameof(channelId));
 
         return new Message(
             id,
-            channelId,
-            conversationId,
+            scope,
             authorUserId,
             replyToMessageId,
             content,

--- a/src/Harmonie.Domain/Entities/Messages/MessageReadState.cs
+++ b/src/Harmonie.Domain/Entities/Messages/MessageReadState.cs
@@ -10,9 +10,7 @@ public sealed class MessageReadState
 {
     public UserId UserId { get; }
 
-    public GuildChannelId? ChannelId { get; }
-
-    public ConversationId? ConversationId { get; }
+    public MessageScope Scope { get; }
 
     public MessageId LastReadMessageId { get; private set; }
 
@@ -20,71 +18,45 @@ public sealed class MessageReadState
 
     private MessageReadState(
         UserId userId,
-        GuildChannelId? channelId,
-        ConversationId? conversationId,
+        MessageScope scope,
         MessageId lastReadMessageId,
         DateTime readAtUtc)
     {
         UserId = userId;
-        ChannelId = channelId;
-        ConversationId = conversationId;
+        Scope = scope;
         LastReadMessageId = lastReadMessageId;
         ReadAtUtc = readAtUtc;
     }
 
-    public static Result<MessageReadState> CreateForChannel(
+    public static Result<MessageReadState> Create(
         UserId userId,
-        GuildChannelId channelId,
-        MessageId lastReadMessageId)
-    {
-        if (channelId is null)
-            return Result.Failure<MessageReadState>("Channel ID is required");
-
-        return Create(userId, channelId, conversationId: null, lastReadMessageId);
-    }
-
-    public static Result<MessageReadState> CreateForConversation(
-        UserId userId,
-        ConversationId conversationId,
-        MessageId lastReadMessageId)
-    {
-        if (conversationId is null)
-            return Result.Failure<MessageReadState>("Conversation ID is required");
-
-        return Create(userId, channelId: null, conversationId, lastReadMessageId);
-    }
-
-    private static Result<MessageReadState> Create(
-        UserId userId,
-        GuildChannelId? channelId,
-        ConversationId? conversationId,
+        MessageScope scope,
         MessageId lastReadMessageId)
     {
         if (userId is null)
             return Result.Failure<MessageReadState>("User ID is required");
 
+        if (scope is null)
+            return Result.Failure<MessageReadState>("Message scope is required");
+
         if (lastReadMessageId is null)
             return Result.Failure<MessageReadState>("Last read message ID is required");
 
         return Result.Success(new MessageReadState(
-            userId, channelId, conversationId, lastReadMessageId, DateTime.UtcNow));
+            userId, scope, lastReadMessageId, DateTime.UtcNow));
     }
 
     public static MessageReadState Rehydrate(
         UserId userId,
-        GuildChannelId? channelId,
-        ConversationId? conversationId,
+        MessageScope scope,
         MessageId lastReadMessageId,
         DateTime readAtUtc)
     {
         ArgumentNullException.ThrowIfNull(userId);
-
-        if ((channelId is null) == (conversationId is null))
-            throw new ArgumentException("Exactly one of ChannelId or ConversationId must be set.");
-
+        ArgumentNullException.ThrowIfNull(scope);
         ArgumentNullException.ThrowIfNull(lastReadMessageId);
 
-        return new MessageReadState(userId, channelId, conversationId, lastReadMessageId, readAtUtc);
+        return new MessageReadState(userId, scope, lastReadMessageId, readAtUtc);
     }
 
     public void Acknowledge(MessageId messageId)

--- a/src/Harmonie.Domain/ValueObjects/Messages/MessageScope.cs
+++ b/src/Harmonie.Domain/ValueObjects/Messages/MessageScope.cs
@@ -1,0 +1,21 @@
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Conversations;
+
+namespace Harmonie.Domain.ValueObjects.Messages;
+
+/// <summary>
+/// Discriminated union for the parent of a message or read state.
+/// Guarantees at the type level that exactly one parent is set.
+/// </summary>
+public abstract record MessageScope
+{
+    private MessageScope() { }
+
+    public sealed record Channel(GuildChannelId ChannelId) : MessageScope;
+
+    public sealed record Conversation(ConversationId ConversationId) : MessageScope;
+
+    public bool Matches(GuildChannelId channelId) => this is Channel c && c.ChannelId == channelId;
+
+    public bool Matches(ConversationId conversationId) => this is Conversation c && c.ConversationId == conversationId;
+}

--- a/src/Harmonie.Infrastructure/Persistence/Channels/ChannelReadStateRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Channels/ChannelReadStateRepository.cs
@@ -36,7 +36,9 @@ public sealed class ChannelReadStateRepository : IChannelReadStateRepository
             new
             {
                 UserId = state.UserId.Value,
-                ChannelId = state.ChannelId!.Value,
+                ChannelId = state.Scope is MessageScope.Channel c
+                    ? c.ChannelId.Value
+                    : throw new InvalidOperationException($"Expected Channel scope but got {state.Scope.GetType().Name}."),
                 LastReadMessageId = state.LastReadMessageId.Value,
                 ReadAtUtc = state.ReadAtUtc
             },
@@ -71,8 +73,7 @@ public sealed class ChannelReadStateRepository : IChannelReadStateRepository
         var row = await connection.QueryFirstOrDefaultAsync<Row>(command);
         return row is null ? null : MessageReadState.Rehydrate(
             UserId.From(row.UserId),
-            GuildChannelId.From(row.ChannelId),
-            conversationId: null,
+            new MessageScope.Channel(GuildChannelId.From(row.ChannelId)),
             MessageId.From(row.LastReadMessageId),
             row.ReadAtUtc);
     }

--- a/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationReadStateRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationReadStateRepository.cs
@@ -36,7 +36,9 @@ public sealed class ConversationReadStateRepository : IConversationReadStateRepo
             new
             {
                 UserId = state.UserId.Value,
-                ConversationId = state.ConversationId!.Value,
+                ConversationId = state.Scope is MessageScope.Conversation c
+                    ? c.ConversationId.Value
+                    : throw new InvalidOperationException($"Expected Conversation scope but got {state.Scope.GetType().Name}."),
                 LastReadMessageId = state.LastReadMessageId.Value,
                 ReadAtUtc = state.ReadAtUtc
             },
@@ -71,8 +73,7 @@ public sealed class ConversationReadStateRepository : IConversationReadStateRepo
         var row = await connection.QueryFirstOrDefaultAsync<Row>(command);
         return row is null ? null : MessageReadState.Rehydrate(
             UserId.From(row.UserId),
-            channelId: null,
-            ConversationId.From(row.ConversationId),
+            new MessageScope.Conversation(ConversationId.From(row.ConversationId)),
             MessageId.From(row.LastReadMessageId),
             row.ReadAtUtc);
     }

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessagePaginationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessagePaginationRepository.cs
@@ -234,8 +234,7 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
         {
             lastReadState = MessageReadState.Rehydrate(
                 UserId.From(callerId.Value),
-                GuildChannelId.From(channelId.Value),
-                conversationId: null,
+                new MessageScope.Channel(GuildChannelId.From(channelId.Value)),
                 MessageId.From(readStateRow.LastReadMessageId),
                 readStateRow.ReadAtUtc);
         }
@@ -456,8 +455,7 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
         {
             lastReadState = MessageReadState.Rehydrate(
                 UserId.From(callerId.Value),
-                channelId: null,
-                ConversationId.From(conversationId.Value),
+                new MessageScope.Conversation(ConversationId.From(conversationId.Value)),
                 MessageId.From(readStateRow.LastReadMessageId),
                 readStateRow.ReadAtUtc);
         }

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepository.cs
@@ -38,11 +38,7 @@ internal sealed class MessageRepository : IMessageRepository
         Message message,
         CancellationToken cancellationToken = default)
     {
-        var channelId = message.ChannelId;
-        var conversationId = message.ConversationId;
-
-        if ((channelId is null) == (conversationId is null))
-            throw new InvalidOperationException("Message must have exactly one parent before persistence.");
+        var (channelId, conversationId) = MessageRepositoryHelpers.SplitScope(message.Scope);
 
         const string sql = """
                            INSERT INTO messages (
@@ -69,8 +65,8 @@ internal sealed class MessageRepository : IMessageRepository
             new
             {
                 Id = message.Id.Value,
-                ChannelId = channelId?.Value,
-                ConversationId = conversationId?.Value,
+                ChannelId = channelId,
+                ConversationId = conversationId,
                 AuthorUserId = message.AuthorUserId.Value,
                 ReplyToMessageId = message.ReplyToMessageId?.Value,
                 Content = message.Content?.Value,
@@ -248,8 +244,7 @@ internal sealed class MessageRepository : IMessageRepository
 
         return new ReplyTargetSummary(
             MessageId.From(row.MessageId),
-            row.ChannelId.HasValue ? GuildChannelId.From(row.ChannelId.Value) : null,
-            row.ConversationId.HasValue ? ConversationId.From(row.ConversationId.Value) : null,
+            MessageRepositoryHelpers.MapToScope(row.ChannelId, row.ConversationId),
             UserId.From(row.AuthorUserId),
             row.AuthorUsername,
             row.AuthorDisplayName,

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepositoryHelpers.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepositoryHelpers.cs
@@ -54,26 +54,41 @@ internal static class MessageRepositoryHelpers
             messageContent = contentResult.Value;
         }
 
-        GuildChannelId? channelId = row.ChannelId.HasValue
-            ? GuildChannelId.From(row.ChannelId.Value)
-            : null;
-        ConversationId? conversationId = row.ConversationId.HasValue
-            ? ConversationId.From(row.ConversationId.Value)
-            : null;
+        var scope = MapToScope(row.ChannelId, row.ConversationId);
+
         MessageId? replyToMessageId = row.ReplyToMessageId.HasValue
             ? MessageId.From(row.ReplyToMessageId.Value)
             : null;
 
         return Message.Rehydrate(
             MessageId.From(row.Id),
-            channelId,
-            conversationId,
+            scope,
             UserId.From(row.AuthorUserId),
             replyToMessageId,
             messageContent,
             row.CreatedAtUtc,
             row.UpdatedAtUtc,
             row.DeletedAtUtc);
+    }
+
+    internal static MessageScope MapToScope(Guid? channelId, Guid? conversationId)
+    {
+        if (channelId.HasValue && conversationId.HasValue)
+            throw new InvalidOperationException("Message row has both channel_id and conversation_id set.");
+        if (channelId.HasValue)
+            return new MessageScope.Channel(GuildChannelId.From(channelId.Value));
+        if (conversationId.HasValue)
+            return new MessageScope.Conversation(ConversationId.From(conversationId.Value));
+        throw new InvalidOperationException("Message row has neither channel_id nor conversation_id set.");
+    }
+
+    internal static (Guid? ChannelId, Guid? ConversationId) SplitScope(MessageScope scope)
+    {
+        if (scope is MessageScope.Channel c)
+            return (c.ChannelId.Value, null);
+        if (scope is MessageScope.Conversation conv)
+            return (null, conv.ConversationId.Value);
+        throw new InvalidOperationException($"Unknown message scope type: {scope.GetType().Name}.");
     }
 
     internal static IReadOnlyDictionary<Guid, IReadOnlyList<LinkPreviewDto>> BuildLinkPreviewsDictionary(

--- a/tests/Harmonie.Application.Tests/Common/ApplicationTestBuilders.cs
+++ b/tests/Harmonie.Application.Tests/Common/ApplicationTestBuilders.cs
@@ -102,8 +102,7 @@ internal static class ApplicationTestBuilders
 
         return Message.Rehydrate(
             id: MessageId.New(),
-            channelId: channelId,
-            conversationId: null,
+            scope: new MessageScope.Channel(channelId),
             authorUserId: authorId,
             replyToMessageId: replyToMessageId,
             content: contentResult.Value,
@@ -126,8 +125,7 @@ internal static class ApplicationTestBuilders
 
         return Message.Rehydrate(
             id: MessageId.New(),
-            channelId: null,
-            conversationId: conversationId,
+            scope: new MessageScope.Conversation(conversationId),
             authorUserId: authorUserId,
             replyToMessageId: replyToMessageId,
             content: contentResult.Value,

--- a/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
@@ -339,8 +339,7 @@ public sealed class SendConversationMessageHandlerTests
             .Setup(x => x.GetReplyTargetSummaryAsync(targetMessageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ReplyTargetSummary(
                 targetMessageId,
-                null,
-                conversation.Id,
+                new MessageScope.Conversation(conversation.Id),
                 UserId.New(),
                 "targetuser",
                 "Target Display",
@@ -400,8 +399,7 @@ public sealed class SendConversationMessageHandlerTests
             .Setup(x => x.GetReplyTargetSummaryAsync(targetMessageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ReplyTargetSummary(
                 targetMessageId,
-                null,
-                otherConversation.Id,
+                new MessageScope.Conversation(otherConversation.Id),
                 UserId.New(),
                 "targetuser",
                 null,
@@ -463,8 +461,7 @@ public sealed class SendConversationMessageHandlerTests
             .Setup(x => x.GetReplyTargetSummaryAsync(targetMessageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ReplyTargetSummary(
                 targetMessageId,
-                null,
-                conversation.Id,
+                new MessageScope.Conversation(conversation.Id),
                 UserId.New(),
                 "deleteduser",
                 "Deleted User",

--- a/tests/Harmonie.Application.Tests/Messages/SendMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SendMessageHandlerTests.cs
@@ -438,8 +438,7 @@ public sealed class SendMessageHandlerTests
             .Setup(x => x.GetReplyTargetSummaryAsync(targetMessageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ReplyTargetSummary(
                 targetMessageId,
-                channel.Id,
-                null,
+                new MessageScope.Channel(channel.Id),
                 UserId.New(),
                 "targetuser",
                 "Target Display",
@@ -498,8 +497,7 @@ public sealed class SendMessageHandlerTests
             .Setup(x => x.GetReplyTargetSummaryAsync(targetMessageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ReplyTargetSummary(
                 targetMessageId,
-                otherChannel.Id,
-                null,
+                new MessageScope.Channel(otherChannel.Id),
                 UserId.New(),
                 "targetuser",
                 null,
@@ -563,8 +561,7 @@ public sealed class SendMessageHandlerTests
             .Setup(x => x.GetReplyTargetSummaryAsync(targetMessageId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ReplyTargetSummary(
                 targetMessageId,
-                channel.Id,
-                null,
+                new MessageScope.Channel(channel.Id),
                 UserId.New(),
                 "deleteduser",
                 "Deleted User",

--- a/tests/Harmonie.Domain.Tests/MessageReadStateTests.cs
+++ b/tests/Harmonie.Domain.Tests/MessageReadStateTests.cs
@@ -11,56 +11,58 @@ namespace Harmonie.Domain.Tests;
 public sealed class MessageReadStateTests
 {
     [Fact]
-    public void CreateForChannel_WithValidInputs_ShouldSucceed()
+    public void Create_WithChannelScope_ShouldSucceed()
     {
         var userId = UserId.New();
         var channelId = GuildChannelId.New();
         var messageId = MessageId.New();
 
-        var result = MessageReadState.CreateForChannel(userId, channelId, messageId);
+        var result = MessageReadState.Create(userId, new MessageScope.Channel(channelId), messageId);
 
         result.IsSuccess.Should().BeTrue();
         result.Value.Should().NotBeNull();
         result.Value!.UserId.Should().Be(userId);
-        result.Value.ChannelId.Should().Be(channelId);
+        result.Value.Scope.Should().BeOfType<MessageScope.Channel>();
+        ((MessageScope.Channel)result.Value.Scope).ChannelId.Should().Be(channelId);
         result.Value.LastReadMessageId.Should().Be(messageId);
         result.Value.ReadAtUtc.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
     }
 
     [Fact]
-    public void CreateForConversation_WithValidInputs_ShouldSucceed()
+    public void Create_WithConversationScope_ShouldSucceed()
     {
         var userId = UserId.New();
         var conversationId = ConversationId.New();
         var messageId = MessageId.New();
 
-        var result = MessageReadState.CreateForConversation(userId, conversationId, messageId);
+        var result = MessageReadState.Create(userId, new MessageScope.Conversation(conversationId), messageId);
 
         result.IsSuccess.Should().BeTrue();
         result.Value.Should().NotBeNull();
         result.Value!.UserId.Should().Be(userId);
-        result.Value.ConversationId.Should().Be(conversationId);
+        result.Value.Scope.Should().BeOfType<MessageScope.Conversation>();
+        ((MessageScope.Conversation)result.Value.Scope).ConversationId.Should().Be(conversationId);
         result.Value.LastReadMessageId.Should().Be(messageId);
     }
 
     [Fact]
-    public void CreateForChannel_WithNullUserId_ShouldFail()
+    public void Create_WithNullUserId_ShouldFail()
     {
-        var result = MessageReadState.CreateForChannel(null!, GuildChannelId.New(), MessageId.New());
+        var result = MessageReadState.Create(null!, new MessageScope.Channel(GuildChannelId.New()), MessageId.New());
         result.IsFailure.Should().BeTrue();
     }
 
     [Fact]
-    public void CreateForConversation_WithNullConversationId_ShouldFail()
+    public void Create_WithNullScope_ShouldFail()
     {
-        var result = MessageReadState.CreateForConversation(UserId.New(), null!, MessageId.New());
+        var result = MessageReadState.Create(UserId.New(), null!, MessageId.New());
         result.IsFailure.Should().BeTrue();
     }
 
     [Fact]
     public void Acknowledge_ShouldUpdateFields()
     {
-        var state = MessageReadState.Rehydrate(UserId.New(), GuildChannelId.New(), conversationId: null, MessageId.New(), DateTime.UtcNow.AddMinutes(-5));
+        var state = MessageReadState.Rehydrate(UserId.New(), new MessageScope.Channel(GuildChannelId.New()), MessageId.New(), DateTime.UtcNow.AddMinutes(-5));
         var newMessageId = MessageId.New();
 
         state.Acknowledge(newMessageId);
@@ -70,9 +72,9 @@ public sealed class MessageReadStateTests
     }
 
     [Fact]
-    public void Rehydrate_WithBothIdsNull_ShouldThrow()
+    public void Rehydrate_WithNullScope_ShouldThrow()
     {
-        var act = () => MessageReadState.Rehydrate(UserId.New(), channelId: null, conversationId: null, MessageId.New(), DateTime.UtcNow);
-        act.Should().Throw<ArgumentException>();
+        var act = () => MessageReadState.Rehydrate(UserId.New(), null!, MessageId.New(), DateTime.UtcNow);
+        act.Should().Throw<ArgumentNullException>();
     }
 }

--- a/tests/Harmonie.Domain.Tests/MessageTests.cs
+++ b/tests/Harmonie.Domain.Tests/MessageTests.cs
@@ -12,40 +12,38 @@ namespace Harmonie.Domain.Tests;
 public sealed class MessageTests
 {
     [Fact]
-    public void CreateForChannel_WithValidInput_ShouldSucceed()
+    public void Create_WithChannelScope_ShouldSucceed()
     {
         var contentResult = MessageContent.Create("hello channel");
         contentResult.IsSuccess.Should().BeTrue();
         contentResult.Value.Should().NotBeNull();
 
-        var result = Message.CreateForChannel(
-            GuildChannelId.New(),
+        var result = Message.Create(
+            new MessageScope.Channel(GuildChannelId.New()),
             UserId.New(),
             contentResult.Value!);
 
         result.IsSuccess.Should().BeTrue();
         result.Value.Should().NotBeNull();
-        result.Value!.ChannelId.Should().NotBeNull();
-        result.Value.ConversationId.Should().BeNull();
+        result.Value!.Scope.Should().BeOfType<MessageScope.Channel>();
         result.Value.DeletedAtUtc.Should().BeNull();
     }
 
     [Fact]
-    public void CreateForConversation_WithValidInput_ShouldSucceed()
+    public void Create_WithConversationScope_ShouldSucceed()
     {
         var contentResult = MessageContent.Create("hello there");
         contentResult.IsSuccess.Should().BeTrue();
         contentResult.Value.Should().NotBeNull();
 
-        var result = Message.CreateForConversation(
-            ConversationId.New(),
+        var result = Message.Create(
+            new MessageScope.Conversation(ConversationId.New()),
             UserId.New(),
             contentResult.Value!);
 
         result.IsSuccess.Should().BeTrue();
         result.Value.Should().NotBeNull();
-        result.Value!.ChannelId.Should().BeNull();
-        result.Value.ConversationId.Should().NotBeNull();
+        result.Value!.Scope.Should().BeOfType<MessageScope.Conversation>();
         result.Value.DeletedAtUtc.Should().BeNull();
     }
 
@@ -56,8 +54,8 @@ public sealed class MessageTests
         contentResult.IsSuccess.Should().BeTrue();
         contentResult.Value.Should().NotBeNull();
 
-        var createResult = Message.CreateForChannel(
-            GuildChannelId.New(),
+        var createResult = Message.Create(
+            new MessageScope.Channel(GuildChannelId.New()),
             UserId.New(),
             contentResult.Value!);
         createResult.IsSuccess.Should().BeTrue();
@@ -71,16 +69,18 @@ public sealed class MessageTests
     }
 
     [Fact]
-    public void Rehydrate_WhenBothParentsMissing_ShouldThrow()
+    public void Rehydrate_WithChannelScope_ShouldSucceed()
     {
         var contentResult = MessageContent.Create("hello");
         contentResult.IsSuccess.Should().BeTrue();
         contentResult.Value.Should().NotBeNull();
 
-        var act = () => Message.Rehydrate(
+        var channelId = GuildChannelId.New();
+        var scope = new MessageScope.Channel(channelId);
+
+        var message = Message.Rehydrate(
             MessageId.New(),
-            channelId: null,
-            conversationId: null,
+            scope,
             authorUserId: UserId.New(),
             replyToMessageId: null,
             content: contentResult.Value!,
@@ -88,7 +88,32 @@ public sealed class MessageTests
             updatedAtUtc: null,
             deletedAtUtc: null);
 
-        act.Should().Throw<ArgumentException>();
+        message.Scope.Should().BeOfType<MessageScope.Channel>();
+        ((MessageScope.Channel)message.Scope).ChannelId.Should().Be(channelId);
+    }
+
+    [Fact]
+    public void Rehydrate_WithConversationScope_ShouldSucceed()
+    {
+        var contentResult = MessageContent.Create("hello");
+        contentResult.IsSuccess.Should().BeTrue();
+        contentResult.Value.Should().NotBeNull();
+
+        var conversationId = ConversationId.New();
+        var scope = new MessageScope.Conversation(conversationId);
+
+        var message = Message.Rehydrate(
+            MessageId.New(),
+            scope,
+            authorUserId: UserId.New(),
+            replyToMessageId: null,
+            content: contentResult.Value!,
+            createdAtUtc: DateTime.UtcNow,
+            updatedAtUtc: null,
+            deletedAtUtc: null);
+
+        message.Scope.Should().BeOfType<MessageScope.Conversation>();
+        ((MessageScope.Conversation)message.Scope).ConversationId.Should().Be(conversationId);
     }
 
     [Fact]
@@ -97,8 +122,8 @@ public sealed class MessageTests
         var contentResult = MessageContent.Create("original");
         contentResult.IsSuccess.Should().BeTrue();
 
-        var createResult = Message.CreateForChannel(
-            GuildChannelId.New(),
+        var createResult = Message.Create(
+            new MessageScope.Channel(GuildChannelId.New()),
             UserId.New(),
             contentResult.Value!);
         createResult.IsSuccess.Should().BeTrue();
@@ -117,15 +142,14 @@ public sealed class MessageTests
     }
 
     [Fact]
-    public void Rehydrate_WhenBothParentsPresent_ShouldThrow()
+    public void Rehydrate_WithNullScope_ShouldThrow()
     {
         var contentResult = MessageContent.Create("hello");
         contentResult.IsSuccess.Should().BeTrue();
 
         var act = () => Message.Rehydrate(
             MessageId.New(),
-            channelId: GuildChannelId.New(),
-            conversationId: ConversationId.New(),
+            scope: null!,
             authorUserId: UserId.New(),
             replyToMessageId: null,
             content: contentResult.Value!,
@@ -133,14 +157,14 @@ public sealed class MessageTests
             updatedAtUtc: null,
             deletedAtUtc: null);
 
-        act.Should().Throw<ArgumentException>();
+        act.Should().Throw<ArgumentNullException>();
     }
 
     [Fact]
-    public void CreateForChannel_WithNullContent_ShouldSucceed()
+    public void Create_WithNullContent_ShouldSucceed()
     {
-        var result = Message.CreateForChannel(
-            GuildChannelId.New(),
+        var result = Message.Create(
+            new MessageScope.Channel(GuildChannelId.New()),
             UserId.New(),
             content: null);
 
@@ -155,8 +179,8 @@ public sealed class MessageTests
         var contentResult = MessageContent.Create("hello");
         contentResult.IsSuccess.Should().BeTrue();
 
-        var createResult = Message.CreateForChannel(
-            GuildChannelId.New(),
+        var createResult = Message.Create(
+            new MessageScope.Channel(GuildChannelId.New()),
             UserId.New(),
             contentResult.Value!);
         createResult.IsSuccess.Should().BeTrue();


### PR DESCRIPTION
## Summary

Introduces a `MessageScope` discriminated union to replace the mutually-exclusive nullable `ChannelId?`/`ConversationId?` pair on `Message` and `MessageReadState`.

Closes #381

## Changes

### New
- **`ValueObjects/Messages/MessageScope.cs`** — sealed abstract record with `Channel(GuildChannelId)` and `Conversation(ConversationId)` variants

### Domain
- **`Message.cs`** — replaced `ChannelId?`/`ConversationId?` with single non-nullable `Scope`, collapsed `CreateForChannel`/`CreateForConversation` into single `Create(MessageScope, ...)`
- **`MessageReadState.cs`** — same treatment, removed runtime "exactly one parent" checks (now guaranteed by the type system)

### Application Interface
- **`IMessageRepository.cs`** — `ReplyTargetSummary` redesigned with `MessageScope` instead of two nullable IDs

### Infrastructure
- `MessageRepositoryHelpers.cs` — new `MapToScope()` helper, updated `MapToMessage()`
- `MessageRepository.cs` — `AddAsync` and `GetReplyTargetSummaryAsync` adapted to use `MessageScope`
- `MessagePaginationRepository.cs` — `MessageReadState.Rehydrate` calls updated
- `ChannelReadStateRepository.cs` — `UpsertAsync` + `Rehydrate` calls
- `ConversationReadStateRepository.cs` — same

### Application Handlers (22 files)
All handlers that accessed `message.ChannelId`/`message.ConversationId` migrated to pattern matching on `Scope`.

### Tests
- Updated domain tests and test builders for the new API
- Fixed `ReplyTargetSummary` constructor calls in handler tests

## Verification
- **Build**: 0 warnings, 0 errors
- **Tests**: 1202/1202 passing (Domain 176, Application 492, Infrastructure 17, API 43, Integration 474)
