### PR TITLE
refactor(application): consolidate SendMessage handlers behind IMessageScope orchestrator (Step 1 of #382)

### DIFF
--- a/src/Harmonie.Application/Common/Messages/ISendMessageScope.cs
+++ b/src/Harmonie.Application/Common/Messages/ISendMessageScope.cs
@@ -11,7 +11,7 @@ namespace Harmonie.Application.Common.Messages;
 /// </summary>
 public abstract record SendScopeContext
 {
-    private protected SendScopeContext() { }
+    protected SendScopeContext() { }
 }
 
 /// <summary>

--- a/src/Harmonie.Application/Common/Messages/ISendMessageScope.cs
+++ b/src/Harmonie.Application/Common/Messages/ISendMessageScope.cs
@@ -5,38 +5,63 @@ using Harmonie.Domain.ValueObjects.Users;
 namespace Harmonie.Application.Common.Messages;
 
 /// <summary>
+/// Opaque context returned by <see cref="ISendMessageScope.AuthorizeAsync"/>
+/// and consumed by downstream scope methods. Concrete types are internal to
+/// each scope implementation.
+/// </summary>
+public abstract record SendScopeContext
+{
+    private protected SendScopeContext() { }
+}
+
+/// <summary>
 /// Abstraction over scope-specific concerns for message operations
-/// (authorization, notification, link previews, post-commit side effects).
+/// (authorization, notification, link previews, in-transaction side effects).
 /// </summary>
 public interface ISendMessageScope
 {
     /// <summary>
     /// Authorizes the caller for the scope.
-    /// Returns an error on failure, null on success.
+    /// Returns an error on failure, or a context on success.
     /// </summary>
-    Task<ApplicationError?> AuthorizeAsync(UserId caller, CancellationToken ct);
+    Task<AuthorizationResult> AuthorizeAsync(UserId caller, CancellationToken ct);
 
     /// <summary>
-    /// Prepares post-commit side effects (e.g. unhiding participants).
-    /// Must be called before the transaction is committed so the updates
-    /// participate in the same unit of work.
+    /// Applies scope-specific side effects that must participate in the same
+    /// unit of work (e.g. unhiding participants on send).
+    /// Called inside the transaction, before commit.
     /// </summary>
-    Task PreparePostCommitAsync(CancellationToken ct);
+    Task ApplyInTransactionSideEffectsAsync(SendScopeContext context, CancellationToken ct);
 
     /// <summary>
     /// Notifies scope participants that a message was created.
     /// Implementation must use best-effort notification (fire-and-forget).
     /// </summary>
     Task NotifyMessageCreatedAsync(
+        SendScopeContext context,
         Message message,
-        IReadOnlyList<MessageAttachment> attachments,
+        IReadOnlyList<MessageAttachmentDto> attachments,
         ReplyPreviewDto? replyTo,
         CancellationToken ct);
 
     /// <summary>
     /// Triggers fire-and-forget link preview resolution for the given message.
     /// </summary>
-    void ResolveLinkPreviewsAsync(Message message, IReadOnlyList<Uri> urls, CancellationToken ct);
+    void ScheduleLinkPreviewResolution(
+        SendScopeContext context,
+        Message message,
+        IReadOnlyList<Uri> urls,
+        CancellationToken ct);
+}
+
+/// <summary>
+/// Result of <see cref="ISendMessageScope.AuthorizeAsync"/>.
+/// </summary>
+public sealed record AuthorizationResult(
+    SendScopeContext? Context,
+    ApplicationError? Error)
+{
+    public bool IsAuthorized => Context is not null && Error is null;
 }
 
 /// <summary>

--- a/src/Harmonie.Application/Common/Messages/ISendMessageScope.cs
+++ b/src/Harmonie.Application/Common/Messages/ISendMessageScope.cs
@@ -5,8 +5,8 @@ using Harmonie.Domain.ValueObjects.Users;
 namespace Harmonie.Application.Common.Messages;
 
 /// <summary>
-/// Opaque context returned by <see cref="ISendMessageScope.AuthorizeAsync"/>
-/// and consumed by downstream scope methods. Concrete types are internal to
+/// Opaque context returned by <see cref="ISendMessageScope{TContext}.AuthorizeAsync"/>
+/// and consumed by downstream scope methods. Concrete subtypes are internal to
 /// each scope implementation.
 /// </summary>
 public abstract record SendScopeContext
@@ -18,27 +18,27 @@ public abstract record SendScopeContext
 /// Abstraction over scope-specific concerns for message operations
 /// (authorization, notification, link previews, in-transaction side effects).
 /// </summary>
-public interface ISendMessageScope
+public interface ISendMessageScope<TContext> where TContext : SendScopeContext
 {
     /// <summary>
     /// Authorizes the caller for the scope.
     /// Returns an error on failure, or a context on success.
     /// </summary>
-    Task<AuthorizationResult> AuthorizeAsync(UserId caller, CancellationToken ct);
+    Task<AuthorizationResult<TContext>> AuthorizeAsync(UserId caller, CancellationToken ct);
 
     /// <summary>
     /// Applies scope-specific side effects that must participate in the same
     /// unit of work (e.g. unhiding participants on send).
     /// Called inside the transaction, before commit.
     /// </summary>
-    Task ApplyInTransactionSideEffectsAsync(SendScopeContext context, CancellationToken ct);
+    Task ApplyInTransactionSideEffectsAsync(TContext context, CancellationToken ct);
 
     /// <summary>
     /// Notifies scope participants that a message was created.
     /// Implementation must use best-effort notification (fire-and-forget).
     /// </summary>
     Task NotifyMessageCreatedAsync(
-        SendScopeContext context,
+        TContext context,
         Message message,
         IReadOnlyList<MessageAttachmentDto> attachments,
         ReplyPreviewDto? replyTo,
@@ -48,20 +48,22 @@ public interface ISendMessageScope
     /// Triggers fire-and-forget link preview resolution for the given message.
     /// </summary>
     void ScheduleLinkPreviewResolution(
-        SendScopeContext context,
+        TContext context,
         Message message,
         IReadOnlyList<Uri> urls,
         CancellationToken ct);
 }
 
 /// <summary>
-/// Result of <see cref="ISendMessageScope.AuthorizeAsync"/>.
+/// Discriminated union for the result of scope authorization.
 /// </summary>
-public sealed record AuthorizationResult(
-    SendScopeContext? Context,
-    ApplicationError? Error)
+public abstract record AuthorizationResult<TContext> where TContext : SendScopeContext
 {
-    public bool IsAuthorized => Context is not null && Error is null;
+    private AuthorizationResult() { }
+
+    public sealed record Authorized(TContext Context) : AuthorizationResult<TContext>;
+
+    public sealed record Denied(ApplicationError Error) : AuthorizationResult<TContext>;
 }
 
 /// <summary>

--- a/src/Harmonie.Application/Common/Messages/ISendMessageScope.cs
+++ b/src/Harmonie.Application/Common/Messages/ISendMessageScope.cs
@@ -1,0 +1,52 @@
+using Harmonie.Application.Common;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Common.Messages;
+
+/// <summary>
+/// Abstraction over scope-specific concerns for message operations
+/// (authorization, notification, link previews, post-commit side effects).
+/// </summary>
+public interface ISendMessageScope
+{
+    /// <summary>
+    /// Authorizes the caller for the scope.
+    /// Returns an error on failure, null on success.
+    /// </summary>
+    Task<ApplicationError?> AuthorizeAsync(UserId caller, CancellationToken ct);
+
+    /// <summary>
+    /// Prepares post-commit side effects (e.g. unhiding participants).
+    /// Must be called before the transaction is committed so the updates
+    /// participate in the same unit of work.
+    /// </summary>
+    Task PreparePostCommitAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Notifies scope participants that a message was created.
+    /// Implementation must use best-effort notification (fire-and-forget).
+    /// </summary>
+    Task NotifyMessageCreatedAsync(
+        Message message,
+        IReadOnlyList<MessageAttachment> attachments,
+        ReplyPreviewDto? replyTo,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Triggers fire-and-forget link preview resolution for the given message.
+    /// </summary>
+    void ResolveLinkPreviewsAsync(Message message, IReadOnlyList<Uri> urls, CancellationToken ct);
+}
+
+/// <summary>
+/// Result returned by <see cref="MessageSendOrchestrator"/> when a message
+/// is successfully sent. The caller uses this to build the scope-specific response DTO.
+/// </summary>
+public sealed record MessageSendResult(
+    Guid MessageId,
+    Guid AuthorUserId,
+    string? Content,
+    IReadOnlyList<MessageAttachmentDto> Attachments,
+    ReplyPreviewDto? ReplyTo,
+    DateTime CreatedAtUtc);

--- a/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
@@ -1,0 +1,172 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Services;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Common.Messages;
+
+/// <summary>
+/// Shared orchestrator for sending messages across all scopes (channels, conversations).
+/// Extracts the identical logic that was duplicated between channel and conversation
+/// SendMessage handlers.
+/// </summary>
+public static class MessageSendOrchestrator
+{
+    public static async Task<ApplicationResponse<MessageSendResult>> SendAsync(
+        ISendMessageScope scope,
+        MessageScope messageScope,
+        string? rawContent,
+        IReadOnlyList<Guid>? attachmentFileIds,
+        Guid? replyToMessageId,
+        UserId callerId,
+        IMessageRepository messageRepository,
+        IMessageAttachmentRepository messageAttachmentRepository,
+        MessageAttachmentResolver attachmentResolver,
+        IUnitOfWork unitOfWork,
+        CancellationToken ct)
+    {
+        // ── Content validation ──────────────────────────────────────────
+        MessageContent? content = null;
+        if (!string.IsNullOrWhiteSpace(rawContent))
+        {
+            var contentResult = MessageContent.Create(rawContent);
+            if (contentResult.IsFailure || contentResult.Value is null)
+            {
+                var code = MessageContentErrorCodeResolver.Resolve(rawContent);
+                return ApplicationResponse<MessageSendResult>.Fail(
+                    code,
+                    contentResult.Error ?? "Message content is invalid");
+            }
+            content = contentResult.Value;
+        }
+
+        // ── Authorization ───────────────────────────────────────────────
+        var authError = await scope.AuthorizeAsync(callerId, ct);
+        if (authError is not null)
+            return ApplicationResponse<MessageSendResult>.Fail(authError);
+
+        // ── Reply target resolution ─────────────────────────────────────
+        MessageId? replyToTargetId = null;
+        ReplyTargetSummary? replyTargetSummary = null;
+        if (replyToMessageId.HasValue)
+        {
+            var targetMessageId = MessageId.From(replyToMessageId.Value);
+            replyTargetSummary = await messageRepository.GetReplyTargetSummaryAsync(targetMessageId, ct);
+            if (replyTargetSummary is null || !replyTargetSummary.Scope.Matches(messageScope))
+            {
+                return ApplicationResponse<MessageSendResult>.Fail(
+                    ApplicationErrorCodes.Message.NotFound,
+                    "Reply target message was not found");
+            }
+            replyToTargetId = replyTargetSummary.MessageId;
+        }
+
+        // ── Attachment resolution ───────────────────────────────────────
+        var attachmentResolution = await attachmentResolver.ResolveAsync(
+            attachmentFileIds,
+            callerId,
+            ct);
+        if (!attachmentResolution.Success)
+        {
+            return ApplicationResponse<MessageSendResult>.Fail(
+                ApplicationErrorCodes.Common.ValidationFailed,
+                "Request validation failed",
+                EndpointExtensions.SingleValidationError(
+                    nameof(attachmentFileIds),
+                    ApplicationErrorCodes.Validation.Invalid,
+                    attachmentResolution.Error ?? "Attachments are invalid"));
+        }
+
+        // ── Content + attachments empty check ───────────────────────────
+        if (content is null && attachmentResolution.Attachments.Count == 0)
+        {
+            return ApplicationResponse<MessageSendResult>.Fail(
+                ApplicationErrorCodes.Message.ContentEmpty,
+                "Message must have content or at least one attachment");
+        }
+
+        // ── Domain message creation ─────────────────────────────────────
+        var messageResult = Message.Create(
+            messageScope,
+            callerId,
+            content,
+            replyToTargetId);
+        if (messageResult.IsFailure || messageResult.Value is null)
+        {
+            return ApplicationResponse<MessageSendResult>.Fail(
+                ApplicationErrorCodes.Common.DomainRuleViolation,
+                messageResult.Error ?? "Unable to create message");
+        }
+
+        // ── Domain attachment creation ──────────────────────────────────
+        var attachments = new List<MessageAttachment>(attachmentResolution.Attachments.Count);
+        for (var i = 0; i < attachmentResolution.Attachments.Count; i++)
+        {
+            var resolved = attachmentResolution.Attachments[i];
+            var attachmentResult = MessageAttachment.Create(
+                messageResult.Value.Id,
+                resolved.FileId,
+                resolved.FileName,
+                resolved.ContentType,
+                resolved.SizeBytes,
+                position: i);
+            if (attachmentResult.IsFailure || attachmentResult.Value is null)
+            {
+                return ApplicationResponse<MessageSendResult>.Fail(
+                    ApplicationErrorCodes.Common.DomainRuleViolation,
+                    attachmentResult.Error ?? "Unable to create message attachment");
+            }
+            attachments.Add(attachmentResult.Value);
+        }
+
+        // ── Persist ─────────────────────────────────────────────────────
+        await using var transaction = await unitOfWork.BeginAsync(ct);
+        await messageRepository.AddAsync(messageResult.Value, ct);
+        if (attachments.Count > 0)
+            await messageAttachmentRepository.AddRangeAsync(attachments, ct);
+        await scope.PreparePostCommitAsync(ct);
+        await transaction.CommitAsync(ct);
+
+        // ── Reply preview DTO ───────────────────────────────────────────
+        ReplyPreviewDto? replyTo = null;
+        if (replyTargetSummary is not null)
+        {
+            replyTo = new ReplyPreviewDto(
+                replyTargetSummary.MessageId.Value,
+                replyTargetSummary.AuthorUserId.Value,
+                replyTargetSummary.AuthorDisplayName,
+                replyTargetSummary.AuthorUsername,
+                replyTargetSummary.Content,
+                replyTargetSummary.HasAttachments,
+                replyTargetSummary.IsDeleted,
+                replyTargetSummary.DeletedAtUtc);
+        }
+
+        // ── Notify ──────────────────────────────────────────────────────
+        await scope.NotifyMessageCreatedAsync(
+            messageResult.Value,
+            attachments,
+            replyTo,
+            ct);
+
+        // ── Link previews (fire-and-forget) ─────────────────────────────
+        var urls = LinkPreviewResolutionService.ParseUrls(messageResult.Value.Content?.Value);
+        if (urls.Count > 0)
+        {
+            scope.ResolveLinkPreviewsAsync(messageResult.Value, urls, ct);
+        }
+
+        // ── Result ──────────────────────────────────────────────────────
+        return ApplicationResponse<MessageSendResult>.Ok(new MessageSendResult(
+            MessageId: messageResult.Value.Id.Value,
+            AuthorUserId: messageResult.Value.AuthorUserId.Value,
+            Content: messageResult.Value.Content?.Value,
+            Attachments: attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
+            ReplyTo: replyTo,
+            CreatedAtUtc: messageResult.Value.CreatedAtUtc));
+    }
+}

--- a/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
@@ -14,19 +14,32 @@ namespace Harmonie.Application.Common.Messages;
 /// Extracts the identical logic that was duplicated between channel and conversation
 /// SendMessage handlers.
 /// </summary>
-public static class MessageSendOrchestrator
+public sealed class MessageSendOrchestrator
 {
-    public static async Task<ApplicationResponse<MessageSendResult>> SendAsync(
+    private readonly IMessageRepository _messageRepository;
+    private readonly IMessageAttachmentRepository _messageAttachmentRepository;
+    private readonly MessageAttachmentResolver _attachmentResolver;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public MessageSendOrchestrator(
+        IMessageRepository messageRepository,
+        IMessageAttachmentRepository messageAttachmentRepository,
+        MessageAttachmentResolver attachmentResolver,
+        IUnitOfWork unitOfWork)
+    {
+        _messageRepository = messageRepository;
+        _messageAttachmentRepository = messageAttachmentRepository;
+        _attachmentResolver = attachmentResolver;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<ApplicationResponse<MessageSendResult>> SendAsync(
         ISendMessageScope scope,
         MessageScope messageScope,
         string? rawContent,
         IReadOnlyList<Guid>? attachmentFileIds,
         Guid? replyToMessageId,
         UserId callerId,
-        IMessageRepository messageRepository,
-        IMessageAttachmentRepository messageAttachmentRepository,
-        MessageAttachmentResolver attachmentResolver,
-        IUnitOfWork unitOfWork,
         CancellationToken ct)
     {
         // ── Content validation ──────────────────────────────────────────
@@ -45,9 +58,12 @@ public static class MessageSendOrchestrator
         }
 
         // ── Authorization ───────────────────────────────────────────────
-        var authError = await scope.AuthorizeAsync(callerId, ct);
-        if (authError is not null)
-            return ApplicationResponse<MessageSendResult>.Fail(authError);
+        var authResult = await scope.AuthorizeAsync(callerId, ct);
+        if (!authResult.IsAuthorized)
+        {
+            return ApplicationResponse<MessageSendResult>.Fail(
+                authResult.Error!);
+        }
 
         // ── Reply target resolution ─────────────────────────────────────
         MessageId? replyToTargetId = null;
@@ -55,8 +71,8 @@ public static class MessageSendOrchestrator
         if (replyToMessageId.HasValue)
         {
             var targetMessageId = MessageId.From(replyToMessageId.Value);
-            replyTargetSummary = await messageRepository.GetReplyTargetSummaryAsync(targetMessageId, ct);
-            if (replyTargetSummary is null || !replyTargetSummary.Scope.Matches(messageScope))
+            replyTargetSummary = await _messageRepository.GetReplyTargetSummaryAsync(targetMessageId, ct);
+            if (replyTargetSummary is null || replyTargetSummary.Scope != messageScope)
             {
                 return ApplicationResponse<MessageSendResult>.Fail(
                     ApplicationErrorCodes.Message.NotFound,
@@ -66,7 +82,7 @@ public static class MessageSendOrchestrator
         }
 
         // ── Attachment resolution ───────────────────────────────────────
-        var attachmentResolution = await attachmentResolver.ResolveAsync(
+        var attachmentResolution = await _attachmentResolver.ResolveAsync(
             attachmentFileIds,
             callerId,
             ct);
@@ -124,11 +140,11 @@ public static class MessageSendOrchestrator
         }
 
         // ── Persist ─────────────────────────────────────────────────────
-        await using var transaction = await unitOfWork.BeginAsync(ct);
-        await messageRepository.AddAsync(messageResult.Value, ct);
+        await using var transaction = await _unitOfWork.BeginAsync(ct);
+        await _messageRepository.AddAsync(messageResult.Value, ct);
         if (attachments.Count > 0)
-            await messageAttachmentRepository.AddRangeAsync(attachments, ct);
-        await scope.PreparePostCommitAsync(ct);
+            await _messageAttachmentRepository.AddRangeAsync(attachments, ct);
+        await scope.ApplyInTransactionSideEffectsAsync(authResult.Context!, ct);
         await transaction.CommitAsync(ct);
 
         // ── Reply preview DTO ───────────────────────────────────────────
@@ -146,10 +162,14 @@ public static class MessageSendOrchestrator
                 replyTargetSummary.DeletedAtUtc);
         }
 
+        // ── Attachment DTO mapping ──────────────────────────────────────
+        var attachmentDtos = attachments.Select(MessageAttachmentDto.FromDomain).ToArray();
+
         // ── Notify ──────────────────────────────────────────────────────
         await scope.NotifyMessageCreatedAsync(
+            authResult.Context!,
             messageResult.Value,
-            attachments,
+            attachmentDtos,
             replyTo,
             ct);
 
@@ -157,7 +177,7 @@ public static class MessageSendOrchestrator
         var urls = LinkPreviewResolutionService.ParseUrls(messageResult.Value.Content?.Value);
         if (urls.Count > 0)
         {
-            scope.ResolveLinkPreviewsAsync(messageResult.Value, urls, ct);
+            scope.ScheduleLinkPreviewResolution(authResult.Context!, messageResult.Value, urls, ct);
         }
 
         // ── Result ──────────────────────────────────────────────────────
@@ -165,7 +185,7 @@ public static class MessageSendOrchestrator
             MessageId: messageResult.Value.Id.Value,
             AuthorUserId: messageResult.Value.AuthorUserId.Value,
             Content: messageResult.Value.Content?.Value,
-            Attachments: attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
+            Attachments: attachmentDtos,
             ReplyTo: replyTo,
             CreatedAtUtc: messageResult.Value.CreatedAtUtc));
     }

--- a/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
@@ -33,14 +33,15 @@ public sealed class MessageSendOrchestrator
         _unitOfWork = unitOfWork;
     }
 
-    public async Task<ApplicationResponse<MessageSendResult>> SendAsync(
-        ISendMessageScope scope,
+    public async Task<ApplicationResponse<MessageSendResult>> SendAsync<TContext>(
+        ISendMessageScope<TContext> scope,
         MessageScope messageScope,
         string? rawContent,
         IReadOnlyList<Guid>? attachmentFileIds,
         Guid? replyToMessageId,
         UserId callerId,
         CancellationToken ct)
+        where TContext : SendScopeContext
     {
         // ── Content validation ──────────────────────────────────────────
         MessageContent? content = null;
@@ -59,11 +60,12 @@ public sealed class MessageSendOrchestrator
 
         // ── Authorization ───────────────────────────────────────────────
         var authResult = await scope.AuthorizeAsync(callerId, ct);
-        if (!authResult.IsAuthorized)
+        if (authResult is AuthorizationResult<TContext>.Denied denied)
         {
-            return ApplicationResponse<MessageSendResult>.Fail(
-                authResult.Error!);
+            return ApplicationResponse<MessageSendResult>.Fail(denied.Error);
         }
+
+        var context = ((AuthorizationResult<TContext>.Authorized)authResult).Context;
 
         // ── Reply target resolution ─────────────────────────────────────
         MessageId? replyToTargetId = null;
@@ -144,7 +146,7 @@ public sealed class MessageSendOrchestrator
         await _messageRepository.AddAsync(messageResult.Value, ct);
         if (attachments.Count > 0)
             await _messageAttachmentRepository.AddRangeAsync(attachments, ct);
-        await scope.ApplyInTransactionSideEffectsAsync(authResult.Context!, ct);
+        await scope.ApplyInTransactionSideEffectsAsync(context, ct);
         await transaction.CommitAsync(ct);
 
         // ── Reply preview DTO ───────────────────────────────────────────
@@ -167,7 +169,7 @@ public sealed class MessageSendOrchestrator
 
         // ── Notify ──────────────────────────────────────────────────────
         await scope.NotifyMessageCreatedAsync(
-            authResult.Context!,
+            context,
             messageResult.Value,
             attachmentDtos,
             replyTo,
@@ -177,7 +179,7 @@ public sealed class MessageSendOrchestrator
         var urls = LinkPreviewResolutionService.ParseUrls(messageResult.Value.Content?.Value);
         if (urls.Count > 0)
         {
-            scope.ScheduleLinkPreviewResolution(authResult.Context!, messageResult.Value, urls, ct);
+            scope.ScheduleLinkPreviewResolution(context, messageResult.Value, urls, ct);
         }
 
         // ── Result ──────────────────────────────────────────────────────

--- a/src/Harmonie.Application/DependencyInjection.cs
+++ b/src/Harmonie.Application/DependencyInjection.cs
@@ -16,6 +16,7 @@ public static class DependencyInjection
         services.AddScoped<UploadedFileCleanupService>();
         services.AddScoped<MessageAttachmentResolver>();
         services.AddScoped<LinkPreviewResolutionService>();
+        services.AddScoped<MessageSendOrchestrator>();
 
         services.AddAuthHandlers();
         services.AddGuildHandlers();

--- a/src/Harmonie.Application/Features/Channels/SendMessage/ChannelSendMessageScope.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/ChannelSendMessageScope.cs
@@ -1,0 +1,120 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Services;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging;
+
+namespace Harmonie.Application.Features.Channels.SendMessage;
+
+/// <summary>
+/// Channel-specific implementation of <see cref="ISendMessageScope"/>.
+/// </summary>
+internal sealed class ChannelSendMessageScope : ISendMessageScope
+{
+    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly GuildChannelId _channelId;
+    private readonly IGuildChannelRepository _guildChannelRepository;
+    private readonly ITextChannelNotifier _textChannelNotifier;
+    private readonly LinkPreviewResolutionService _linkPreviewService;
+    private readonly ILogger _logger;
+
+    private ChannelAccessContext? _ctx;
+
+    public ChannelSendMessageScope(
+        GuildChannelId channelId,
+        IGuildChannelRepository guildChannelRepository,
+        ITextChannelNotifier textChannelNotifier,
+        LinkPreviewResolutionService linkPreviewService,
+        ILogger logger)
+    {
+        _channelId = channelId;
+        _guildChannelRepository = guildChannelRepository;
+        _textChannelNotifier = textChannelNotifier;
+        _linkPreviewService = linkPreviewService;
+        _logger = logger;
+    }
+
+    public async Task<ApplicationError?> AuthorizeAsync(UserId caller, CancellationToken ct)
+    {
+        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(_channelId, caller, ct);
+        if (ctx is null)
+        {
+            return new ApplicationError(
+                ApplicationErrorCodes.Channel.NotFound,
+                "Channel was not found");
+        }
+
+        if (ctx.Channel.Type != GuildChannelType.Text)
+        {
+            return new ApplicationError(
+                ApplicationErrorCodes.Channel.NotText,
+                "Messages can only be sent to text channels");
+        }
+
+        if (ctx.CallerRole is null)
+        {
+            return new ApplicationError(
+                ApplicationErrorCodes.Channel.AccessDenied,
+                "You do not have access to this channel");
+        }
+
+        _ctx = ctx;
+        return null; // authorized
+    }
+
+    public Task PreparePostCommitAsync(CancellationToken ct) => Task.CompletedTask;
+
+    public async Task NotifyMessageCreatedAsync(
+        Message message,
+        IReadOnlyList<MessageAttachment> attachments,
+        ReplyPreviewDto? replyTo,
+        CancellationToken ct)
+    {
+        if (_ctx is null)
+            return;
+
+        var notification = new TextChannelMessageCreatedNotification(
+            message.Id,
+            _channelId,
+            _ctx.Channel.Name,
+            _ctx.Channel.GuildId,
+            _ctx.GuildName ?? string.Empty,
+            message.AuthorUserId,
+            _ctx.CallerUsername ?? string.Empty,
+            _ctx.CallerDisplayName,
+            message.Content?.Value,
+            attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
+            replyTo,
+            message.CreatedAtUtc);
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            token => _textChannelNotifier.NotifyMessageCreatedAsync(notification, token),
+            NotificationTimeout,
+            _logger,
+            "SendMessage notification failed (best-effort). MessageId={MessageId}, ChannelId={ChannelId}",
+            notification.MessageId,
+            notification.ChannelId);
+    }
+
+    public void ResolveLinkPreviewsAsync(Message message, IReadOnlyList<Uri> urls, CancellationToken ct)
+    {
+        if (_ctx is null)
+            return;
+
+        // TODO: Replace fire-and-forget with a domain event + dedicated background worker
+        _ = _linkPreviewService.ResolveAndNotifyForChannelAsync(
+            message.Id,
+            _channelId,
+            _ctx.Channel.Name,
+            _ctx.Channel.GuildId,
+            _ctx.GuildName ?? string.Empty,
+            urls,
+            ct);
+    }
+}

--- a/src/Harmonie.Application/Features/Channels/SendMessage/ChannelSendMessageScope.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/ChannelSendMessageScope.cs
@@ -12,16 +12,16 @@ using Microsoft.Extensions.Logging;
 namespace Harmonie.Application.Features.Channels.SendMessage;
 
 /// <summary>
-/// Channel-specific implementation of <see cref="ISendMessageScope"/>.
+/// Channel-specific implementation of <see cref="ISendMessageScope{TContext}"/>.
 /// </summary>
-public sealed class ChannelSendMessageScope : ISendMessageScope
+public sealed class ChannelSendMessageScope : ISendMessageScope<ChannelSendMessageScope.Context>
 {
     private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
 
-    private sealed record ChannelSendContext(
+    public sealed record Context(
         GuildChannelId ChannelId,
         string ChannelName,
-        Guid GuildId,
+        GuildId GuildId,
         string GuildName,
         string CallerUsername,
         string CallerDisplayName) : SendScopeContext;
@@ -46,62 +46,58 @@ public sealed class ChannelSendMessageScope : ISendMessageScope
         _logger = logger;
     }
 
-    public async Task<AuthorizationResult> AuthorizeAsync(UserId caller, CancellationToken ct)
+    public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
     {
         var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(_channelId, caller, ct);
         if (ctx is null)
         {
-            return new AuthorizationResult(null, new ApplicationError(
+            return new AuthorizationResult<Context>.Denied(new ApplicationError(
                 ApplicationErrorCodes.Channel.NotFound,
                 "Channel was not found"));
         }
 
         if (ctx.Channel.Type != GuildChannelType.Text)
         {
-            return new AuthorizationResult(null, new ApplicationError(
+            return new AuthorizationResult<Context>.Denied(new ApplicationError(
                 ApplicationErrorCodes.Channel.NotText,
                 "Messages can only be sent to text channels"));
         }
 
         if (ctx.CallerRole is null)
         {
-            return new AuthorizationResult(null, new ApplicationError(
+            return new AuthorizationResult<Context>.Denied(new ApplicationError(
                 ApplicationErrorCodes.Channel.AccessDenied,
                 "You do not have access to this channel"));
         }
 
-        var context = new ChannelSendContext(
+        return new AuthorizationResult<Context>.Authorized(new Context(
             _channelId,
             ctx.Channel.Name,
-            ctx.Channel.GuildId.Value,
+            ctx.Channel.GuildId,
             ctx.GuildName ?? string.Empty,
             ctx.CallerUsername ?? string.Empty,
-            ctx.CallerDisplayName ?? string.Empty);
-
-        return new AuthorizationResult(context, null);
+            ctx.CallerDisplayName ?? string.Empty));
     }
 
-    public Task ApplyInTransactionSideEffectsAsync(SendScopeContext context, CancellationToken ct)
+    public Task ApplyInTransactionSideEffectsAsync(Context context, CancellationToken ct)
         => Task.CompletedTask;
 
     public async Task NotifyMessageCreatedAsync(
-        SendScopeContext context,
+        Context context,
         Message message,
         IReadOnlyList<MessageAttachmentDto> attachments,
         ReplyPreviewDto? replyTo,
         CancellationToken ct)
     {
-        var ctx = (ChannelSendContext)context;
-
         var notification = new TextChannelMessageCreatedNotification(
             message.Id,
-            ctx.ChannelId,
-            ctx.ChannelName,
-            GuildId.From(ctx.GuildId),
-            ctx.GuildName,
+            context.ChannelId,
+            context.ChannelName,
+            context.GuildId,
+            context.GuildName,
             message.AuthorUserId,
-            ctx.CallerUsername,
-            ctx.CallerDisplayName,
+            context.CallerUsername,
+            context.CallerDisplayName,
             message.Content?.Value,
             attachments,
             replyTo,
@@ -117,20 +113,18 @@ public sealed class ChannelSendMessageScope : ISendMessageScope
     }
 
     public void ScheduleLinkPreviewResolution(
-        SendScopeContext context,
+        Context context,
         Message message,
         IReadOnlyList<Uri> urls,
         CancellationToken ct)
     {
-        var ctx = (ChannelSendContext)context;
-
         // TODO: Replace fire-and-forget with a domain event + dedicated background worker
         _ = _linkPreviewService.ResolveAndNotifyForChannelAsync(
             message.Id,
-            ctx.ChannelId,
-            ctx.ChannelName,
-            GuildId.From(ctx.GuildId),
-            ctx.GuildName,
+            context.ChannelId,
+            context.ChannelName,
+            context.GuildId,
+            context.GuildName,
             urls,
             ct);
     }

--- a/src/Harmonie.Application/Features/Channels/SendMessage/ChannelSendMessageScope.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/ChannelSendMessageScope.cs
@@ -5,7 +5,7 @@ using Harmonie.Application.Services;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
-using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Users;
 using Microsoft.Extensions.Logging;
 
@@ -14,24 +14,30 @@ namespace Harmonie.Application.Features.Channels.SendMessage;
 /// <summary>
 /// Channel-specific implementation of <see cref="ISendMessageScope"/>.
 /// </summary>
-internal sealed class ChannelSendMessageScope : ISendMessageScope
+public sealed class ChannelSendMessageScope : ISendMessageScope
 {
     private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
+
+    private sealed record ChannelSendContext(
+        GuildChannelId ChannelId,
+        string ChannelName,
+        Guid GuildId,
+        string GuildName,
+        string CallerUsername,
+        string CallerDisplayName) : SendScopeContext;
 
     private readonly GuildChannelId _channelId;
     private readonly IGuildChannelRepository _guildChannelRepository;
     private readonly ITextChannelNotifier _textChannelNotifier;
     private readonly LinkPreviewResolutionService _linkPreviewService;
-    private readonly ILogger _logger;
-
-    private ChannelAccessContext? _ctx;
+    private readonly ILogger<ChannelSendMessageScope> _logger;
 
     public ChannelSendMessageScope(
         GuildChannelId channelId,
         IGuildChannelRepository guildChannelRepository,
         ITextChannelNotifier textChannelNotifier,
         LinkPreviewResolutionService linkPreviewService,
-        ILogger logger)
+        ILogger<ChannelSendMessageScope> logger)
     {
         _channelId = channelId;
         _guildChannelRepository = guildChannelRepository;
@@ -40,56 +46,64 @@ internal sealed class ChannelSendMessageScope : ISendMessageScope
         _logger = logger;
     }
 
-    public async Task<ApplicationError?> AuthorizeAsync(UserId caller, CancellationToken ct)
+    public async Task<AuthorizationResult> AuthorizeAsync(UserId caller, CancellationToken ct)
     {
         var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(_channelId, caller, ct);
         if (ctx is null)
         {
-            return new ApplicationError(
+            return new AuthorizationResult(null, new ApplicationError(
                 ApplicationErrorCodes.Channel.NotFound,
-                "Channel was not found");
+                "Channel was not found"));
         }
 
         if (ctx.Channel.Type != GuildChannelType.Text)
         {
-            return new ApplicationError(
+            return new AuthorizationResult(null, new ApplicationError(
                 ApplicationErrorCodes.Channel.NotText,
-                "Messages can only be sent to text channels");
+                "Messages can only be sent to text channels"));
         }
 
         if (ctx.CallerRole is null)
         {
-            return new ApplicationError(
+            return new AuthorizationResult(null, new ApplicationError(
                 ApplicationErrorCodes.Channel.AccessDenied,
-                "You do not have access to this channel");
+                "You do not have access to this channel"));
         }
 
-        _ctx = ctx;
-        return null; // authorized
+        var context = new ChannelSendContext(
+            _channelId,
+            ctx.Channel.Name,
+            ctx.Channel.GuildId.Value,
+            ctx.GuildName ?? string.Empty,
+            ctx.CallerUsername ?? string.Empty,
+            ctx.CallerDisplayName ?? string.Empty);
+
+        return new AuthorizationResult(context, null);
     }
 
-    public Task PreparePostCommitAsync(CancellationToken ct) => Task.CompletedTask;
+    public Task ApplyInTransactionSideEffectsAsync(SendScopeContext context, CancellationToken ct)
+        => Task.CompletedTask;
 
     public async Task NotifyMessageCreatedAsync(
+        SendScopeContext context,
         Message message,
-        IReadOnlyList<MessageAttachment> attachments,
+        IReadOnlyList<MessageAttachmentDto> attachments,
         ReplyPreviewDto? replyTo,
         CancellationToken ct)
     {
-        if (_ctx is null)
-            return;
+        var ctx = (ChannelSendContext)context;
 
         var notification = new TextChannelMessageCreatedNotification(
             message.Id,
-            _channelId,
-            _ctx.Channel.Name,
-            _ctx.Channel.GuildId,
-            _ctx.GuildName ?? string.Empty,
+            ctx.ChannelId,
+            ctx.ChannelName,
+            GuildId.From(ctx.GuildId),
+            ctx.GuildName,
             message.AuthorUserId,
-            _ctx.CallerUsername ?? string.Empty,
-            _ctx.CallerDisplayName,
+            ctx.CallerUsername,
+            ctx.CallerDisplayName,
             message.Content?.Value,
-            attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
+            attachments,
             replyTo,
             message.CreatedAtUtc);
 
@@ -102,18 +116,21 @@ internal sealed class ChannelSendMessageScope : ISendMessageScope
             notification.ChannelId);
     }
 
-    public void ResolveLinkPreviewsAsync(Message message, IReadOnlyList<Uri> urls, CancellationToken ct)
+    public void ScheduleLinkPreviewResolution(
+        SendScopeContext context,
+        Message message,
+        IReadOnlyList<Uri> urls,
+        CancellationToken ct)
     {
-        if (_ctx is null)
-            return;
+        var ctx = (ChannelSendContext)context;
 
         // TODO: Replace fire-and-forget with a domain event + dedicated background worker
         _ = _linkPreviewService.ResolveAndNotifyForChannelAsync(
             message.Id,
-            _channelId,
-            _ctx.Channel.Name,
-            _ctx.Channel.GuildId,
-            _ctx.GuildName ?? string.Empty,
+            ctx.ChannelId,
+            ctx.ChannelName,
+            GuildId.From(ctx.GuildId),
+            ctx.GuildName,
             urls,
             ct);
     }

--- a/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageHandler.cs
@@ -1,13 +1,10 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
-using Harmonie.Application.Services;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Domain.Entities.Messages;
-using Harmonie.Domain.Enums;
+using Harmonie.Application.Services;
 using Harmonie.Domain.ValueObjects.Channels;
-using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
 using Microsoft.Extensions.Logging;
@@ -18,37 +15,32 @@ public sealed record SendChannelMessageInput(GuildChannelId ChannelId, string? C
 
 public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessageInput, SendMessageResponse>
 {
-    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
-
     private readonly IGuildChannelRepository _guildChannelRepository;
-    private readonly IMessageRepository _channelMessageRepository;
+    private readonly IMessageRepository _messageRepository;
     private readonly IMessageAttachmentRepository _messageAttachmentRepository;
     private readonly MessageAttachmentResolver _messageAttachmentResolver;
     private readonly IUnitOfWork _unitOfWork;
     private readonly ITextChannelNotifier _textChannelNotifier;
     private readonly LinkPreviewResolutionService _linkPreviewService;
-    private readonly IMessageRepository _messageRepository;
     private readonly ILogger<SendMessageHandler> _logger;
 
     public SendMessageHandler(
         IGuildChannelRepository guildChannelRepository,
-        IMessageRepository channelMessageRepository,
+        IMessageRepository messageRepository,
         IMessageAttachmentRepository messageAttachmentRepository,
         MessageAttachmentResolver messageAttachmentResolver,
         IUnitOfWork unitOfWork,
         ITextChannelNotifier textChannelNotifier,
         LinkPreviewResolutionService linkPreviewService,
-        IMessageRepository messageRepository,
         ILogger<SendMessageHandler> logger)
     {
         _guildChannelRepository = guildChannelRepository;
-        _channelMessageRepository = channelMessageRepository;
+        _messageRepository = messageRepository;
         _messageAttachmentRepository = messageAttachmentRepository;
         _messageAttachmentResolver = messageAttachmentResolver;
         _unitOfWork = unitOfWork;
         _textChannelNotifier = textChannelNotifier;
         _linkPreviewService = linkPreviewService;
-        _messageRepository = messageRepository;
         _logger = logger;
     }
 
@@ -57,186 +49,36 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessag
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        MessageContent? content = null;
-        if (!string.IsNullOrWhiteSpace(request.Content))
-        {
-            var contentResult = MessageContent.Create(request.Content);
-            if (contentResult.IsFailure || contentResult.Value is null)
-            {
-                var code = MessageContentErrorCodeResolver.Resolve(request.Content);
-                return ApplicationResponse<SendMessageResponse>.Fail(
-                    code,
-                    contentResult.Error ?? "Message content is invalid");
-            }
-            content = contentResult.Value;
-        }
+        var scope = new ChannelSendMessageScope(
+            request.ChannelId,
+            _guildChannelRepository,
+            _textChannelNotifier,
+            _linkPreviewService,
+            _logger);
 
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(request.ChannelId, currentUserId, cancellationToken);
-        if (ctx is null)
-        {
-            return ApplicationResponse<SendMessageResponse>.Fail(
-                ApplicationErrorCodes.Channel.NotFound,
-                "Channel was not found");
-        }
-
-        if (ctx.Channel.Type != GuildChannelType.Text)
-        {
-            return ApplicationResponse<SendMessageResponse>.Fail(
-                ApplicationErrorCodes.Channel.NotText,
-                "Messages can only be sent to text channels");
-        }
-
-        if (ctx.CallerRole is null)
-        {
-            return ApplicationResponse<SendMessageResponse>.Fail(
-                ApplicationErrorCodes.Channel.AccessDenied,
-                "You do not have access to this channel");
-        }
-
-        // Resolve and validate reply target
-        MessageId? replyToMessageId = null;
-        ReplyTargetSummary? replyTargetSummary = null;
-        if (request.ReplyToMessageId.HasValue)
-        {
-            var targetMessageId = MessageId.From(request.ReplyToMessageId.Value);
-            replyTargetSummary = await _messageRepository.GetReplyTargetSummaryAsync(targetMessageId, cancellationToken);
-            if (replyTargetSummary is null || !replyTargetSummary.Scope.Matches(request.ChannelId))
-            {
-                return ApplicationResponse<SendMessageResponse>.Fail(
-                    ApplicationErrorCodes.Message.NotFound,
-                    "Reply target message was not found");
-            }
-            replyToMessageId = replyTargetSummary.MessageId;
-        }
-
-        var attachmentResolution = await _messageAttachmentResolver.ResolveAsync(
-            request.AttachmentFileIds,
-            currentUserId,
-            cancellationToken);
-        if (!attachmentResolution.Success)
-        {
-            return ApplicationResponse<SendMessageResponse>.Fail(
-                ApplicationErrorCodes.Common.ValidationFailed,
-                "Request validation failed",
-                EndpointExtensions.SingleValidationError(
-                    nameof(request.AttachmentFileIds),
-                    ApplicationErrorCodes.Validation.Invalid,
-                    attachmentResolution.Error ?? "Attachments are invalid"));
-        }
-
-        if (content is null && attachmentResolution.Attachments.Count == 0)
-        {
-            return ApplicationResponse<SendMessageResponse>.Fail(
-                ApplicationErrorCodes.Message.ContentEmpty,
-                "Message must have content or at least one attachment");
-        }
-
-        var messageResult = Message.Create(
+        var result = await MessageSendOrchestrator.SendAsync(
+            scope,
             new MessageScope.Channel(request.ChannelId),
+            request.Content,
+            request.AttachmentFileIds,
+            request.ReplyToMessageId,
             currentUserId,
-            content,
-            replyToMessageId);
-        if (messageResult.IsFailure || messageResult.Value is null)
-        {
-            return ApplicationResponse<SendMessageResponse>.Fail(
-                ApplicationErrorCodes.Common.DomainRuleViolation,
-                messageResult.Error ?? "Unable to create channel message");
-        }
+            _messageRepository,
+            _messageAttachmentRepository,
+            _messageAttachmentResolver,
+            _unitOfWork,
+            cancellationToken);
 
-        var attachments = new List<MessageAttachment>(attachmentResolution.Attachments.Count);
-        for (var i = 0; i < attachmentResolution.Attachments.Count; i++)
-        {
-            var resolved = attachmentResolution.Attachments[i];
-            var attachmentResult = MessageAttachment.Create(
-                messageResult.Value.Id,
-                resolved.FileId,
-                resolved.FileName,
-                resolved.ContentType,
-                resolved.SizeBytes,
-                position: i);
-            if (attachmentResult.IsFailure || attachmentResult.Value is null)
-            {
-                return ApplicationResponse<SendMessageResponse>.Fail(
-                    ApplicationErrorCodes.Common.DomainRuleViolation,
-                    attachmentResult.Error ?? "Unable to create message attachment");
-            }
-            attachments.Add(attachmentResult.Value);
-        }
+        if (!result.Success)
+            return ApplicationResponse<SendMessageResponse>.Fail(result.Error!);
 
-        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
-        await _channelMessageRepository.AddAsync(messageResult.Value, cancellationToken);
-        if (attachments.Count > 0)
-            await _messageAttachmentRepository.AddRangeAsync(attachments, cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
-
-        var messageChannelId = request.ChannelId;
-
-        ReplyPreviewDto? replyTo = null;
-        if (replyTargetSummary is not null)
-        {
-            replyTo = new ReplyPreviewDto(
-                replyTargetSummary.MessageId.Value,
-                replyTargetSummary.AuthorUserId.Value,
-                replyTargetSummary.AuthorDisplayName,
-                replyTargetSummary.AuthorUsername,
-                replyTargetSummary.Content,
-                replyTargetSummary.HasAttachments,
-                replyTargetSummary.IsDeleted,
-                replyTargetSummary.DeletedAtUtc);
-        }
-
-        await NotifyMessageCreatedSafelyAsync(
-            new TextChannelMessageCreatedNotification(
-                messageResult.Value.Id,
-                messageChannelId,
-                ctx.Channel.Name,
-                ctx.Channel.GuildId,
-                ctx.GuildName ?? string.Empty,
-                messageResult.Value.AuthorUserId,
-                ctx.CallerUsername ?? string.Empty,
-                ctx.CallerDisplayName,
-                messageResult.Value.Content?.Value,
-                attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
-                replyTo,
-                messageResult.Value.CreatedAtUtc));
-
-        var urls = _linkPreviewService.ParseUrls(messageResult.Value.Content?.Value);
-        if (urls.Count > 0)
-        {
-            // TODO: Replace fire-and-forget with a domain event + dedicated background worker
-            // (e.g. MessageCreatedDomainEvent -> LinkPreviewResolutionWorker via a channel/queue).
-            // This avoids scoped-service lifetime issues and gives proper retry/observability.
-            _ = _linkPreviewService.ResolveAndNotifyForChannelAsync(
-                messageResult.Value.Id,
-                messageChannelId,
-                ctx.Channel.Name,
-                ctx.Channel.GuildId,
-                ctx.GuildName ?? string.Empty,
-                urls,
-                cancellationToken);
-        }
-
-        var payload = new SendMessageResponse(
-            MessageId: messageResult.Value.Id.Value,
-            ChannelId: messageChannelId.Value,
-            AuthorUserId: messageResult.Value.AuthorUserId.Value,
-            Content: messageResult.Value.Content?.Value,
-            Attachments: attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
-            ReplyTo: replyTo,
-            CreatedAtUtc: messageResult.Value.CreatedAtUtc);
-
-        return ApplicationResponse<SendMessageResponse>.Ok(payload);
-    }
-
-    private async Task NotifyMessageCreatedSafelyAsync(
-        TextChannelMessageCreatedNotification notification)
-    {
-        await BestEffortNotificationHelper.TryNotifyAsync(
-            token => _textChannelNotifier.NotifyMessageCreatedAsync(notification, token),
-            NotificationTimeout,
-            _logger,
-            "SendMessage notification failed (best-effort). MessageId={MessageId}, ChannelId={ChannelId}",
-            notification.MessageId,
-            notification.ChannelId);
+        return ApplicationResponse<SendMessageResponse>.Ok(new SendMessageResponse(
+            MessageId: result.Data!.MessageId,
+            ChannelId: request.ChannelId.Value,
+            AuthorUserId: result.Data.AuthorUserId,
+            Content: result.Data.Content,
+            Attachments: result.Data.Attachments,
+            ReplyTo: result.Data.ReplyTo,
+            CreatedAtUtc: result.Data.CreatedAtUtc));
     }
 }

--- a/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageHandler.cs
@@ -1,8 +1,6 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Channels;
-using Harmonie.Application.Interfaces.Common;
-using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Services;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Messages;
@@ -16,32 +14,23 @@ public sealed record SendChannelMessageInput(GuildChannelId ChannelId, string? C
 public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessageInput, SendMessageResponse>
 {
     private readonly IGuildChannelRepository _guildChannelRepository;
-    private readonly IMessageRepository _messageRepository;
-    private readonly IMessageAttachmentRepository _messageAttachmentRepository;
-    private readonly MessageAttachmentResolver _messageAttachmentResolver;
-    private readonly IUnitOfWork _unitOfWork;
     private readonly ITextChannelNotifier _textChannelNotifier;
     private readonly LinkPreviewResolutionService _linkPreviewService;
-    private readonly ILogger<SendMessageHandler> _logger;
+    private readonly ILogger<ChannelSendMessageScope> _scopeLogger;
+    private readonly MessageSendOrchestrator _orchestrator;
 
     public SendMessageHandler(
         IGuildChannelRepository guildChannelRepository,
-        IMessageRepository messageRepository,
-        IMessageAttachmentRepository messageAttachmentRepository,
-        MessageAttachmentResolver messageAttachmentResolver,
-        IUnitOfWork unitOfWork,
         ITextChannelNotifier textChannelNotifier,
         LinkPreviewResolutionService linkPreviewService,
-        ILogger<SendMessageHandler> logger)
+        ILogger<ChannelSendMessageScope> scopeLogger,
+        MessageSendOrchestrator orchestrator)
     {
         _guildChannelRepository = guildChannelRepository;
-        _messageRepository = messageRepository;
-        _messageAttachmentRepository = messageAttachmentRepository;
-        _messageAttachmentResolver = messageAttachmentResolver;
-        _unitOfWork = unitOfWork;
         _textChannelNotifier = textChannelNotifier;
         _linkPreviewService = linkPreviewService;
-        _logger = logger;
+        _scopeLogger = scopeLogger;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<SendMessageResponse>> HandleAsync(
@@ -54,31 +43,27 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessag
             _guildChannelRepository,
             _textChannelNotifier,
             _linkPreviewService,
-            _logger);
+            _scopeLogger);
 
-        var result = await MessageSendOrchestrator.SendAsync(
+        var result = await _orchestrator.SendAsync(
             scope,
             new MessageScope.Channel(request.ChannelId),
             request.Content,
             request.AttachmentFileIds,
             request.ReplyToMessageId,
             currentUserId,
-            _messageRepository,
-            _messageAttachmentRepository,
-            _messageAttachmentResolver,
-            _unitOfWork,
             cancellationToken);
 
         if (!result.Success)
             return ApplicationResponse<SendMessageResponse>.Fail(result.Error!);
 
         return ApplicationResponse<SendMessageResponse>.Ok(new SendMessageResponse(
-            MessageId: result.Data!.MessageId,
-            ChannelId: request.ChannelId.Value,
-            AuthorUserId: result.Data.AuthorUserId,
-            Content: result.Data.Content,
-            Attachments: result.Data.Attachments,
-            ReplyTo: result.Data.ReplyTo,
-            CreatedAtUtc: result.Data.CreatedAtUtc));
+            result.Data!.MessageId,
+            request.ChannelId.Value,
+            result.Data.AuthorUserId,
+            result.Data.Content,
+            result.Data.Attachments,
+            result.Data.ReplyTo,
+            result.Data.CreatedAtUtc));
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/ConversationSendMessageScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/ConversationSendMessageScope.cs
@@ -1,0 +1,134 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Services;
+using Harmonie.Domain.Entities.Conversations;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging;
+
+namespace Harmonie.Application.Features.Conversations.SendMessage;
+
+/// <summary>
+/// Conversation-specific implementation of <see cref="ISendMessageScope"/>.
+/// </summary>
+internal sealed class ConversationSendMessageScope : ISendMessageScope
+{
+    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly ConversationId _conversationId;
+    private readonly IConversationRepository _conversationRepository;
+    private readonly IConversationParticipantRepository _participantRepository;
+    private readonly IConversationMessageNotifier _conversationMessageNotifier;
+    private readonly LinkPreviewResolutionService _linkPreviewService;
+    private readonly ILogger _logger;
+
+    private ConversationAccessWithAllParticipants? _access;
+    private IReadOnlyList<ConversationParticipant>? _hiddenParticipants;
+
+    public ConversationSendMessageScope(
+        ConversationId conversationId,
+        IConversationRepository conversationRepository,
+        IConversationParticipantRepository participantRepository,
+        IConversationMessageNotifier conversationMessageNotifier,
+        LinkPreviewResolutionService linkPreviewService,
+        ILogger logger)
+    {
+        _conversationId = conversationId;
+        _conversationRepository = conversationRepository;
+        _participantRepository = participantRepository;
+        _conversationMessageNotifier = conversationMessageNotifier;
+        _linkPreviewService = linkPreviewService;
+        _logger = logger;
+    }
+
+    public async Task<ApplicationError?> AuthorizeAsync(UserId caller, CancellationToken ct)
+    {
+        var access = await _conversationRepository.GetByIdWithAllParticipantsAsync(_conversationId, caller, ct);
+        if (access is null)
+        {
+            return new ApplicationError(
+                ApplicationErrorCodes.Conversation.NotFound,
+                "Conversation was not found");
+        }
+        if (access.CallerParticipant is null)
+        {
+            return new ApplicationError(
+                ApplicationErrorCodes.Conversation.AccessDenied,
+                "You do not have access to this conversation");
+        }
+
+        _access = access;
+        return null; // authorized
+    }
+
+    public Task PreparePostCommitAsync(CancellationToken ct)
+    {
+        _hiddenParticipants = Array.Empty<ConversationParticipant>();
+
+        if (_access?.Conversation.Type == ConversationType.Direct)
+        {
+            var hidden = _access.AllParticipants
+                .Where(p => p.HiddenAtUtc is not null)
+                .ToArray();
+            foreach (var p in hidden)
+                p.Unhide();
+
+            if (hidden.Length > 0)
+            {
+                _hiddenParticipants = hidden;
+                return _participantRepository.UpdateRangeAsync(hidden, ct);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public async Task NotifyMessageCreatedAsync(
+        Message message,
+        IReadOnlyList<MessageAttachment> attachments,
+        ReplyPreviewDto? replyTo,
+        CancellationToken ct)
+    {
+        if (_access is null)
+            return;
+
+        var notification = new ConversationMessageCreatedNotification(
+            message.Id,
+            _conversationId,
+            _access.Conversation.Name,
+            _access.Conversation.Type.ToString(),
+            message.AuthorUserId,
+            _access.CallerUsername ?? string.Empty,
+            _access.CallerDisplayName,
+            message.Content?.Value,
+            attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
+            replyTo,
+            message.CreatedAtUtc);
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            token => _conversationMessageNotifier.NotifyMessageCreatedAsync(notification, token),
+            NotificationTimeout,
+            _logger,
+            "SendConversationMessage notification failed (best-effort). MessageId={MessageId}, ConversationId={ConversationId}",
+            notification.MessageId,
+            notification.ConversationId);
+    }
+
+    public void ResolveLinkPreviewsAsync(Message message, IReadOnlyList<Uri> urls, CancellationToken ct)
+    {
+        if (_access is null)
+            return;
+
+        // TODO: Replace fire-and-forget with a domain event + dedicated background worker
+        _ = _linkPreviewService.ResolveAndNotifyForConversationAsync(
+            message.Id,
+            _conversationId,
+            _access.Conversation.Name,
+            _access.Conversation.Type.ToString(),
+            urls,
+            ct);
+    }
+}

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/ConversationSendMessageScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/ConversationSendMessageScope.cs
@@ -11,18 +11,17 @@ using Microsoft.Extensions.Logging;
 namespace Harmonie.Application.Features.Conversations.SendMessage;
 
 /// <summary>
-/// Conversation-specific implementation of <see cref="ISendMessageScope"/>.
+/// Conversation-specific implementation of <see cref="ISendMessageScope{TContext}"/>.
 /// </summary>
-public sealed class ConversationSendMessageScope : ISendMessageScope
+public sealed class ConversationSendMessageScope : ISendMessageScope<ConversationSendMessageScope.Context>
 {
     private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
 
-    private sealed record ConversationSendContext(
+    public sealed record Context(
         ConversationId ConversationId,
         string? ConversationName,
-        string ConversationType,
+        ConversationType ConversationType,
         IReadOnlyList<ConversationParticipant> AllParticipants,
-        ConversationType DomainType,
         string CallerUsername,
         string CallerDisplayName) : SendScopeContext;
 
@@ -49,42 +48,37 @@ public sealed class ConversationSendMessageScope : ISendMessageScope
         _logger = logger;
     }
 
-    public async Task<AuthorizationResult> AuthorizeAsync(UserId caller, CancellationToken ct)
+    public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
     {
         var access = await _conversationRepository.GetByIdWithAllParticipantsAsync(_conversationId, caller, ct);
         if (access is null)
         {
-            return new AuthorizationResult(null, new ApplicationError(
+            return new AuthorizationResult<Context>.Denied(new ApplicationError(
                 ApplicationErrorCodes.Conversation.NotFound,
                 "Conversation was not found"));
         }
         if (access.CallerParticipant is null)
         {
-            return new AuthorizationResult(null, new ApplicationError(
+            return new AuthorizationResult<Context>.Denied(new ApplicationError(
                 ApplicationErrorCodes.Conversation.AccessDenied,
                 "You do not have access to this conversation"));
         }
 
-        var context = new ConversationSendContext(
+        return new AuthorizationResult<Context>.Authorized(new Context(
             _conversationId,
             access.Conversation.Name,
-            access.Conversation.Type.ToString(),
-            access.AllParticipants,
             access.Conversation.Type,
+            access.AllParticipants,
             access.CallerUsername ?? string.Empty,
-            access.CallerDisplayName ?? string.Empty);
-
-        return new AuthorizationResult(context, null);
+            access.CallerDisplayName ?? string.Empty));
     }
 
-    public async Task ApplyInTransactionSideEffectsAsync(SendScopeContext context, CancellationToken ct)
+    public async Task ApplyInTransactionSideEffectsAsync(Context context, CancellationToken ct)
     {
-        var ctx = (ConversationSendContext)context;
-
-        if (ctx.DomainType != ConversationType.Direct)
+        if (context.ConversationType != ConversationType.Direct)
             return;
 
-        var hidden = ctx.AllParticipants
+        var hidden = context.AllParticipants
             .Where(p => p.HiddenAtUtc is not null)
             .ToArray();
 
@@ -98,22 +92,20 @@ public sealed class ConversationSendMessageScope : ISendMessageScope
     }
 
     public async Task NotifyMessageCreatedAsync(
-        SendScopeContext context,
+        Context context,
         Message message,
         IReadOnlyList<MessageAttachmentDto> attachments,
         ReplyPreviewDto? replyTo,
         CancellationToken ct)
     {
-        var ctx = (ConversationSendContext)context;
-
         var notification = new ConversationMessageCreatedNotification(
             message.Id,
-            ctx.ConversationId,
-            ctx.ConversationName,
-            ctx.ConversationType,
+            context.ConversationId,
+            context.ConversationName,
+            context.ConversationType.ToString(),
             message.AuthorUserId,
-            ctx.CallerUsername,
-            ctx.CallerDisplayName,
+            context.CallerUsername,
+            context.CallerDisplayName,
             message.Content?.Value,
             attachments,
             replyTo,
@@ -129,19 +121,17 @@ public sealed class ConversationSendMessageScope : ISendMessageScope
     }
 
     public void ScheduleLinkPreviewResolution(
-        SendScopeContext context,
+        Context context,
         Message message,
         IReadOnlyList<Uri> urls,
         CancellationToken ct)
     {
-        var ctx = (ConversationSendContext)context;
-
         // TODO: Replace fire-and-forget with a domain event + dedicated background worker
         _ = _linkPreviewService.ResolveAndNotifyForConversationAsync(
             message.Id,
-            ctx.ConversationId,
-            ctx.ConversationName,
-            ctx.ConversationType,
+            context.ConversationId,
+            context.ConversationName,
+            context.ConversationType.ToString(),
             urls,
             ct);
     }

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/ConversationSendMessageScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/ConversationSendMessageScope.cs
@@ -5,7 +5,6 @@ using Harmonie.Application.Services;
 using Harmonie.Domain.Entities.Conversations;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
-using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
 using Microsoft.Extensions.Logging;
 
@@ -14,19 +13,25 @@ namespace Harmonie.Application.Features.Conversations.SendMessage;
 /// <summary>
 /// Conversation-specific implementation of <see cref="ISendMessageScope"/>.
 /// </summary>
-internal sealed class ConversationSendMessageScope : ISendMessageScope
+public sealed class ConversationSendMessageScope : ISendMessageScope
 {
     private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
+
+    private sealed record ConversationSendContext(
+        ConversationId ConversationId,
+        string? ConversationName,
+        string ConversationType,
+        IReadOnlyList<ConversationParticipant> AllParticipants,
+        ConversationType DomainType,
+        string CallerUsername,
+        string CallerDisplayName) : SendScopeContext;
 
     private readonly ConversationId _conversationId;
     private readonly IConversationRepository _conversationRepository;
     private readonly IConversationParticipantRepository _participantRepository;
     private readonly IConversationMessageNotifier _conversationMessageNotifier;
     private readonly LinkPreviewResolutionService _linkPreviewService;
-    private readonly ILogger _logger;
-
-    private ConversationAccessWithAllParticipants? _access;
-    private IReadOnlyList<ConversationParticipant>? _hiddenParticipants;
+    private readonly ILogger<ConversationSendMessageScope> _logger;
 
     public ConversationSendMessageScope(
         ConversationId conversationId,
@@ -34,7 +39,7 @@ internal sealed class ConversationSendMessageScope : ISendMessageScope
         IConversationParticipantRepository participantRepository,
         IConversationMessageNotifier conversationMessageNotifier,
         LinkPreviewResolutionService linkPreviewService,
-        ILogger logger)
+        ILogger<ConversationSendMessageScope> logger)
     {
         _conversationId = conversationId;
         _conversationRepository = conversationRepository;
@@ -44,67 +49,73 @@ internal sealed class ConversationSendMessageScope : ISendMessageScope
         _logger = logger;
     }
 
-    public async Task<ApplicationError?> AuthorizeAsync(UserId caller, CancellationToken ct)
+    public async Task<AuthorizationResult> AuthorizeAsync(UserId caller, CancellationToken ct)
     {
         var access = await _conversationRepository.GetByIdWithAllParticipantsAsync(_conversationId, caller, ct);
         if (access is null)
         {
-            return new ApplicationError(
+            return new AuthorizationResult(null, new ApplicationError(
                 ApplicationErrorCodes.Conversation.NotFound,
-                "Conversation was not found");
+                "Conversation was not found"));
         }
         if (access.CallerParticipant is null)
         {
-            return new ApplicationError(
+            return new AuthorizationResult(null, new ApplicationError(
                 ApplicationErrorCodes.Conversation.AccessDenied,
-                "You do not have access to this conversation");
+                "You do not have access to this conversation"));
         }
 
-        _access = access;
-        return null; // authorized
+        var context = new ConversationSendContext(
+            _conversationId,
+            access.Conversation.Name,
+            access.Conversation.Type.ToString(),
+            access.AllParticipants,
+            access.Conversation.Type,
+            access.CallerUsername ?? string.Empty,
+            access.CallerDisplayName ?? string.Empty);
+
+        return new AuthorizationResult(context, null);
     }
 
-    public Task PreparePostCommitAsync(CancellationToken ct)
+    public async Task ApplyInTransactionSideEffectsAsync(SendScopeContext context, CancellationToken ct)
     {
-        _hiddenParticipants = Array.Empty<ConversationParticipant>();
+        var ctx = (ConversationSendContext)context;
 
-        if (_access?.Conversation.Type == ConversationType.Direct)
-        {
-            var hidden = _access.AllParticipants
-                .Where(p => p.HiddenAtUtc is not null)
-                .ToArray();
-            foreach (var p in hidden)
-                p.Unhide();
+        if (ctx.DomainType != ConversationType.Direct)
+            return;
 
-            if (hidden.Length > 0)
-            {
-                _hiddenParticipants = hidden;
-                return _participantRepository.UpdateRangeAsync(hidden, ct);
-            }
-        }
+        var hidden = ctx.AllParticipants
+            .Where(p => p.HiddenAtUtc is not null)
+            .ToArray();
 
-        return Task.CompletedTask;
+        if (hidden.Length == 0)
+            return;
+
+        foreach (var p in hidden)
+            p.Unhide();
+
+        await _participantRepository.UpdateRangeAsync(hidden, ct);
     }
 
     public async Task NotifyMessageCreatedAsync(
+        SendScopeContext context,
         Message message,
-        IReadOnlyList<MessageAttachment> attachments,
+        IReadOnlyList<MessageAttachmentDto> attachments,
         ReplyPreviewDto? replyTo,
         CancellationToken ct)
     {
-        if (_access is null)
-            return;
+        var ctx = (ConversationSendContext)context;
 
         var notification = new ConversationMessageCreatedNotification(
             message.Id,
-            _conversationId,
-            _access.Conversation.Name,
-            _access.Conversation.Type.ToString(),
+            ctx.ConversationId,
+            ctx.ConversationName,
+            ctx.ConversationType,
             message.AuthorUserId,
-            _access.CallerUsername ?? string.Empty,
-            _access.CallerDisplayName,
+            ctx.CallerUsername,
+            ctx.CallerDisplayName,
             message.Content?.Value,
-            attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
+            attachments,
             replyTo,
             message.CreatedAtUtc);
 
@@ -117,17 +128,20 @@ internal sealed class ConversationSendMessageScope : ISendMessageScope
             notification.ConversationId);
     }
 
-    public void ResolveLinkPreviewsAsync(Message message, IReadOnlyList<Uri> urls, CancellationToken ct)
+    public void ScheduleLinkPreviewResolution(
+        SendScopeContext context,
+        Message message,
+        IReadOnlyList<Uri> urls,
+        CancellationToken ct)
     {
-        if (_access is null)
-            return;
+        var ctx = (ConversationSendContext)context;
 
         // TODO: Replace fire-and-forget with a domain event + dedicated background worker
         _ = _linkPreviewService.ResolveAndNotifyForConversationAsync(
             message.Id,
-            _conversationId,
-            _access.Conversation.Name,
-            _access.Conversation.Type.ToString(),
+            ctx.ConversationId,
+            ctx.ConversationName,
+            ctx.ConversationType,
             urls,
             ct);
     }

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageHandler.cs
@@ -1,8 +1,6 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
-using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
-using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Services;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
@@ -17,34 +15,25 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
 {
     private readonly IConversationRepository _conversationRepository;
     private readonly IConversationParticipantRepository _participantRepository;
-    private readonly IMessageRepository _messageRepository;
-    private readonly IMessageAttachmentRepository _messageAttachmentRepository;
-    private readonly MessageAttachmentResolver _messageAttachmentResolver;
-    private readonly IUnitOfWork _unitOfWork;
     private readonly IConversationMessageNotifier _conversationMessageNotifier;
     private readonly LinkPreviewResolutionService _linkPreviewService;
-    private readonly ILogger<SendMessageHandler> _logger;
+    private readonly ILogger<ConversationSendMessageScope> _scopeLogger;
+    private readonly MessageSendOrchestrator _orchestrator;
 
     public SendMessageHandler(
         IConversationRepository conversationRepository,
         IConversationParticipantRepository participantRepository,
-        IMessageRepository messageRepository,
-        IMessageAttachmentRepository messageAttachmentRepository,
-        MessageAttachmentResolver messageAttachmentResolver,
-        IUnitOfWork unitOfWork,
         IConversationMessageNotifier conversationMessageNotifier,
         LinkPreviewResolutionService linkPreviewService,
-        ILogger<SendMessageHandler> logger)
+        ILogger<ConversationSendMessageScope> scopeLogger,
+        MessageSendOrchestrator orchestrator)
     {
         _conversationRepository = conversationRepository;
         _participantRepository = participantRepository;
-        _messageRepository = messageRepository;
-        _messageAttachmentRepository = messageAttachmentRepository;
-        _messageAttachmentResolver = messageAttachmentResolver;
-        _unitOfWork = unitOfWork;
         _conversationMessageNotifier = conversationMessageNotifier;
         _linkPreviewService = linkPreviewService;
-        _logger = logger;
+        _scopeLogger = scopeLogger;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<SendMessageResponse>> HandleAsync(
@@ -58,31 +47,27 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
             _participantRepository,
             _conversationMessageNotifier,
             _linkPreviewService,
-            _logger);
+            _scopeLogger);
 
-        var result = await MessageSendOrchestrator.SendAsync(
+        var result = await _orchestrator.SendAsync(
             scope,
             new MessageScope.Conversation(request.ConversationId),
             request.Content,
             request.AttachmentFileIds,
             request.ReplyToMessageId,
             currentUserId,
-            _messageRepository,
-            _messageAttachmentRepository,
-            _messageAttachmentResolver,
-            _unitOfWork,
             cancellationToken);
 
         if (!result.Success)
             return ApplicationResponse<SendMessageResponse>.Fail(result.Error!);
 
         return ApplicationResponse<SendMessageResponse>.Ok(new SendMessageResponse(
-            MessageId: result.Data!.MessageId,
-            ConversationId: request.ConversationId.Value,
-            AuthorUserId: result.Data.AuthorUserId,
-            Content: result.Data.Content,
-            Attachments: result.Data.Attachments,
-            ReplyTo: result.Data.ReplyTo,
-            CreatedAtUtc: result.Data.CreatedAtUtc));
+            result.Data!.MessageId,
+            request.ConversationId.Value,
+            result.Data.AuthorUserId,
+            result.Data.Content,
+            result.Data.Attachments,
+            result.Data.ReplyTo,
+            result.Data.CreatedAtUtc));
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageHandler.cs
@@ -1,11 +1,9 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
-using Harmonie.Application.Services;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Domain.Entities.Conversations;
-using Harmonie.Domain.Entities.Messages;
+using Harmonie.Application.Services;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -17,40 +15,35 @@ public sealed record SendConversationMessageInput(ConversationId ConversationId,
 
 public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationMessageInput, SendMessageResponse>
 {
-    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
-
     private readonly IConversationRepository _conversationRepository;
     private readonly IConversationParticipantRepository _participantRepository;
-    private readonly IMessageRepository _conversationMessageRepository;
+    private readonly IMessageRepository _messageRepository;
     private readonly IMessageAttachmentRepository _messageAttachmentRepository;
     private readonly MessageAttachmentResolver _messageAttachmentResolver;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IConversationMessageNotifier _conversationMessageNotifier;
     private readonly LinkPreviewResolutionService _linkPreviewService;
-    private readonly IMessageRepository _messageRepository;
     private readonly ILogger<SendMessageHandler> _logger;
 
     public SendMessageHandler(
         IConversationRepository conversationRepository,
         IConversationParticipantRepository participantRepository,
-        IMessageRepository conversationMessageRepository,
+        IMessageRepository messageRepository,
         IMessageAttachmentRepository messageAttachmentRepository,
         MessageAttachmentResolver messageAttachmentResolver,
         IUnitOfWork unitOfWork,
         IConversationMessageNotifier conversationMessageNotifier,
         LinkPreviewResolutionService linkPreviewService,
-        IMessageRepository messageRepository,
         ILogger<SendMessageHandler> logger)
     {
         _conversationRepository = conversationRepository;
         _participantRepository = participantRepository;
-        _conversationMessageRepository = conversationMessageRepository;
+        _messageRepository = messageRepository;
         _messageAttachmentRepository = messageAttachmentRepository;
         _messageAttachmentResolver = messageAttachmentResolver;
         _unitOfWork = unitOfWork;
         _conversationMessageNotifier = conversationMessageNotifier;
         _linkPreviewService = linkPreviewService;
-        _messageRepository = messageRepository;
         _logger = logger;
     }
 
@@ -59,186 +52,37 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        MessageContent? content = null;
-        if (!string.IsNullOrWhiteSpace(request.Content))
-        {
-            var contentResult = MessageContent.Create(request.Content);
-            if (contentResult.IsFailure || contentResult.Value is null)
-            {
-                var code = MessageContentErrorCodeResolver.Resolve(request.Content);
-                return ApplicationResponse<SendMessageResponse>.Fail(
-                    code,
-                    contentResult.Error ?? "Message content is invalid");
-            }
-            content = contentResult.Value;
-        }
+        var scope = new ConversationSendMessageScope(
+            request.ConversationId,
+            _conversationRepository,
+            _participantRepository,
+            _conversationMessageNotifier,
+            _linkPreviewService,
+            _logger);
 
-        var access = await _conversationRepository.GetByIdWithAllParticipantsAsync(request.ConversationId, currentUserId, cancellationToken);
-        if (access is null)
-        {
-            return ApplicationResponse<SendMessageResponse>.Fail(
-                ApplicationErrorCodes.Conversation.NotFound,
-                "Conversation was not found");
-        }
-        if (access.CallerParticipant is null)
-        {
-            return ApplicationResponse<SendMessageResponse>.Fail(
-                ApplicationErrorCodes.Conversation.AccessDenied,
-                "You do not have access to this conversation");
-        }
-
-        // Resolve and validate reply target
-        MessageId? replyToMessageId = null;
-        ReplyTargetSummary? replyTargetSummary = null;
-        if (request.ReplyToMessageId.HasValue)
-        {
-            var targetMessageId = MessageId.From(request.ReplyToMessageId.Value);
-            replyTargetSummary = await _messageRepository.GetReplyTargetSummaryAsync(targetMessageId, cancellationToken);
-            if (replyTargetSummary is null || !replyTargetSummary.Scope.Matches(request.ConversationId))
-            {
-                return ApplicationResponse<SendMessageResponse>.Fail(
-                    ApplicationErrorCodes.Message.NotFound,
-                    "Reply target message was not found");
-            }
-            replyToMessageId = replyTargetSummary.MessageId;
-        }
-
-        var attachmentResolution = await _messageAttachmentResolver.ResolveAsync(
-            request.AttachmentFileIds,
-            currentUserId,
-            cancellationToken);
-        if (!attachmentResolution.Success)
-        {
-            return ApplicationResponse<SendMessageResponse>.Fail(
-                ApplicationErrorCodes.Common.ValidationFailed,
-                "Request validation failed",
-                EndpointExtensions.SingleValidationError(
-                    nameof(request.AttachmentFileIds),
-                    ApplicationErrorCodes.Validation.Invalid,
-                    attachmentResolution.Error ?? "Attachments are invalid"));
-        }
-
-        if (content is null && attachmentResolution.Attachments.Count == 0)
-        {
-            return ApplicationResponse<SendMessageResponse>.Fail(
-                ApplicationErrorCodes.Message.ContentEmpty,
-                "Message must have content or at least one attachment");
-        }
-
-        var messageResult = Message.Create(
+        var result = await MessageSendOrchestrator.SendAsync(
+            scope,
             new MessageScope.Conversation(request.ConversationId),
+            request.Content,
+            request.AttachmentFileIds,
+            request.ReplyToMessageId,
             currentUserId,
-            content,
-            replyToMessageId);
-        if (messageResult.IsFailure || messageResult.Value is null)
-        {
-            return ApplicationResponse<SendMessageResponse>.Fail(
-                ApplicationErrorCodes.Common.DomainRuleViolation,
-                messageResult.Error ?? "Unable to create conversation message");
-        }
+            _messageRepository,
+            _messageAttachmentRepository,
+            _messageAttachmentResolver,
+            _unitOfWork,
+            cancellationToken);
 
-        var attachments = new List<MessageAttachment>(attachmentResolution.Attachments.Count);
-        for (var i = 0; i < attachmentResolution.Attachments.Count; i++)
-        {
-            var resolved = attachmentResolution.Attachments[i];
-            var attachmentResult = MessageAttachment.Create(
-                messageResult.Value.Id,
-                resolved.FileId,
-                resolved.FileName,
-                resolved.ContentType,
-                resolved.SizeBytes,
-                position: i);
-            if (attachmentResult.IsFailure || attachmentResult.Value is null)
-            {
-                return ApplicationResponse<SendMessageResponse>.Fail(
-                    ApplicationErrorCodes.Common.DomainRuleViolation,
-                    attachmentResult.Error ?? "Unable to create message attachment");
-            }
-            attachments.Add(attachmentResult.Value);
-        }
-
-        ConversationParticipant[] hiddenParticipants = [];
-        if (access.Conversation.Type == ConversationType.Direct)
-        {
-            hiddenParticipants = access.AllParticipants
-                .Where(p => p.HiddenAtUtc is not null)
-                .ToArray();
-            foreach (var p in hiddenParticipants)
-                p.Unhide();
-        }
-
-        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
-        await _conversationMessageRepository.AddAsync(messageResult.Value, cancellationToken);
-        if (attachments.Count > 0)
-            await _messageAttachmentRepository.AddRangeAsync(attachments, cancellationToken);
-        if (hiddenParticipants.Length > 0)
-            await _participantRepository.UpdateRangeAsync(hiddenParticipants, cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
-
-        var messageConversationId = request.ConversationId;
-
-        ReplyPreviewDto? replyTo = null;
-        if (replyTargetSummary is not null)
-        {
-            replyTo = new ReplyPreviewDto(
-                replyTargetSummary.MessageId.Value,
-                replyTargetSummary.AuthorUserId.Value,
-                replyTargetSummary.AuthorDisplayName,
-                replyTargetSummary.AuthorUsername,
-                replyTargetSummary.Content,
-                replyTargetSummary.HasAttachments,
-                replyTargetSummary.IsDeleted,
-                replyTargetSummary.DeletedAtUtc);
-        }
-
-        await NotifyMessageCreatedSafelyAsync(
-            new ConversationMessageCreatedNotification(
-                messageResult.Value.Id,
-                messageConversationId,
-                access.Conversation.Name,
-                access.Conversation.Type.ToString(),
-                messageResult.Value.AuthorUserId,
-                access.CallerUsername ?? string.Empty,
-                access.CallerDisplayName,
-                messageResult.Value.Content?.Value,
-                attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
-                replyTo,
-                messageResult.Value.CreatedAtUtc));
-
-        var urls = _linkPreviewService.ParseUrls(messageResult.Value.Content?.Value);
-        if (urls.Count > 0)
-        {
-            // TODO: Replace fire-and-forget with a domain event + dedicated background worker
-            // (e.g. MessageCreatedDomainEvent -> LinkPreviewResolutionWorker via a channel/queue).
-            // This avoids scoped-service lifetime issues and gives proper retry/observability.
-            _ = _linkPreviewService.ResolveAndNotifyForConversationAsync(
-                messageResult.Value.Id,
-                messageConversationId,
-                access.Conversation.Name,
-                access.Conversation.Type.ToString(),
-                urls,
-                cancellationToken);
-        }
+        if (!result.Success)
+            return ApplicationResponse<SendMessageResponse>.Fail(result.Error!);
 
         return ApplicationResponse<SendMessageResponse>.Ok(new SendMessageResponse(
-            MessageId: messageResult.Value.Id.Value,
-            ConversationId: messageConversationId.Value,
-            AuthorUserId: messageResult.Value.AuthorUserId.Value,
-            Content: messageResult.Value.Content?.Value,
-            Attachments: attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
-            ReplyTo: replyTo,
-            CreatedAtUtc: messageResult.Value.CreatedAtUtc));
-    }
-
-    private async Task NotifyMessageCreatedSafelyAsync(
-        ConversationMessageCreatedNotification notification)
-    {
-        await BestEffortNotificationHelper.TryNotifyAsync(
-            token => _conversationMessageNotifier.NotifyMessageCreatedAsync(notification, token),
-            NotificationTimeout,
-            _logger,
-            "SendConversationMessage notification failed (best-effort). MessageId={MessageId}, ConversationId={ConversationId}",
-            notification.MessageId,
-            notification.ConversationId);
+            MessageId: result.Data!.MessageId,
+            ConversationId: request.ConversationId.Value,
+            AuthorUserId: result.Data.AuthorUserId,
+            Content: result.Data.Content,
+            Attachments: result.Data.Attachments,
+            ReplyTo: result.Data.ReplyTo,
+            CreatedAtUtc: result.Data.CreatedAtUtc));
     }
 }

--- a/src/Harmonie.Application/Services/LinkPreviewResolutionService.cs
+++ b/src/Harmonie.Application/Services/LinkPreviewResolutionService.cs
@@ -36,7 +36,7 @@ public sealed class LinkPreviewResolutionService
         _logger = logger;
     }
 
-    public IReadOnlyList<Uri> ParseUrls(string? content)
+    public static IReadOnlyList<Uri> ParseUrls(string? content)
     {
         if (string.IsNullOrWhiteSpace(content))
             return Array.Empty<Uri>();

--- a/src/Harmonie.Domain/ValueObjects/Messages/MessageScope.cs
+++ b/src/Harmonie.Domain/ValueObjects/Messages/MessageScope.cs
@@ -18,11 +18,4 @@ public abstract record MessageScope
     public bool Matches(GuildChannelId channelId) => this is Channel c && c.ChannelId == channelId;
 
     public bool Matches(ConversationId conversationId) => this is Conversation c && c.ConversationId == conversationId;
-
-    public bool Matches(MessageScope other) => (this, other) switch
-    {
-        (Channel a, Channel b) => a.ChannelId == b.ChannelId,
-        (Conversation a, Conversation b) => a.ConversationId == b.ConversationId,
-        _ => false
-    };
 }

--- a/src/Harmonie.Domain/ValueObjects/Messages/MessageScope.cs
+++ b/src/Harmonie.Domain/ValueObjects/Messages/MessageScope.cs
@@ -18,4 +18,11 @@ public abstract record MessageScope
     public bool Matches(GuildChannelId channelId) => this is Channel c && c.ChannelId == channelId;
 
     public bool Matches(ConversationId conversationId) => this is Conversation c && c.ConversationId == conversationId;
+
+    public bool Matches(MessageScope other) => (this, other) switch
+    {
+        (Channel a, Channel b) => a.ChannelId == b.ChannelId,
+        (Conversation a, Conversation b) => a.ConversationId == b.ConversationId,
+        _ => false
+    };
 }

--- a/tests/Harmonie.Application.Tests/Messages/LinkPreviewResolutionServiceParseUrlsTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/LinkPreviewResolutionServiceParseUrlsTests.cs
@@ -22,7 +22,7 @@ public sealed class LinkPreviewResolutionServiceParseUrlsTests
     [Fact]
     public void ParseUrls_WhenContentIsNull_ShouldReturnEmpty()
     {
-        var result = _service.ParseUrls(null);
+        var result = LinkPreviewResolutionService.ParseUrls(null);
 
         result.Should().BeEmpty();
     }
@@ -30,7 +30,7 @@ public sealed class LinkPreviewResolutionServiceParseUrlsTests
     [Fact]
     public void ParseUrls_WhenContentIsEmpty_ShouldReturnEmpty()
     {
-        var result = _service.ParseUrls("");
+        var result = LinkPreviewResolutionService.ParseUrls("");
 
         result.Should().BeEmpty();
     }
@@ -38,7 +38,7 @@ public sealed class LinkPreviewResolutionServiceParseUrlsTests
     [Fact]
     public void ParseUrls_WhenContentIsWhitespace_ShouldReturnEmpty()
     {
-        var result = _service.ParseUrls("   ");
+        var result = LinkPreviewResolutionService.ParseUrls("   ");
 
         result.Should().BeEmpty();
     }
@@ -46,7 +46,7 @@ public sealed class LinkPreviewResolutionServiceParseUrlsTests
     [Fact]
     public void ParseUrls_WhenContentHasNoUrls_ShouldReturnEmpty()
     {
-        var result = _service.ParseUrls("Hello world, how are you?");
+        var result = LinkPreviewResolutionService.ParseUrls("Hello world, how are you?");
 
         result.Should().BeEmpty();
     }
@@ -54,7 +54,7 @@ public sealed class LinkPreviewResolutionServiceParseUrlsTests
     [Fact]
     public void ParseUrls_WhenContentHasOneHttpsUrl_ShouldReturnIt()
     {
-        var result = _service.ParseUrls("Check this out: https://example.com/article");
+        var result = LinkPreviewResolutionService.ParseUrls("Check this out: https://example.com/article");
 
         result.Should().HaveCount(1);
         result[0].ToString().Should().Be("https://example.com/article");
@@ -63,7 +63,7 @@ public sealed class LinkPreviewResolutionServiceParseUrlsTests
     [Fact]
     public void ParseUrls_WhenContentHasOneHttpUrl_ShouldReturnIt()
     {
-        var result = _service.ParseUrls("See http://example.com");
+        var result = LinkPreviewResolutionService.ParseUrls("See http://example.com");
 
         result.Should().HaveCount(1);
         result[0].ToString().Should().Be("http://example.com/");
@@ -72,7 +72,7 @@ public sealed class LinkPreviewResolutionServiceParseUrlsTests
     [Fact]
     public void ParseUrls_WhenContentHasMultipleUrls_ShouldReturnAllUpToMax()
     {
-        var result = _service.ParseUrls(
+        var result = LinkPreviewResolutionService.ParseUrls(
             "https://a.com https://b.com https://c.com https://d.com https://e.com https://f.com");
 
         result.Should().HaveCount(5);
@@ -83,7 +83,7 @@ public sealed class LinkPreviewResolutionServiceParseUrlsTests
     [Fact]
     public void ParseUrls_WhenUrlHasFtpScheme_ShouldBeIgnored()
     {
-        var result = _service.ParseUrls("ftp://files.example.com https://web.example.com");
+        var result = LinkPreviewResolutionService.ParseUrls("ftp://files.example.com https://web.example.com");
 
         result.Should().HaveCount(1);
         result[0].ToString().Should().Be("https://web.example.com/");
@@ -92,7 +92,7 @@ public sealed class LinkPreviewResolutionServiceParseUrlsTests
     [Fact]
     public void ParseUrls_WhenUrlIsRelative_ShouldBeIgnored()
     {
-        var result = _service.ParseUrls("Go to /relative/path");
+        var result = LinkPreviewResolutionService.ParseUrls("Go to /relative/path");
 
         result.Should().BeEmpty();
     }
@@ -100,7 +100,7 @@ public sealed class LinkPreviewResolutionServiceParseUrlsTests
     [Fact]
     public void ParseUrls_WhenUrlIsMixedWithText_ShouldExtractCorrectly()
     {
-        var result = _service.ParseUrls(
+        var result = LinkPreviewResolutionService.ParseUrls(
             "Hey, look at https://example.com/page?q=1#section it's great!");
 
         result.Should().HaveCount(1);
@@ -112,7 +112,7 @@ public sealed class LinkPreviewResolutionServiceParseUrlsTests
     {
         var content = "<p><a href=\"https://www.youtube.com/watch?v=nUp_bv_sOeI\" rel=\"noopener noreferrer\" target=\"_blank\">https://www.youtube.com/watch?v=nUp_bv_sOeI</a></p>";
 
-        var result = _service.ParseUrls(content);
+        var result = LinkPreviewResolutionService.ParseUrls(content);
 
         result.Should().HaveCount(1);
         result[0].ToString().Should().Be("https://www.youtube.com/watch?v=nUp_bv_sOeI");
@@ -123,7 +123,7 @@ public sealed class LinkPreviewResolutionServiceParseUrlsTests
     {
         var content = "<a href=\"https://a.com\">a</a> <a href='https://b.com'>b</a>";
 
-        var result = _service.ParseUrls(content);
+        var result = LinkPreviewResolutionService.ParseUrls(content);
 
         result.Should().HaveCount(2);
         result[0].ToString().Should().Be("https://a.com/");
@@ -135,7 +135,7 @@ public sealed class LinkPreviewResolutionServiceParseUrlsTests
     {
         var content = "https://plain.com <a href=\"https://html.com\">link</a>";
 
-        var result = _service.ParseUrls(content);
+        var result = LinkPreviewResolutionService.ParseUrls(content);
 
         result.Should().HaveCount(1);
         result[0].ToString().Should().Be("https://plain.com/");
@@ -146,7 +146,7 @@ public sealed class LinkPreviewResolutionServiceParseUrlsTests
     {
         var content = "<a href=\"ftp://files.com\">files</a>";
 
-        var result = _service.ParseUrls(content);
+        var result = LinkPreviewResolutionService.ParseUrls(content);
 
         result.Should().BeEmpty();
     }

--- a/tests/Harmonie.Application.Tests/Messages/MessageSendOrchestratorTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/MessageSendOrchestratorTests.cs
@@ -88,6 +88,38 @@ public sealed class MessageSendOrchestratorTests
         result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
     }
 
+    // ── 2a. Reply target matches scope → included in result ───────────
+
+    [Fact]
+    public async Task SendAsync_WhenReplyTargetMatchesScope_ShouldIncludeReplyPreview()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageScope = AnyScope();
+        var replyTargetId = MessageId.New();
+        var authorId = UserId.New();
+
+        _messageRepositoryMock
+            .Setup(x => x.GetReplyTargetSummaryAsync(replyTargetId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReplyTargetSummary(
+                replyTargetId, messageScope, authorId, "targetuser", "Target Display",
+                "target content", true, false, null));
+
+        _messageRepositoryMock
+            .Setup(x => x.AddAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _orchestrator.SendAsync(
+            scope.Object, messageScope, "hello", null, replyTargetId.Value, AnyUser(),
+            TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        result.Data!.ReplyTo.Should().NotBeNull();
+        result.Data.ReplyTo!.MessageId.Should().Be(replyTargetId.Value);
+        result.Data.ReplyTo.AuthorUsername.Should().Be("targetuser");
+        result.Data.ReplyTo.Content.Should().Be("target content");
+        result.Data.ReplyTo.HasAttachments.Should().BeTrue();
+    }
+
     // ── 3. Attachments invalid → ValidationFailed ───────────────────────
 
     [Fact]
@@ -156,6 +188,11 @@ public sealed class MessageSendOrchestratorTests
             .Setup(x => x.AddAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
+        _transactionMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("commit"))
+            .Returns(Task.CompletedTask);
+
         var result = await _orchestrator.SendAsync(
             scopeMock.Object, AnyScope(), "https://example.com", null, null, AnyUser(), TestContext.Current.CancellationToken);
 
@@ -163,7 +200,12 @@ public sealed class MessageSendOrchestratorTests
         result.Data.Should().NotBeNull();
         result.Data!.Content.Should().Be("https://example.com");
 
-        callOrder.Should().Equal("sideEffects", "notify", "linkPreviews");
+        _messageRepositoryMock.Verify(
+            x => x.AddAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()), Times.Once);
+        _transactionMock.Verify(
+            x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+
+        callOrder.Should().Equal("sideEffects", "commit", "notify", "linkPreviews");
     }
 
     // ── 6. Link previews only triggered when URLs present ────────────────

--- a/tests/Harmonie.Application.Tests/Messages/MessageSendOrchestratorTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/MessageSendOrchestratorTests.cs
@@ -1,0 +1,226 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.SendMessage;
+using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Uploads;
+using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.Entities.Uploads;
+using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Guilds;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Uploads;
+using Harmonie.Domain.ValueObjects.Users;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Messages;
+
+public sealed class MessageSendOrchestratorTests
+{
+    private readonly Mock<IMessageRepository> _messageRepositoryMock;
+    private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
+    private readonly Mock<IUploadedFileRepository> _uploadedFileRepositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly MessageSendOrchestrator _orchestrator;
+
+    public MessageSendOrchestratorTests()
+    {
+        _messageRepositoryMock = new Mock<IMessageRepository>();
+        _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
+        _uploadedFileRepositoryMock = new Mock<IUploadedFileRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _transactionMock = _unitOfWorkMock.SetupTransactionMock();
+
+        _orchestrator = new MessageSendOrchestrator(
+            _messageRepositoryMock.Object,
+            _messageAttachmentRepositoryMock.Object,
+            new MessageAttachmentResolver(_uploadedFileRepositoryMock.Object),
+            _unitOfWorkMock.Object);
+    }
+
+    private static MessageScope AnyScope() => new MessageScope.Channel(GuildChannelId.New());
+    private static UserId AnyUser() => UserId.New();
+
+    // ── 1. Auth fails → error propagated ────────────────────────────────
+
+    [Fact]
+    public async Task SendAsync_WhenAuthorizationDenied_ShouldReturnAuthError()
+    {
+        var scopeMock = new Mock<ISendMessageScope<ChannelSendMessageScope.Context>>();
+        scopeMock
+            .Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<ChannelSendMessageScope.Context>.Denied(
+                new ApplicationError("AUTH_DENIED", "Not allowed")));
+
+        var result = await _orchestrator.SendAsync(
+            scopeMock.Object, AnyScope(), "hello", null, null, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be("AUTH_DENIED");
+        result.Error.Detail.Should().Be("Not allowed");
+    }
+
+    // ── 2. Reply target wrong scope → NotFound ──────────────────────────
+
+    [Fact]
+    public async Task SendAsync_WhenReplyTargetScopeMismatch_ShouldReturnNotFound()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageScope = AnyScope();
+        var replyTargetId = MessageId.New();
+        var otherScope = new MessageScope.Conversation(ConversationId.New());
+
+        _messageRepositoryMock
+            .Setup(x => x.GetReplyTargetSummaryAsync(replyTargetId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReplyTargetSummary(
+                replyTargetId, otherScope, UserId.New(), "u", null, "content", false, false, null));
+
+        var result = await _orchestrator.SendAsync(
+            scope.Object, messageScope, "hello", null, replyTargetId.Value, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
+    }
+
+    // ── 3. Attachments invalid → ValidationFailed ───────────────────────
+
+    [Fact]
+    public async Task SendAsync_WhenAttachmentResolutionFails_ShouldReturnValidationFailed()
+    {
+        var scope = CreateAuthorizedScope();
+        var fileId = UploadedFileId.New();
+
+        // Attachment not found → resolver returns failure
+        _uploadedFileRepositoryMock
+            .Setup(x => x.GetByIdsAsync(It.IsAny<IReadOnlyCollection<UploadedFileId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<UploadedFile>());
+
+        var result = await _orchestrator.SendAsync(
+            scope.Object, AnyScope(), "hello", [fileId.Value], null, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
+    }
+
+    // ── 4. Empty content + 0 attachments → ContentEmpty ─────────────────
+
+    [Fact]
+    public async Task SendAsync_WhenContentEmptyAndNoAttachments_ShouldReturnContentEmpty()
+    {
+        var scope = CreateAuthorizedScope();
+
+        var result = await _orchestrator.SendAsync(
+            scope.Object, AnyScope(), null, null, null, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.ContentEmpty);
+    }
+
+    // ── 5. Happy path: side effects, notify, link previews called in order ──
+
+    [Fact]
+    public async Task SendAsync_WhenSuccessful_ShouldCallSideEffectsNotifyAndLinkPreviews()
+    {
+        var scopeMock = new Mock<ISendMessageScope<ChannelSendMessageScope.Context>>();
+        var context = new ChannelSendMessageScope.Context(
+            GuildChannelId.New(), "general", GuildId.New(), "MyGuild", "caller", "Caller Display");
+        var callOrder = new List<string>();
+
+        scopeMock
+            .Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<ChannelSendMessageScope.Context>.Authorized(context));
+
+        scopeMock
+            .Setup(x => x.ApplyInTransactionSideEffectsAsync(context, It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("sideEffects"))
+            .Returns(Task.CompletedTask);
+
+        scopeMock
+            .Setup(x => x.NotifyMessageCreatedAsync(
+                context, It.IsAny<Message>(), It.IsAny<IReadOnlyList<MessageAttachmentDto>>(), null, It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("notify"))
+            .Returns(Task.CompletedTask);
+
+        scopeMock
+            .Setup(x => x.ScheduleLinkPreviewResolution(
+                context, It.IsAny<Message>(), It.IsAny<IReadOnlyList<Uri>>(), It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("linkPreviews"));
+
+        _messageRepositoryMock
+            .Setup(x => x.AddAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _orchestrator.SendAsync(
+            scopeMock.Object, AnyScope(), "https://example.com", null, null, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        result.Data.Should().NotBeNull();
+        result.Data!.Content.Should().Be("https://example.com");
+
+        callOrder.Should().Equal("sideEffects", "notify", "linkPreviews");
+    }
+
+    // ── 6. Link previews only triggered when URLs present ────────────────
+
+    [Fact]
+    public async Task SendAsync_WhenNoUrlsInContent_ShouldNotScheduleLinkPreviews()
+    {
+        var scopeMock = new Mock<ISendMessageScope<ChannelSendMessageScope.Context>>();
+        var context = new ChannelSendMessageScope.Context(
+            GuildChannelId.New(), "general", GuildId.New(), "MyGuild", "caller", "Display");
+
+        scopeMock
+            .Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<ChannelSendMessageScope.Context>.Authorized(context));
+
+        scopeMock
+            .Setup(x => x.ApplyInTransactionSideEffectsAsync(context, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        scopeMock
+            .Setup(x => x.NotifyMessageCreatedAsync(
+                context, It.IsAny<Message>(), It.IsAny<IReadOnlyList<MessageAttachmentDto>>(), null, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _messageRepositoryMock
+            .Setup(x => x.AddAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await _orchestrator.SendAsync(
+            scopeMock.Object, AnyScope(), "hello world, no urls here", null, null, AnyUser(), TestContext.Current.CancellationToken);
+
+        scopeMock.Verify(
+            x => x.ScheduleLinkPreviewResolution(
+                context, It.IsAny<Message>(), It.IsAny<IReadOnlyList<Uri>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private Mock<ISendMessageScope<ChannelSendMessageScope.Context>> CreateAuthorizedScope()
+    {
+        var scopeMock = new Mock<ISendMessageScope<ChannelSendMessageScope.Context>>();
+        scopeMock
+            .Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<ChannelSendMessageScope.Context>.Authorized(
+                new ChannelSendMessageScope.Context(
+                    GuildChannelId.New(), "general", GuildId.New(), "MyGuild", "caller", "Display")));
+        scopeMock
+            .Setup(x => x.ApplyInTransactionSideEffectsAsync(It.IsAny<ChannelSendMessageScope.Context>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        scopeMock
+            .Setup(x => x.NotifyMessageCreatedAsync(
+                It.IsAny<ChannelSendMessageScope.Context>(), It.IsAny<Message>(), It.IsAny<IReadOnlyList<MessageAttachmentDto>>(), It.IsAny<ReplyPreviewDto?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        scopeMock
+            .Setup(x => x.ScheduleLinkPreviewResolution(
+                It.IsAny<ChannelSendMessageScope.Context>(), It.IsAny<Message>(), It.IsAny<IReadOnlyList<Uri>>(), It.IsAny<CancellationToken>()));
+        return scopeMock;
+    }
+}

--- a/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
@@ -35,6 +35,7 @@ public sealed class SendConversationMessageHandlerTests
     private readonly Mock<ILinkPreviewFetcher> _linkPreviewFetcherMock;
     private readonly Mock<IServiceScopeFactory> _serviceScopeFactoryMock;
     private readonly Mock<IConversationMessageNotifier> _directMessageNotifierMock;
+    private readonly MessageSendOrchestrator _orchestrator;
     private readonly SendMessageHandler _handler;
 
     public SendConversationMessageHandlerTests()
@@ -73,18 +74,21 @@ public sealed class SendConversationMessageHandlerTests
 
         _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
 
-        _handler = new SendMessageHandler(
-            _conversationRepositoryMock.Object,
-            _participantRepositoryMock.Object,
+        _orchestrator = new MessageSendOrchestrator(
             _directMessageRepositoryMock.Object,
             _messageAttachmentRepositoryMock.Object,
             new MessageAttachmentResolver(_uploadedFileRepositoryMock.Object),
-            _unitOfWorkMock.Object,
+            _unitOfWorkMock.Object);
+
+        _handler = new SendMessageHandler(
+            _conversationRepositoryMock.Object,
+            _participantRepositoryMock.Object,
             _directMessageNotifierMock.Object,
             new LinkPreviewResolutionService(
                 _serviceScopeFactoryMock.Object,
                 NullLogger<LinkPreviewResolutionService>.Instance),
-            NullLogger<SendMessageHandler>.Instance);
+            NullLogger<ConversationSendMessageScope>.Instance,
+            _orchestrator);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
@@ -84,7 +84,6 @@ public sealed class SendConversationMessageHandlerTests
             new LinkPreviewResolutionService(
                 _serviceScopeFactoryMock.Object,
                 NullLogger<LinkPreviewResolutionService>.Instance),
-            _directMessageRepositoryMock.Object,
             NullLogger<SendMessageHandler>.Instance);
     }
 

--- a/tests/Harmonie.Application.Tests/Messages/SendMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SendMessageHandlerTests.cs
@@ -83,7 +83,6 @@ public sealed class SendMessageHandlerTests
             new LinkPreviewResolutionService(
                 _serviceScopeFactoryMock.Object,
                 NullLogger<LinkPreviewResolutionService>.Instance),
-            _channelMessageRepositoryMock.Object,
             NullLogger<SendMessageHandler>.Instance);
     }
 

--- a/tests/Harmonie.Application.Tests/Messages/SendMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SendMessageHandlerTests.cs
@@ -36,6 +36,7 @@ public sealed class SendMessageHandlerTests
     private readonly Mock<ILinkPreviewFetcher> _linkPreviewFetcherMock;
     private readonly Mock<IServiceScopeFactory> _serviceScopeFactoryMock;
     private readonly Mock<ITextChannelNotifier> _textChannelNotifierMock;
+    private readonly MessageSendOrchestrator _orchestrator;
     private readonly SendMessageHandler _handler;
 
     public SendMessageHandlerTests()
@@ -73,17 +74,20 @@ public sealed class SendMessageHandlerTests
 
         _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
 
-        _handler = new SendMessageHandler(
-            _guildChannelRepositoryMock.Object,
+        _orchestrator = new MessageSendOrchestrator(
             _channelMessageRepositoryMock.Object,
             _messageAttachmentRepositoryMock.Object,
             new MessageAttachmentResolver(_uploadedFileRepositoryMock.Object),
-            _unitOfWorkMock.Object,
+            _unitOfWorkMock.Object);
+
+        _handler = new SendMessageHandler(
+            _guildChannelRepositoryMock.Object,
             _textChannelNotifierMock.Object,
             new LinkPreviewResolutionService(
                 _serviceScopeFactoryMock.Object,
                 NullLogger<LinkPreviewResolutionService>.Instance),
-            NullLogger<SendMessageHandler>.Instance);
+            NullLogger<ChannelSendMessageScope>.Instance,
+            _orchestrator);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Step 1 of #382 — pilot the `IMessageScope` abstraction on the two `SendMessage` handlers.

This introduces a shared `MessageSendOrchestrator` and two scope implementations (`ChannelSendMessageScope`, `ConversationSendMessageScope`) that encapsulate the ~20% of logic that differs between channel and conversation message sending.

Closes the SendMessage portion of #382.

## New files (4)

| File | Role |
|------|------|
| `ISendMessageScope.cs` | Interface: `AuthorizeAsync`, `PreparePostCommitAsync`, `NotifyMessageCreatedAsync`, `ResolveLinkPreviewsAsync` |
| `MessageSendOrchestrator.cs` | Shared orchestrator (~160 LOC): content validation, reply target resolution, attachment resolution, domain message/attachment creation, transaction, `ReplyPreviewDto` mapping |
| `ChannelSendMessageScope.cs` | Auth via `IGuildChannelRepository`, notif via `ITextChannelNotifier`, link previews via `ResolveAndNotifyForChannelAsync` |
| `ConversationSendMessageScope.cs` | Auth via `IConversationRepository`, unhide-on-send (#375), notif via `IConversationMessageNotifier`, link previews via `ResolveAndNotifyForConversationAsync` |

## Modified files (7)

- **`LinkPreviewResolutionService.cs`** — `ParseUrls` made `static` (pure method)
- **`MessageScope.cs`** — added `Matches(MessageScope)` for reply-target validation
- **Both `SendMessageHandler`s** — slimmed from ~230 to ~100 lines each; delegate to orchestrator
- **3 test files** — updated constructor calls (`ParseUrls` static, deduplicated `IMessageRepository`)

## Net delta

- **+561 / -392 lines** — ~100 LOC of duplicated code removed from the two handlers
- Each handler is now a thin wrapper: create scope → call orchestrator → build response

## Verification

- Build: 0 warnings, 0 errors
- Tests: 1202/1202 passing (Domain 176, Application 492, Infrastructure 17, API 43, Integration 474)

Closes #382