### PR TITLE
refactor(application): consolidate reaction handlers behind IReactionScope (Step 2 of #382)

### DIFF
--- a/src/Harmonie.Application/Common/Messages/IReactionScope.cs
+++ b/src/Harmonie.Application/Common/Messages/IReactionScope.cs
@@ -1,0 +1,26 @@
+using Harmonie.Application.Common;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Common.Messages;
+
+/// <summary>
+/// Scope-specific concerns for reaction operations (authorization and notification).
+/// </summary>
+public interface IReactionScope<TContext> where TContext : SendScopeContext
+{
+    Task<AuthorizationResult<TContext>> AuthorizeAsync(UserId caller, CancellationToken ct);
+    Task NotifyReactionAddedAsync(TContext context, MessageId messageId, UserId userId, string emoji, CancellationToken ct);
+    Task NotifyReactionRemovedAsync(TContext context, MessageId messageId, UserId userId, string emoji, CancellationToken ct);
+}
+
+/// <summary>
+/// Result returned by <see cref="ReactionOrchestrator.GetUsersAsync"/>.
+/// The caller maps this to the namespace-specific GetReactionUsersResponse DTO.
+/// </summary>
+public sealed record ReactionUsersResult(
+    Guid MessageId,
+    string Emoji,
+    int TotalCount,
+    IReadOnlyList<ReactionUserDto> Users,
+    string? NextCursor);

--- a/src/Harmonie.Application/Common/Messages/IReactionScope.cs
+++ b/src/Harmonie.Application/Common/Messages/IReactionScope.cs
@@ -7,7 +7,7 @@ namespace Harmonie.Application.Common.Messages;
 /// <summary>
 /// Scope-specific concerns for reaction operations (authorization and notification).
 /// </summary>
-public interface IReactionScope<TContext> where TContext : SendScopeContext
+public interface IReactionScope<TContext> where TContext : ScopeContext
 {
     Task<AuthorizationResult<TContext>> AuthorizeAsync(UserId caller, CancellationToken ct);
     Task NotifyReactionAddedAsync(TContext context, MessageId messageId, UserId userId, string emoji, CancellationToken ct);

--- a/src/Harmonie.Application/Common/Messages/ISendMessageScope.cs
+++ b/src/Harmonie.Application/Common/Messages/ISendMessageScope.cs
@@ -9,16 +9,16 @@ namespace Harmonie.Application.Common.Messages;
 /// and consumed by downstream scope methods. Concrete subtypes are internal to
 /// each scope implementation.
 /// </summary>
-public abstract record SendScopeContext
+public abstract record ScopeContext
 {
-    protected SendScopeContext() { }
+    protected ScopeContext() { }
 }
 
 /// <summary>
 /// Abstraction over scope-specific concerns for message operations
 /// (authorization, notification, link previews, in-transaction side effects).
 /// </summary>
-public interface ISendMessageScope<TContext> where TContext : SendScopeContext
+public interface ISendMessageScope<TContext> where TContext : ScopeContext
 {
     /// <summary>
     /// Authorizes the caller for the scope.
@@ -57,7 +57,7 @@ public interface ISendMessageScope<TContext> where TContext : SendScopeContext
 /// <summary>
 /// Discriminated union for the result of scope authorization.
 /// </summary>
-public abstract record AuthorizationResult<TContext> where TContext : SendScopeContext
+public abstract record AuthorizationResult<TContext> where TContext : ScopeContext
 {
     private AuthorizationResult() { }
 

--- a/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
@@ -41,7 +41,7 @@ public sealed class MessageSendOrchestrator
         Guid? replyToMessageId,
         UserId callerId,
         CancellationToken ct)
-        where TContext : SendScopeContext
+        where TContext : ScopeContext
     {
         // ── Content validation ──────────────────────────────────────────
         MessageContent? content = null;

--- a/src/Harmonie.Application/Common/Messages/ReactionOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/ReactionOrchestrator.cs
@@ -31,7 +31,7 @@ public sealed class ReactionOrchestrator
         string emoji,
         UserId callerId,
         CancellationToken ct)
-        where TContext : SendScopeContext
+        where TContext : ScopeContext
     {
         var authResult = await scope.AuthorizeAsync(callerId, ct);
         if (authResult is AuthorizationResult<TContext>.Denied denied)
@@ -47,7 +47,6 @@ public sealed class ReactionOrchestrator
                 "Message was not found");
         }
 
-        await using var transaction = await _unitOfWork.BeginAsync(ct);
         var reaction = MessageReaction.Create(messageId, callerId, emoji);
         if (reaction.IsFailure || reaction.Value is null)
         {
@@ -56,6 +55,7 @@ public sealed class ReactionOrchestrator
                 reaction.Error ?? "Invalid reaction");
         }
 
+        await using var transaction = await _unitOfWork.BeginAsync(ct);
         await _reactionRepository.AddAsync(reaction.Value, ct);
         await transaction.CommitAsync(ct);
 
@@ -71,7 +71,7 @@ public sealed class ReactionOrchestrator
         string emoji,
         UserId callerId,
         CancellationToken ct)
-        where TContext : SendScopeContext
+        where TContext : ScopeContext
     {
         var authResult = await scope.AuthorizeAsync(callerId, ct);
         if (authResult is AuthorizationResult<TContext>.Denied denied)
@@ -105,8 +105,12 @@ public sealed class ReactionOrchestrator
         int? rawLimit,
         UserId callerId,
         CancellationToken ct)
-        where TContext : SendScopeContext
+        where TContext : ScopeContext
     {
+        var authResult = await scope.AuthorizeAsync(callerId, ct);
+        if (authResult is AuthorizationResult<TContext>.Denied denied)
+            return ApplicationResponse<ReactionUsersResult>.Fail(denied.Error);
+
         ReactionUsersCursor? cursor = null;
         if (rawCursor is not null)
         {
@@ -124,10 +128,6 @@ public sealed class ReactionOrchestrator
         }
 
         var limit = Math.Clamp(rawLimit ?? 50, 1, 100);
-
-        var authResult = await scope.AuthorizeAsync(callerId, ct);
-        if (authResult is AuthorizationResult<TContext>.Denied denied)
-            return ApplicationResponse<ReactionUsersResult>.Fail(denied.Error);
 
         var message = await _messageRepository.GetByIdAsync(messageId, ct);
         if (message is null || message.Scope != messageScope)

--- a/src/Harmonie.Application/Common/Messages/ReactionOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/ReactionOrchestrator.cs
@@ -1,0 +1,154 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Common.Messages;
+
+public sealed class ReactionOrchestrator
+{
+    private readonly IMessageRepository _messageRepository;
+    private readonly IMessageReactionRepository _reactionRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public ReactionOrchestrator(
+        IMessageRepository messageRepository,
+        IMessageReactionRepository reactionRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _messageRepository = messageRepository;
+        _reactionRepository = reactionRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<ApplicationResponse<bool>> AddAsync<TContext>(
+        IReactionScope<TContext> scope,
+        MessageScope messageScope,
+        MessageId messageId,
+        string emoji,
+        UserId callerId,
+        CancellationToken ct)
+        where TContext : SendScopeContext
+    {
+        var authResult = await scope.AuthorizeAsync(callerId, ct);
+        if (authResult is AuthorizationResult<TContext>.Denied denied)
+            return ApplicationResponse<bool>.Fail(denied.Error);
+
+        var context = ((AuthorizationResult<TContext>.Authorized)authResult).Context;
+
+        var message = await _messageRepository.GetByIdAsync(messageId, ct);
+        if (message is null || message.Scope != messageScope)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Reaction.MessageNotFound,
+                "Message was not found");
+        }
+
+        await using var transaction = await _unitOfWork.BeginAsync(ct);
+        var reaction = MessageReaction.Create(messageId, callerId, emoji);
+        if (reaction.IsFailure || reaction.Value is null)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Common.DomainRuleViolation,
+                reaction.Error ?? "Invalid reaction");
+        }
+
+        await _reactionRepository.AddAsync(reaction.Value, ct);
+        await transaction.CommitAsync(ct);
+
+        await scope.NotifyReactionAddedAsync(context, messageId, callerId, emoji, ct);
+
+        return ApplicationResponse<bool>.Ok(true);
+    }
+
+    public async Task<ApplicationResponse<bool>> RemoveAsync<TContext>(
+        IReactionScope<TContext> scope,
+        MessageScope messageScope,
+        MessageId messageId,
+        string emoji,
+        UserId callerId,
+        CancellationToken ct)
+        where TContext : SendScopeContext
+    {
+        var authResult = await scope.AuthorizeAsync(callerId, ct);
+        if (authResult is AuthorizationResult<TContext>.Denied denied)
+            return ApplicationResponse<bool>.Fail(denied.Error);
+
+        var context = ((AuthorizationResult<TContext>.Authorized)authResult).Context;
+
+        var message = await _messageRepository.GetByIdAsync(messageId, ct);
+        if (message is null || message.Scope != messageScope)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Reaction.MessageNotFound,
+                "Message was not found");
+        }
+
+        await using var transaction = await _unitOfWork.BeginAsync(ct);
+        await _reactionRepository.RemoveAsync(messageId, callerId, emoji, ct);
+        await transaction.CommitAsync(ct);
+
+        await scope.NotifyReactionRemovedAsync(context, messageId, callerId, emoji, ct);
+
+        return ApplicationResponse<bool>.Ok(true);
+    }
+
+    public async Task<ApplicationResponse<ReactionUsersResult>> GetUsersAsync<TContext>(
+        IReactionScope<TContext> scope,
+        MessageScope messageScope,
+        MessageId messageId,
+        string emoji,
+        string? rawCursor,
+        int? rawLimit,
+        UserId callerId,
+        CancellationToken ct)
+        where TContext : SendScopeContext
+    {
+        ReactionUsersCursor? cursor = null;
+        if (rawCursor is not null)
+        {
+            if (!ReactionUsersCursorCodec.TryParse(rawCursor, out var parsedCursor) || parsedCursor is null)
+            {
+                return ApplicationResponse<ReactionUsersResult>.Fail(
+                    ApplicationErrorCodes.Common.ValidationFailed,
+                    "Request validation failed",
+                    EndpointExtensions.SingleValidationError(
+                        nameof(rawCursor),
+                        ApplicationErrorCodes.Validation.InvalidFormat,
+                        "Cursor is invalid"));
+            }
+            cursor = parsedCursor;
+        }
+
+        var limit = Math.Clamp(rawLimit ?? 50, 1, 100);
+
+        var authResult = await scope.AuthorizeAsync(callerId, ct);
+        if (authResult is AuthorizationResult<TContext>.Denied denied)
+            return ApplicationResponse<ReactionUsersResult>.Fail(denied.Error);
+
+        var message = await _messageRepository.GetByIdAsync(messageId, ct);
+        if (message is null || message.Scope != messageScope)
+        {
+            return ApplicationResponse<ReactionUsersResult>.Fail(
+                ApplicationErrorCodes.Reaction.MessageNotFound,
+                "Message was not found");
+        }
+
+        var page = await _reactionRepository.GetReactionUsersAsync(
+            messageId, emoji, limit, cursor, ct);
+
+        var users = page.Users
+            .Select(u => new ReactionUserDto(u.UserId, u.Username, u.DisplayName))
+            .ToArray();
+
+        return ApplicationResponse<ReactionUsersResult>.Ok(new ReactionUsersResult(
+            MessageId: messageId.Value,
+            Emoji: emoji,
+            TotalCount: page.TotalCount,
+            Users: users,
+            NextCursor: page.NextCursor is null ? null : ReactionUsersCursorCodec.Encode(page.NextCursor)));
+    }
+}

--- a/src/Harmonie.Application/DependencyInjection.cs
+++ b/src/Harmonie.Application/DependencyInjection.cs
@@ -17,6 +17,7 @@ public static class DependencyInjection
         services.AddScoped<MessageAttachmentResolver>();
         services.AddScoped<LinkPreviewResolutionService>();
         services.AddScoped<MessageSendOrchestrator>();
+        services.AddScoped<ReactionOrchestrator>();
 
         services.AddAuthHandlers();
         services.AddGuildHandlers();

--- a/src/Harmonie.Application/Features/Channels/AddReaction/AddReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/AddReaction/AddReactionHandler.cs
@@ -1,5 +1,7 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.Reactions;
+using Harmonie.Application.Features.Channels.AddReaction;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.ValueObjects.Channels;

--- a/src/Harmonie.Application/Features/Channels/AddReaction/AddReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/AddReaction/AddReactionHandler.cs
@@ -1,9 +1,7 @@
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Channels;
-using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Domain.Entities.Messages;
-using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -15,29 +13,21 @@ public sealed record ChannelAddReactionInput(GuildChannelId ChannelId, MessageId
 
 public sealed class AddReactionHandler : IAuthenticatedHandler<ChannelAddReactionInput, bool>
 {
-    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
-
     private readonly IGuildChannelRepository _guildChannelRepository;
-    private readonly IMessageRepository _messageRepository;
-    private readonly IMessageReactionRepository _reactionRepository;
-    private readonly IUnitOfWork _unitOfWork;
     private readonly IReactionNotifier _reactionNotifier;
-    private readonly ILogger<AddReactionHandler> _logger;
+    private readonly ILogger<ChannelReactionScope> _scopeLogger;
+    private readonly ReactionOrchestrator _orchestrator;
 
     public AddReactionHandler(
         IGuildChannelRepository guildChannelRepository,
-        IMessageRepository messageRepository,
-        IMessageReactionRepository reactionRepository,
-        IUnitOfWork unitOfWork,
         IReactionNotifier reactionNotifier,
-        ILogger<AddReactionHandler> logger)
+        ILogger<ChannelReactionScope> scopeLogger,
+        ReactionOrchestrator orchestrator)
     {
         _guildChannelRepository = guildChannelRepository;
-        _messageRepository = messageRepository;
-        _reactionRepository = reactionRepository;
-        _unitOfWork = unitOfWork;
         _reactionNotifier = reactionNotifier;
-        _logger = logger;
+        _scopeLogger = scopeLogger;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<bool>> HandleAsync(
@@ -45,72 +35,15 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ChannelAddReactio
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(request.ChannelId, currentUserId, cancellationToken);
-        if (ctx is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.NotFound,
-                "Channel was not found");
-        }
+        var scope = new ChannelReactionScope(
+            request.ChannelId, _guildChannelRepository, _reactionNotifier, _scopeLogger);
 
-        if (ctx.Channel.Type != GuildChannelType.Text)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.NotText,
-                "Reactions can only be added in text channels");
-        }
-
-        if (ctx.CallerRole is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.AccessDenied,
-                "You do not have access to this channel");
-        }
-
-        var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        if (message is null || !message.Scope.Matches(request.ChannelId))
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Reaction.MessageNotFound,
-                "Message was not found");
-        }
-
-        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
-        var reaction = MessageReaction.Create(request.MessageId, currentUserId, request.Emoji);
-        if (reaction.IsFailure || reaction.Value is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Common.DomainRuleViolation,
-                reaction.Error ?? "Invalid reaction");
-        }
-
-        await _reactionRepository.AddAsync(reaction.Value, cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
-
-        await NotifyReactionAddedSafelyAsync(
-            new ChannelReactionAddedNotification(
-                request.MessageId,
-                request.ChannelId,
-                ctx.Channel.Name,
-                ctx.Channel.GuildId,
-                ctx.GuildName ?? string.Empty,
-                currentUserId,
-                ctx.CallerUsername ?? string.Empty,
-                ctx.CallerDisplayName,
-                request.Emoji));
-
-        return ApplicationResponse<bool>.Ok(true);
-    }
-
-    private async Task NotifyReactionAddedSafelyAsync(
-        ChannelReactionAddedNotification notification)
-    {
-        await BestEffortNotificationHelper.TryNotifyAsync(
-            token => _reactionNotifier.NotifyReactionAddedToChannelAsync(notification, token),
-            NotificationTimeout,
-            _logger,
-            "AddChannelReaction notification failed (best-effort). MessageId={MessageId}, ChannelId={ChannelId}",
-            notification.MessageId,
-            notification.ChannelId);
+        return await _orchestrator.AddAsync(
+            scope,
+            new MessageScope.Channel(request.ChannelId),
+            request.MessageId,
+            request.Emoji,
+            currentUserId,
+            cancellationToken);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/AddReaction/ChannelReactionScope.cs
+++ b/src/Harmonie.Application/Features/Channels/AddReaction/ChannelReactionScope.cs
@@ -1,0 +1,94 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Guilds;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging;
+
+namespace Harmonie.Application.Features.Channels.AddReaction;
+
+public sealed class ChannelReactionScope : IReactionScope<ChannelReactionScope.Context>
+{
+    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
+
+    public sealed record Context(
+        GuildChannelId ChannelId,
+        string ChannelName,
+        GuildId GuildId,
+        string GuildName,
+        string CallerUsername,
+        string CallerDisplayName) : SendScopeContext;
+
+    private readonly GuildChannelId _channelId;
+    private readonly IGuildChannelRepository _guildChannelRepository;
+    private readonly IReactionNotifier _reactionNotifier;
+    private readonly ILogger<ChannelReactionScope> _logger;
+
+    public ChannelReactionScope(
+        GuildChannelId channelId,
+        IGuildChannelRepository guildChannelRepository,
+        IReactionNotifier reactionNotifier,
+        ILogger<ChannelReactionScope> logger)
+    {
+        _channelId = channelId;
+        _guildChannelRepository = guildChannelRepository;
+        _reactionNotifier = reactionNotifier;
+        _logger = logger;
+    }
+
+    public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
+    {
+        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(_channelId, caller, ct);
+        if (ctx is null)
+            return Denied(ApplicationErrorCodes.Channel.NotFound, "Channel was not found");
+
+        if (ctx.Channel.Type != GuildChannelType.Text)
+            return Denied(ApplicationErrorCodes.Channel.NotText, "Reactions can only be used in text channels");
+
+        if (ctx.CallerRole is null)
+            return Denied(ApplicationErrorCodes.Channel.AccessDenied, "You do not have access to this channel");
+
+        return new AuthorizationResult<Context>.Authorized(new Context(
+            _channelId, ctx.Channel.Name, ctx.Channel.GuildId,
+            ctx.GuildName ?? string.Empty,
+            ctx.CallerUsername ?? string.Empty,
+            ctx.CallerDisplayName ?? string.Empty));
+    }
+
+    public async Task NotifyReactionAddedAsync(
+        Context context, MessageId messageId, UserId userId, string emoji, CancellationToken ct)
+    {
+        var notification = new ChannelReactionAddedNotification(
+            messageId, context.ChannelId, context.ChannelName,
+            context.GuildId, context.GuildName,
+            userId, context.CallerUsername, context.CallerDisplayName, emoji);
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            token => _reactionNotifier.NotifyReactionAddedToChannelAsync(notification, token),
+            NotificationTimeout, _logger,
+            "AddChannelReaction notification failed (best-effort). MessageId={MessageId}, ChannelId={ChannelId}",
+            notification.MessageId, notification.ChannelId);
+    }
+
+    public async Task NotifyReactionRemovedAsync(
+        Context context, MessageId messageId, UserId userId, string emoji, CancellationToken ct)
+    {
+        var notification = new ChannelReactionRemovedNotification(
+            messageId, context.ChannelId, context.ChannelName,
+            context.GuildId, context.GuildName,
+            userId, context.CallerUsername, context.CallerDisplayName, emoji);
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            token => _reactionNotifier.NotifyReactionRemovedFromChannelAsync(notification, token),
+            NotificationTimeout, _logger,
+            "RemoveChannelReaction notification failed (best-effort). MessageId={MessageId}, ChannelId={ChannelId}",
+            notification.MessageId, notification.ChannelId);
+    }
+
+    private static AuthorizationResult<Context> Denied(string code, string detail)
+        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
+}

--- a/src/Harmonie.Application/Features/Channels/GetReactionUsers/GetReactionUsersHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/GetReactionUsers/GetReactionUsersHandler.cs
@@ -1,6 +1,6 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
-using Harmonie.Application.Features.Channels.AddReaction;
+using Harmonie.Application.Features.Channels.Reactions;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.ValueObjects.Channels;

--- a/src/Harmonie.Application/Features/Channels/GetReactionUsers/GetReactionUsersHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/GetReactionUsers/GetReactionUsersHandler.cs
@@ -1,11 +1,12 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.AddReaction;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging;
 
 namespace Harmonie.Application.Features.Channels.GetReactionUsers;
 
@@ -18,21 +19,21 @@ public sealed record GetChannelReactionUsersInput(
 
 public sealed class GetReactionUsersHandler : IAuthenticatedHandler<GetChannelReactionUsersInput, GetReactionUsersResponse>
 {
-    private const int DefaultLimit = 50;
-    private const int MaxLimit = 100;
-
     private readonly IGuildChannelRepository _guildChannelRepository;
-    private readonly IMessageRepository _messageRepository;
-    private readonly IMessageReactionRepository _reactionRepository;
+    private readonly IReactionNotifier _reactionNotifier;
+    private readonly ILogger<ChannelReactionScope> _scopeLogger;
+    private readonly ReactionOrchestrator _orchestrator;
 
     public GetReactionUsersHandler(
         IGuildChannelRepository guildChannelRepository,
-        IMessageRepository messageRepository,
-        IMessageReactionRepository reactionRepository)
+        IReactionNotifier reactionNotifier,
+        ILogger<ChannelReactionScope> scopeLogger,
+        ReactionOrchestrator orchestrator)
     {
         _guildChannelRepository = guildChannelRepository;
-        _messageRepository = messageRepository;
-        _reactionRepository = reactionRepository;
+        _reactionNotifier = reactionNotifier;
+        _scopeLogger = scopeLogger;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<GetReactionUsersResponse>> HandleAsync(
@@ -40,73 +41,27 @@ public sealed class GetReactionUsersHandler : IAuthenticatedHandler<GetChannelRe
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        ReactionUsersCursor? cursor = null;
-        if (request.Cursor is not null)
-        {
-            if (!ReactionUsersCursorCodec.TryParse(request.Cursor, out var parsedCursor) || parsedCursor is null)
-            {
-                return ApplicationResponse<GetReactionUsersResponse>.Fail(
-                    ApplicationErrorCodes.Common.ValidationFailed,
-                    "Request validation failed",
-                    EndpointExtensions.SingleValidationError(
-                        nameof(request.Cursor),
-                        ApplicationErrorCodes.Validation.InvalidFormat,
-                        "Cursor is invalid"));
-            }
+        var scope = new ChannelReactionScope(
+            request.ChannelId, _guildChannelRepository, _reactionNotifier, _scopeLogger);
 
-            cursor = parsedCursor;
-        }
-
-        var limit = Math.Clamp(request.Limit ?? DefaultLimit, 1, MaxLimit);
-
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(request.ChannelId, currentUserId, cancellationToken);
-        if (ctx is null)
-        {
-            return ApplicationResponse<GetReactionUsersResponse>.Fail(
-                ApplicationErrorCodes.Channel.NotFound,
-                "Channel was not found");
-        }
-
-        if (ctx.Channel.Type != GuildChannelType.Text)
-        {
-            return ApplicationResponse<GetReactionUsersResponse>.Fail(
-                ApplicationErrorCodes.Channel.NotText,
-                "Reactions can only be viewed in text channels");
-        }
-
-        if (ctx.CallerRole is null)
-        {
-            return ApplicationResponse<GetReactionUsersResponse>.Fail(
-                ApplicationErrorCodes.Channel.AccessDenied,
-                "You do not have access to this channel");
-        }
-
-        var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        if (message is null || !message.Scope.Matches(request.ChannelId))
-        {
-            return ApplicationResponse<GetReactionUsersResponse>.Fail(
-                ApplicationErrorCodes.Reaction.MessageNotFound,
-                "Message was not found");
-        }
-
-        var page = await _reactionRepository.GetReactionUsersAsync(
+        var result = await _orchestrator.GetUsersAsync(
+            scope,
+            new MessageScope.Channel(request.ChannelId),
             request.MessageId,
             request.Emoji,
-            limit,
-            cursor,
+            request.Cursor,
+            request.Limit,
+            currentUserId,
             cancellationToken);
 
-        var users = page.Users
-            .Select(u => new ReactionUserDto(u.UserId, u.Username, u.DisplayName))
-            .ToArray();
+        if (!result.Success)
+            return ApplicationResponse<GetReactionUsersResponse>.Fail(result.Error!);
 
-        var payload = new GetReactionUsersResponse(
-            MessageId: request.MessageId.Value,
-            Emoji: request.Emoji,
-            TotalCount: page.TotalCount,
-            Users: users,
-            NextCursor: page.NextCursor is null ? null : ReactionUsersCursorCodec.Encode(page.NextCursor));
-
-        return ApplicationResponse<GetReactionUsersResponse>.Ok(payload);
+        return ApplicationResponse<GetReactionUsersResponse>.Ok(new GetReactionUsersResponse(
+            result.Data!.MessageId,
+            result.Data.Emoji,
+            result.Data.TotalCount,
+            result.Data.Users,
+            result.Data.NextCursor));
     }
 }

--- a/src/Harmonie.Application/Features/Channels/Reactions/ChannelReactionScope.cs
+++ b/src/Harmonie.Application/Features/Channels/Reactions/ChannelReactionScope.cs
@@ -9,7 +9,7 @@ using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
 using Microsoft.Extensions.Logging;
 
-namespace Harmonie.Application.Features.Channels.AddReaction;
+namespace Harmonie.Application.Features.Channels.Reactions;
 
 public sealed class ChannelReactionScope : IReactionScope<ChannelReactionScope.Context>
 {
@@ -21,7 +21,7 @@ public sealed class ChannelReactionScope : IReactionScope<ChannelReactionScope.C
         GuildId GuildId,
         string GuildName,
         string CallerUsername,
-        string CallerDisplayName) : SendScopeContext;
+        string CallerDisplayName) : ScopeContext;
 
     private readonly GuildChannelId _channelId;
     private readonly IGuildChannelRepository _guildChannelRepository;

--- a/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionHandler.cs
@@ -1,8 +1,8 @@
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.AddReaction;
 using Harmonie.Application.Interfaces.Channels;
-using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -14,29 +14,21 @@ public sealed record ChannelRemoveReactionInput(GuildChannelId ChannelId, Messag
 
 public sealed class RemoveReactionHandler : IAuthenticatedHandler<ChannelRemoveReactionInput, bool>
 {
-    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
-
     private readonly IGuildChannelRepository _guildChannelRepository;
-    private readonly IMessageRepository _messageRepository;
-    private readonly IMessageReactionRepository _reactionRepository;
-    private readonly IUnitOfWork _unitOfWork;
     private readonly IReactionNotifier _reactionNotifier;
-    private readonly ILogger<RemoveReactionHandler> _logger;
+    private readonly ILogger<ChannelReactionScope> _scopeLogger;
+    private readonly ReactionOrchestrator _orchestrator;
 
     public RemoveReactionHandler(
         IGuildChannelRepository guildChannelRepository,
-        IMessageRepository messageRepository,
-        IMessageReactionRepository reactionRepository,
-        IUnitOfWork unitOfWork,
         IReactionNotifier reactionNotifier,
-        ILogger<RemoveReactionHandler> logger)
+        ILogger<ChannelReactionScope> scopeLogger,
+        ReactionOrchestrator orchestrator)
     {
         _guildChannelRepository = guildChannelRepository;
-        _messageRepository = messageRepository;
-        _reactionRepository = reactionRepository;
-        _unitOfWork = unitOfWork;
         _reactionNotifier = reactionNotifier;
-        _logger = logger;
+        _scopeLogger = scopeLogger;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<bool>> HandleAsync(
@@ -44,64 +36,15 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ChannelRemoveR
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(request.ChannelId, currentUserId, cancellationToken);
-        if (ctx is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.NotFound,
-                "Channel was not found");
-        }
+        var scope = new ChannelReactionScope(
+            request.ChannelId, _guildChannelRepository, _reactionNotifier, _scopeLogger);
 
-        if (ctx.Channel.Type != GuildChannelType.Text)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.NotText,
-                "Reactions can only be removed from text channels");
-        }
-
-        if (ctx.CallerRole is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.AccessDenied,
-                "You do not have access to this channel");
-        }
-
-        var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        if (message is null || !message.Scope.Matches(request.ChannelId))
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Reaction.MessageNotFound,
-                "Message was not found");
-        }
-
-        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
-        await _reactionRepository.RemoveAsync(request.MessageId, currentUserId, request.Emoji, cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
-
-        await NotifyReactionRemovedSafelyAsync(
-            new ChannelReactionRemovedNotification(
-                request.MessageId,
-                request.ChannelId,
-                ctx.Channel.Name,
-                ctx.Channel.GuildId,
-                ctx.GuildName ?? string.Empty,
-                currentUserId,
-                ctx.CallerUsername ?? string.Empty,
-                ctx.CallerDisplayName,
-                request.Emoji));
-
-        return ApplicationResponse<bool>.Ok(true);
-    }
-
-    private async Task NotifyReactionRemovedSafelyAsync(
-        ChannelReactionRemovedNotification notification)
-    {
-        await BestEffortNotificationHelper.TryNotifyAsync(
-            token => _reactionNotifier.NotifyReactionRemovedFromChannelAsync(notification, token),
-            NotificationTimeout,
-            _logger,
-            "RemoveChannelReaction notification failed (best-effort). MessageId={MessageId}, ChannelId={ChannelId}",
-            notification.MessageId,
-            notification.ChannelId);
+        return await _orchestrator.RemoveAsync(
+            scope,
+            new MessageScope.Channel(request.ChannelId),
+            request.MessageId,
+            request.Emoji,
+            currentUserId,
+            cancellationToken);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/RemoveReaction/RemoveReactionHandler.cs
@@ -1,6 +1,6 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
-using Harmonie.Application.Features.Channels.AddReaction;
+using Harmonie.Application.Features.Channels.Reactions;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.ValueObjects.Channels;

--- a/src/Harmonie.Application/Features/Channels/SendMessage/ChannelSendMessageScope.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/ChannelSendMessageScope.cs
@@ -24,7 +24,7 @@ public sealed class ChannelSendMessageScope : ISendMessageScope<ChannelSendMessa
         GuildId GuildId,
         string GuildName,
         string CallerUsername,
-        string CallerDisplayName) : SendScopeContext;
+        string CallerDisplayName) : ScopeContext;
 
     private readonly GuildChannelId _channelId;
     private readonly IGuildChannelRepository _guildChannelRepository;

--- a/src/Harmonie.Application/Features/Conversations/AddReaction/AddReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/AddReaction/AddReactionHandler.cs
@@ -1,5 +1,7 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Conversations.Reactions;
+using Harmonie.Application.Features.Conversations.AddReaction;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;

--- a/src/Harmonie.Application/Features/Conversations/AddReaction/AddReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/AddReaction/AddReactionHandler.cs
@@ -1,8 +1,7 @@
 using Harmonie.Application.Common;
-using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -14,29 +13,21 @@ public sealed record ConversationAddReactionInput(ConversationId ConversationId,
 
 public sealed class AddReactionHandler : IAuthenticatedHandler<ConversationAddReactionInput, bool>
 {
-    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
-
     private readonly IConversationRepository _conversationRepository;
-    private readonly IMessageRepository _messageRepository;
-    private readonly IMessageReactionRepository _reactionRepository;
-    private readonly IUnitOfWork _unitOfWork;
     private readonly IReactionNotifier _reactionNotifier;
-    private readonly ILogger<AddReactionHandler> _logger;
+    private readonly ILogger<ConversationReactionScope> _scopeLogger;
+    private readonly ReactionOrchestrator _orchestrator;
 
     public AddReactionHandler(
         IConversationRepository conversationRepository,
-        IMessageRepository messageRepository,
-        IMessageReactionRepository reactionRepository,
-        IUnitOfWork unitOfWork,
         IReactionNotifier reactionNotifier,
-        ILogger<AddReactionHandler> logger)
+        ILogger<ConversationReactionScope> scopeLogger,
+        ReactionOrchestrator orchestrator)
     {
         _conversationRepository = conversationRepository;
-        _messageRepository = messageRepository;
-        _reactionRepository = reactionRepository;
-        _unitOfWork = unitOfWork;
         _reactionNotifier = reactionNotifier;
-        _logger = logger;
+        _scopeLogger = scopeLogger;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<bool>> HandleAsync(
@@ -44,63 +35,15 @@ public sealed class AddReactionHandler : IAuthenticatedHandler<ConversationAddRe
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(request.ConversationId, currentUserId, cancellationToken);
-        if (access is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Conversation.NotFound,
-                "Conversation was not found");
-        }
-        if (access.Participant is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Conversation.AccessDenied,
-                "You do not have access to this conversation");
-        }
+        var scope = new ConversationReactionScope(
+            request.ConversationId, _conversationRepository, _reactionNotifier, _scopeLogger);
 
-        var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        if (message is null || !message.Scope.Matches(request.ConversationId))
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Reaction.MessageNotFound,
-                "Message was not found");
-        }
-
-        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
-        var reaction = MessageReaction.Create(request.MessageId, currentUserId, request.Emoji);
-        if (reaction.IsFailure || reaction.Value is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Common.DomainRuleViolation,
-                reaction.Error ?? "Invalid reaction");
-        }
-
-        await _reactionRepository.AddAsync(reaction.Value, cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
-
-        await NotifyReactionAddedSafelyAsync(
-            new ConversationReactionAddedNotification(
-                request.MessageId,
-                request.ConversationId,
-                access.Conversation.Name,
-                access.Conversation.Type.ToString(),
-                currentUserId,
-                access.CallerUsername ?? string.Empty,
-                access.CallerDisplayName,
-                request.Emoji));
-
-        return ApplicationResponse<bool>.Ok(true);
-    }
-
-    private async Task NotifyReactionAddedSafelyAsync(
-        ConversationReactionAddedNotification notification)
-    {
-        await BestEffortNotificationHelper.TryNotifyAsync(
-            token => _reactionNotifier.NotifyReactionAddedToConversationAsync(notification, token),
-            NotificationTimeout,
-            _logger,
-            "AddConversationReaction notification failed (best-effort). MessageId={MessageId}, ConversationId={ConversationId}",
-            notification.MessageId,
-            notification.ConversationId);
+        return await _orchestrator.AddAsync(
+            scope,
+            new MessageScope.Conversation(request.ConversationId),
+            request.MessageId,
+            request.Emoji,
+            currentUserId,
+            cancellationToken);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/AddReaction/ConversationReactionScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/AddReaction/ConversationReactionScope.cs
@@ -1,0 +1,88 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.Entities.Conversations;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging;
+
+namespace Harmonie.Application.Features.Conversations.AddReaction;
+
+public sealed class ConversationReactionScope : IReactionScope<ConversationReactionScope.Context>
+{
+    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
+
+    public sealed record Context(
+        ConversationId ConversationId,
+        string? ConversationName,
+        ConversationType ConversationType,
+        string CallerUsername,
+        string CallerDisplayName) : SendScopeContext;
+
+    private readonly ConversationId _conversationId;
+    private readonly IConversationRepository _conversationRepository;
+    private readonly IReactionNotifier _reactionNotifier;
+    private readonly ILogger<ConversationReactionScope> _logger;
+
+    public ConversationReactionScope(
+        ConversationId conversationId,
+        IConversationRepository conversationRepository,
+        IReactionNotifier reactionNotifier,
+        ILogger<ConversationReactionScope> logger)
+    {
+        _conversationId = conversationId;
+        _conversationRepository = conversationRepository;
+        _reactionNotifier = reactionNotifier;
+        _logger = logger;
+    }
+
+    public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
+    {
+        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(_conversationId, caller, ct);
+        if (access is null)
+            return Denied(ApplicationErrorCodes.Conversation.NotFound, "Conversation was not found");
+
+        if (access.Participant is null)
+            return Denied(ApplicationErrorCodes.Conversation.AccessDenied, "You do not have access to this conversation");
+
+        return new AuthorizationResult<Context>.Authorized(new Context(
+            _conversationId, access.Conversation.Name, access.Conversation.Type,
+            access.CallerUsername ?? string.Empty,
+            access.CallerDisplayName ?? string.Empty));
+    }
+
+    public async Task NotifyReactionAddedAsync(
+        Context context, MessageId messageId, UserId userId, string emoji, CancellationToken ct)
+    {
+        var notification = new ConversationReactionAddedNotification(
+            messageId, context.ConversationId, context.ConversationName,
+            context.ConversationType.ToString(),
+            userId, context.CallerUsername, context.CallerDisplayName, emoji);
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            token => _reactionNotifier.NotifyReactionAddedToConversationAsync(notification, token),
+            NotificationTimeout, _logger,
+            "AddConversationReaction notification failed (best-effort). MessageId={MessageId}, ConversationId={ConversationId}",
+            notification.MessageId, notification.ConversationId);
+    }
+
+    public async Task NotifyReactionRemovedAsync(
+        Context context, MessageId messageId, UserId userId, string emoji, CancellationToken ct)
+    {
+        var notification = new ConversationReactionRemovedNotification(
+            messageId, context.ConversationId, context.ConversationName,
+            context.ConversationType.ToString(),
+            userId, context.CallerUsername, context.CallerDisplayName, emoji);
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            token => _reactionNotifier.NotifyReactionRemovedFromConversationAsync(notification, token),
+            NotificationTimeout, _logger,
+            "RemoveConversationReaction notification failed (best-effort). MessageId={MessageId}, ConversationId={ConversationId}",
+            notification.MessageId, notification.ConversationId);
+    }
+
+    private static AuthorizationResult<Context> Denied(string code, string detail)
+        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
+}

--- a/src/Harmonie.Application/Features/Conversations/GetReactionUsers/GetReactionUsersHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetReactionUsers/GetReactionUsersHandler.cs
@@ -1,10 +1,12 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Conversations.AddReaction;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging;
 
 namespace Harmonie.Application.Features.Conversations.GetReactionUsers;
 
@@ -17,21 +19,21 @@ public sealed record GetConversationReactionUsersInput(
 
 public sealed class GetReactionUsersHandler : IAuthenticatedHandler<GetConversationReactionUsersInput, GetReactionUsersResponse>
 {
-    private const int DefaultLimit = 50;
-    private const int MaxLimit = 100;
-
     private readonly IConversationRepository _conversationRepository;
-    private readonly IMessageRepository _messageRepository;
-    private readonly IMessageReactionRepository _reactionRepository;
+    private readonly IReactionNotifier _reactionNotifier;
+    private readonly ILogger<ConversationReactionScope> _scopeLogger;
+    private readonly ReactionOrchestrator _orchestrator;
 
     public GetReactionUsersHandler(
         IConversationRepository conversationRepository,
-        IMessageRepository messageRepository,
-        IMessageReactionRepository reactionRepository)
+        IReactionNotifier reactionNotifier,
+        ILogger<ConversationReactionScope> scopeLogger,
+        ReactionOrchestrator orchestrator)
     {
         _conversationRepository = conversationRepository;
-        _messageRepository = messageRepository;
-        _reactionRepository = reactionRepository;
+        _reactionNotifier = reactionNotifier;
+        _scopeLogger = scopeLogger;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<GetReactionUsersResponse>> HandleAsync(
@@ -39,65 +41,27 @@ public sealed class GetReactionUsersHandler : IAuthenticatedHandler<GetConversat
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        ReactionUsersCursor? cursor = null;
-        if (request.Cursor is not null)
-        {
-            if (!ReactionUsersCursorCodec.TryParse(request.Cursor, out var parsedCursor) || parsedCursor is null)
-            {
-                return ApplicationResponse<GetReactionUsersResponse>.Fail(
-                    ApplicationErrorCodes.Common.ValidationFailed,
-                    "Request validation failed",
-                    EndpointExtensions.SingleValidationError(
-                        nameof(request.Cursor),
-                        ApplicationErrorCodes.Validation.InvalidFormat,
-                        "Cursor is invalid"));
-            }
+        var scope = new ConversationReactionScope(
+            request.ConversationId, _conversationRepository, _reactionNotifier, _scopeLogger);
 
-            cursor = parsedCursor;
-        }
-
-        var limit = Math.Clamp(request.Limit ?? DefaultLimit, 1, MaxLimit);
-
-        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(request.ConversationId, currentUserId, cancellationToken);
-        if (access is null)
-        {
-            return ApplicationResponse<GetReactionUsersResponse>.Fail(
-                ApplicationErrorCodes.Conversation.NotFound,
-                "Conversation was not found");
-        }
-        if (access.Participant is null)
-        {
-            return ApplicationResponse<GetReactionUsersResponse>.Fail(
-                ApplicationErrorCodes.Conversation.AccessDenied,
-                "You do not have access to this conversation");
-        }
-
-        var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        if (message is null || !message.Scope.Matches(request.ConversationId))
-        {
-            return ApplicationResponse<GetReactionUsersResponse>.Fail(
-                ApplicationErrorCodes.Reaction.MessageNotFound,
-                "Message was not found");
-        }
-
-        var page = await _reactionRepository.GetReactionUsersAsync(
+        var result = await _orchestrator.GetUsersAsync(
+            scope,
+            new MessageScope.Conversation(request.ConversationId),
             request.MessageId,
             request.Emoji,
-            limit,
-            cursor,
+            request.Cursor,
+            request.Limit,
+            currentUserId,
             cancellationToken);
 
-        var users = page.Users
-            .Select(u => new ReactionUserDto(u.UserId, u.Username, u.DisplayName))
-            .ToArray();
+        if (!result.Success)
+            return ApplicationResponse<GetReactionUsersResponse>.Fail(result.Error!);
 
-        var payload = new GetReactionUsersResponse(
-            MessageId: request.MessageId.Value,
-            Emoji: request.Emoji,
-            TotalCount: page.TotalCount,
-            Users: users,
-            NextCursor: page.NextCursor is null ? null : ReactionUsersCursorCodec.Encode(page.NextCursor));
-
-        return ApplicationResponse<GetReactionUsersResponse>.Ok(payload);
+        return ApplicationResponse<GetReactionUsersResponse>.Ok(new GetReactionUsersResponse(
+            result.Data!.MessageId,
+            result.Data.Emoji,
+            result.Data.TotalCount,
+            result.Data.Users,
+            result.Data.NextCursor));
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/GetReactionUsers/GetReactionUsersHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetReactionUsers/GetReactionUsersHandler.cs
@@ -1,6 +1,6 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
-using Harmonie.Application.Features.Conversations.AddReaction;
+using Harmonie.Application.Features.Conversations.Reactions;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;

--- a/src/Harmonie.Application/Features/Conversations/Reactions/ConversationReactionScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/Reactions/ConversationReactionScope.cs
@@ -8,7 +8,7 @@ using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
 using Microsoft.Extensions.Logging;
 
-namespace Harmonie.Application.Features.Conversations.AddReaction;
+namespace Harmonie.Application.Features.Conversations.Reactions;
 
 public sealed class ConversationReactionScope : IReactionScope<ConversationReactionScope.Context>
 {
@@ -19,7 +19,7 @@ public sealed class ConversationReactionScope : IReactionScope<ConversationReact
         string? ConversationName,
         ConversationType ConversationType,
         string CallerUsername,
-        string CallerDisplayName) : SendScopeContext;
+        string CallerDisplayName) : ScopeContext;
 
     private readonly ConversationId _conversationId;
     private readonly IConversationRepository _conversationRepository;

--- a/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionHandler.cs
@@ -1,5 +1,6 @@
 using Harmonie.Application.Common;
-using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Conversations.AddReaction;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
@@ -13,29 +14,21 @@ public sealed record ConversationRemoveReactionInput(ConversationId Conversation
 
 public sealed class RemoveReactionHandler : IAuthenticatedHandler<ConversationRemoveReactionInput, bool>
 {
-    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
-
     private readonly IConversationRepository _conversationRepository;
-    private readonly IMessageRepository _messageRepository;
-    private readonly IMessageReactionRepository _reactionRepository;
-    private readonly IUnitOfWork _unitOfWork;
     private readonly IReactionNotifier _reactionNotifier;
-    private readonly ILogger<RemoveReactionHandler> _logger;
+    private readonly ILogger<ConversationReactionScope> _scopeLogger;
+    private readonly ReactionOrchestrator _orchestrator;
 
     public RemoveReactionHandler(
         IConversationRepository conversationRepository,
-        IMessageRepository messageRepository,
-        IMessageReactionRepository reactionRepository,
-        IUnitOfWork unitOfWork,
         IReactionNotifier reactionNotifier,
-        ILogger<RemoveReactionHandler> logger)
+        ILogger<ConversationReactionScope> scopeLogger,
+        ReactionOrchestrator orchestrator)
     {
         _conversationRepository = conversationRepository;
-        _messageRepository = messageRepository;
-        _reactionRepository = reactionRepository;
-        _unitOfWork = unitOfWork;
         _reactionNotifier = reactionNotifier;
-        _logger = logger;
+        _scopeLogger = scopeLogger;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<bool>> HandleAsync(
@@ -43,55 +36,15 @@ public sealed class RemoveReactionHandler : IAuthenticatedHandler<ConversationRe
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(request.ConversationId, currentUserId, cancellationToken);
-        if (access is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Conversation.NotFound,
-                "Conversation was not found");
-        }
-        if (access.Participant is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Conversation.AccessDenied,
-                "You do not have access to this conversation");
-        }
+        var scope = new ConversationReactionScope(
+            request.ConversationId, _conversationRepository, _reactionNotifier, _scopeLogger);
 
-        var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        if (message is null || !message.Scope.Matches(request.ConversationId))
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Reaction.MessageNotFound,
-                "Message was not found");
-        }
-
-        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
-        await _reactionRepository.RemoveAsync(request.MessageId, currentUserId, request.Emoji, cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
-
-        await NotifyReactionRemovedSafelyAsync(
-            new ConversationReactionRemovedNotification(
-                request.MessageId,
-                request.ConversationId,
-                access.Conversation.Name,
-                access.Conversation.Type.ToString(),
-                currentUserId,
-                access.CallerUsername ?? string.Empty,
-                access.CallerDisplayName,
-                request.Emoji));
-
-        return ApplicationResponse<bool>.Ok(true);
-    }
-
-    private async Task NotifyReactionRemovedSafelyAsync(
-        ConversationReactionRemovedNotification notification)
-    {
-        await BestEffortNotificationHelper.TryNotifyAsync(
-            token => _reactionNotifier.NotifyReactionRemovedFromConversationAsync(notification, token),
-            NotificationTimeout,
-            _logger,
-            "RemoveConversationReaction notification failed (best-effort). MessageId={MessageId}, ConversationId={ConversationId}",
-            notification.MessageId,
-            notification.ConversationId);
+        return await _orchestrator.RemoveAsync(
+            scope,
+            new MessageScope.Conversation(request.ConversationId),
+            request.MessageId,
+            request.Emoji,
+            currentUserId,
+            cancellationToken);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/RemoveReaction/RemoveReactionHandler.cs
@@ -1,6 +1,6 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
-using Harmonie.Application.Features.Conversations.AddReaction;
+using Harmonie.Application.Features.Conversations.Reactions;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/ConversationSendMessageScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/ConversationSendMessageScope.cs
@@ -23,7 +23,7 @@ public sealed class ConversationSendMessageScope : ISendMessageScope<Conversatio
         ConversationType ConversationType,
         IReadOnlyList<ConversationParticipant> AllParticipants,
         string CallerUsername,
-        string CallerDisplayName) : SendScopeContext;
+        string CallerDisplayName) : ScopeContext;
 
     private readonly ConversationId _conversationId;
     private readonly IConversationRepository _conversationRepository;

--- a/tests/Harmonie.Application.Tests/Messages/AddChannelReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/AddChannelReactionHandlerTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
 using Harmonie.Application.Features.Channels.AddReaction;
+using Harmonie.Application.Features.Channels.Reactions;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;

--- a/tests/Harmonie.Application.Tests/Messages/AddChannelReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/AddChannelReactionHandlerTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
 using Harmonie.Application.Features.Channels.AddReaction;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
@@ -29,6 +30,7 @@ public sealed class AddChannelReactionHandlerTests
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IReactionNotifier> _reactionNotifierMock;
+    private readonly ReactionOrchestrator _orchestrator;
     private readonly AddReactionHandler _handler;
 
     public AddChannelReactionHandlerTests()
@@ -46,13 +48,16 @@ public sealed class AddChannelReactionHandlerTests
             .Setup(x => x.NotifyReactionAddedToChannelAsync(It.IsAny<ChannelReactionAddedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        _handler = new AddReactionHandler(
-            _guildChannelRepositoryMock.Object,
+        _orchestrator = new ReactionOrchestrator(
             _messageRepositoryMock.Object,
             _reactionRepositoryMock.Object,
-            _unitOfWorkMock.Object,
+            _unitOfWorkMock.Object);
+
+        _handler = new AddReactionHandler(
+            _guildChannelRepositoryMock.Object,
             _reactionNotifierMock.Object,
-            NullLogger<AddReactionHandler>.Instance);
+            NullLogger<ChannelReactionScope>.Instance,
+            _orchestrator);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/AddConversationReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/AddConversationReactionHandlerTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
 using Harmonie.Application.Features.Conversations.AddReaction;
+using Harmonie.Application.Features.Conversations.Reactions;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;

--- a/tests/Harmonie.Application.Tests/Messages/AddConversationReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/AddConversationReactionHandlerTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
 using Harmonie.Application.Features.Conversations.AddReaction;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
@@ -27,6 +28,7 @@ public sealed class AddConversationReactionHandlerTests
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IReactionNotifier> _reactionNotifierMock;
+    private readonly ReactionOrchestrator _orchestrator;
     private readonly AddReactionHandler _handler;
 
     public AddConversationReactionHandlerTests()
@@ -44,13 +46,16 @@ public sealed class AddConversationReactionHandlerTests
             .Setup(x => x.NotifyReactionAddedToConversationAsync(It.IsAny<ConversationReactionAddedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        _handler = new AddReactionHandler(
-            _conversationRepositoryMock.Object,
+        _orchestrator = new ReactionOrchestrator(
             _messageRepositoryMock.Object,
             _reactionRepositoryMock.Object,
-            _unitOfWorkMock.Object,
+            _unitOfWorkMock.Object);
+
+        _handler = new AddReactionHandler(
+            _conversationRepositoryMock.Object,
             _reactionNotifierMock.Object,
-            NullLogger<AddReactionHandler>.Instance);
+            NullLogger<ConversationReactionScope>.Instance,
+            _orchestrator);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/GetChannelReactionUsersHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetChannelReactionUsersHandlerTests.cs
@@ -1,7 +1,11 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Channels.GetReactionUsers;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.AddReaction;
 using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Enums;
@@ -9,6 +13,7 @@ using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
 using Moq;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Harmonie.Application.Tests.Messages;
@@ -18,6 +23,9 @@ public sealed class GetChannelReactionUsersHandlerTests
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IMessageRepository> _messageRepositoryMock;
     private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IReactionNotifier> _reactionNotifierMock;
+    private readonly ReactionOrchestrator _orchestrator;
     private readonly GetReactionUsersHandler _handler;
 
     public GetChannelReactionUsersHandlerTests()
@@ -25,11 +33,19 @@ public sealed class GetChannelReactionUsersHandlerTests
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
         _messageRepositoryMock = new Mock<IMessageRepository>();
         _reactionRepositoryMock = new Mock<IMessageReactionRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _reactionNotifierMock = new Mock<IReactionNotifier>();
+
+        _orchestrator = new ReactionOrchestrator(
+            _messageRepositoryMock.Object,
+            _reactionRepositoryMock.Object,
+            _unitOfWorkMock.Object);
 
         _handler = new GetReactionUsersHandler(
             _guildChannelRepositoryMock.Object,
-            _messageRepositoryMock.Object,
-            _reactionRepositoryMock.Object);
+            _reactionNotifierMock.Object,
+            NullLogger<ChannelReactionScope>.Instance,
+            _orchestrator);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/GetChannelReactionUsersHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetChannelReactionUsersHandlerTests.cs
@@ -1,9 +1,9 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.Reactions;
 using Harmonie.Application.Features.Channels.GetReactionUsers;
-using Harmonie.Application.Common.Messages;
-using Harmonie.Application.Features.Channels.AddReaction;
+using Harmonie.Application.Features.Channels.Reactions;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;

--- a/tests/Harmonie.Application.Tests/Messages/GetChannelReactionUsersHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetChannelReactionUsersHandlerTests.cs
@@ -3,7 +3,6 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Channels.Reactions;
 using Harmonie.Application.Features.Channels.GetReactionUsers;
-using Harmonie.Application.Features.Channels.Reactions;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;

--- a/tests/Harmonie.Application.Tests/Messages/GetConversationReactionUsersHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetConversationReactionUsersHandlerTests.cs
@@ -1,9 +1,9 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Conversations.Reactions;
 using Harmonie.Application.Features.Conversations.GetReactionUsers;
-using Harmonie.Application.Common.Messages;
-using Harmonie.Application.Features.Conversations.AddReaction;
+using Harmonie.Application.Features.Conversations.Reactions;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;

--- a/tests/Harmonie.Application.Tests/Messages/GetConversationReactionUsersHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetConversationReactionUsersHandlerTests.cs
@@ -3,7 +3,6 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Conversations.Reactions;
 using Harmonie.Application.Features.Conversations.GetReactionUsers;
-using Harmonie.Application.Features.Conversations.Reactions;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;

--- a/tests/Harmonie.Application.Tests/Messages/GetConversationReactionUsersHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetConversationReactionUsersHandlerTests.cs
@@ -1,13 +1,18 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Conversations.GetReactionUsers;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Conversations.AddReaction;
 using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
 using Moq;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Harmonie.Application.Tests.Messages;
@@ -17,6 +22,9 @@ public sealed class GetConversationReactionUsersHandlerTests
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IMessageRepository> _messageRepositoryMock;
     private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IReactionNotifier> _reactionNotifierMock;
+    private readonly ReactionOrchestrator _orchestrator;
     private readonly GetReactionUsersHandler _handler;
 
     public GetConversationReactionUsersHandlerTests()
@@ -24,11 +32,19 @@ public sealed class GetConversationReactionUsersHandlerTests
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _messageRepositoryMock = new Mock<IMessageRepository>();
         _reactionRepositoryMock = new Mock<IMessageReactionRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _reactionNotifierMock = new Mock<IReactionNotifier>();
+
+        _orchestrator = new ReactionOrchestrator(
+            _messageRepositoryMock.Object,
+            _reactionRepositoryMock.Object,
+            _unitOfWorkMock.Object);
 
         _handler = new GetReactionUsersHandler(
             _conversationRepositoryMock.Object,
-            _messageRepositoryMock.Object,
-            _reactionRepositoryMock.Object);
+            _reactionNotifierMock.Object,
+            NullLogger<ConversationReactionScope>.Instance,
+            _orchestrator);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/ReactionOrchestratorTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/ReactionOrchestratorTests.cs
@@ -1,0 +1,296 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.Reactions;
+using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Guilds;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Messages;
+
+public sealed class ReactionOrchestratorTests
+{
+    private readonly Mock<IMessageRepository> _messageRepositoryMock;
+    private readonly Mock<IMessageReactionRepository> _reactionRepositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly ReactionOrchestrator _orchestrator;
+
+    private static readonly ChannelReactionScope.Context Ctx = new(
+        GuildChannelId.New(), "general", GuildId.New(), "MyGuild", "caller", "Display");
+
+    public ReactionOrchestratorTests()
+    {
+        _messageRepositoryMock = new Mock<IMessageRepository>();
+        _reactionRepositoryMock = new Mock<IMessageReactionRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _transactionMock = _unitOfWorkMock.SetupTransactionMock();
+
+        _orchestrator = new ReactionOrchestrator(
+            _messageRepositoryMock.Object,
+            _reactionRepositoryMock.Object,
+            _unitOfWorkMock.Object);
+    }
+
+    private static MessageScope AnyScope() => new MessageScope.Channel(GuildChannelId.New());
+    private static MessageId AnyMessageId() => MessageId.New();
+    private static UserId AnyUser() => UserId.New();
+    private const string TestEmoji = "👍";
+
+    private static Mock<IReactionScope<ChannelReactionScope.Context>> CreateAuthorizedScope()
+    {
+        var mock = new Mock<IReactionScope<ChannelReactionScope.Context>>();
+        mock.Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<ChannelReactionScope.Context>.Authorized(Ctx));
+        mock.Setup(x => x.NotifyReactionAddedAsync(
+            Ctx, It.IsAny<MessageId>(), It.IsAny<UserId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        mock.Setup(x => x.NotifyReactionRemovedAsync(
+            Ctx, It.IsAny<MessageId>(), It.IsAny<UserId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        return mock;
+    }
+
+    private void SetupMessageExists(MessageId messageId, MessageScope scope)
+    {
+        Message message;
+        if (scope is MessageScope.Channel c)
+            message = ApplicationTestBuilders.CreateChannelMessage(c.ChannelId, AnyUser());
+        else
+            message = ApplicationTestBuilders.CreateConversationMessage(
+                ((MessageScope.Conversation)scope).ConversationId, AnyUser());
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+    }
+
+    // ── AddAsync ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AddAsync_WhenAuthorizationDenied_ShouldReturnAuthError()
+    {
+        var scopeMock = new Mock<IReactionScope<ChannelReactionScope.Context>>();
+        scopeMock.Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<ChannelReactionScope.Context>.Denied(
+                new ApplicationError("AUTH_DENIED", "Not allowed")));
+
+        var result = await _orchestrator.AddAsync(
+            scopeMock.Object, AnyScope(), AnyMessageId(), TestEmoji, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be("AUTH_DENIED");
+    }
+
+    [Fact]
+    public async Task AddAsync_WhenMessageNotFound_ShouldReturnMessageNotFound()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Message?)null);
+
+        var result = await _orchestrator.AddAsync(
+            scope.Object, AnyScope(), messageId, TestEmoji, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
+    }
+
+    [Fact]
+    public async Task AddAsync_WhenMessageInWrongScope_ShouldReturnMessageNotFound()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var wrongScope = new MessageScope.Conversation(ConversationId.New());
+        SetupMessageExists(messageId, wrongScope);
+
+        var result = await _orchestrator.AddAsync(
+            scope.Object, AnyScope(), messageId, TestEmoji, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
+    }
+
+    [Fact]
+    public async Task AddAsync_WhenSuccessful_ShouldCreateReactionAndNotify()
+    {
+        var scopeMock = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var scope = AnyScope();
+        SetupMessageExists(messageId, scope);
+        var callOrder = new List<string>();
+
+        _reactionRepositoryMock
+            .Setup(x => x.AddAsync(It.IsAny<MessageReaction>(), It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("add"))
+            .Returns(Task.CompletedTask);
+
+        _transactionMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("commit"))
+            .Returns(Task.CompletedTask);
+
+        scopeMock
+            .Setup(x => x.NotifyReactionAddedAsync(
+                Ctx, messageId, It.IsAny<UserId>(), TestEmoji, It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("notify"))
+            .Returns(Task.CompletedTask);
+
+        var result = await _orchestrator.AddAsync(
+            scopeMock.Object, scope, messageId, TestEmoji, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        _reactionRepositoryMock.Verify(x => x.AddAsync(It.IsAny<MessageReaction>(), It.IsAny<CancellationToken>()), Times.Once);
+        _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+        callOrder.Should().Equal("add", "commit", "notify");
+    }
+
+    // ── RemoveAsync ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RemoveAsync_WhenAuthorizationDenied_ShouldReturnAuthError()
+    {
+        var scopeMock = new Mock<IReactionScope<ChannelReactionScope.Context>>();
+        scopeMock.Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<ChannelReactionScope.Context>.Denied(
+                new ApplicationError("AUTH_DENIED", "Not allowed")));
+
+        var result = await _orchestrator.RemoveAsync(
+            scopeMock.Object, AnyScope(), AnyMessageId(), TestEmoji, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be("AUTH_DENIED");
+    }
+
+    [Fact]
+    public async Task RemoveAsync_WhenMessageNotFound_ShouldReturnMessageNotFound()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Message?)null);
+
+        var result = await _orchestrator.RemoveAsync(
+            scope.Object, AnyScope(), messageId, TestEmoji, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
+    }
+
+    [Fact]
+    public async Task RemoveAsync_WhenSuccessful_ShouldRemoveReactionAndNotify()
+    {
+        var scopeMock = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var scope = AnyScope();
+        SetupMessageExists(messageId, scope);
+        var callOrder = new List<string>();
+
+        _reactionRepositoryMock
+            .Setup(x => x.RemoveAsync(messageId, It.IsAny<UserId>(), TestEmoji, It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("remove"))
+            .Returns(Task.CompletedTask);
+
+        _transactionMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("commit"))
+            .Returns(Task.CompletedTask);
+
+        scopeMock
+            .Setup(x => x.NotifyReactionRemovedAsync(
+                Ctx, messageId, It.IsAny<UserId>(), TestEmoji, It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("notify"))
+            .Returns(Task.CompletedTask);
+
+        var result = await _orchestrator.RemoveAsync(
+            scopeMock.Object, scope, messageId, TestEmoji, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        _reactionRepositoryMock.Verify(
+            x => x.RemoveAsync(messageId, It.IsAny<UserId>(), TestEmoji, It.IsAny<CancellationToken>()), Times.Once);
+        _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+        callOrder.Should().Equal("remove", "commit", "notify");
+    }
+
+    // ── GetUsersAsync ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetUsersAsync_WhenAuthorizationDenied_ShouldReturnAuthError_BeforeCursorValidation()
+    {
+        var scopeMock = new Mock<IReactionScope<ChannelReactionScope.Context>>();
+        scopeMock.Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<ChannelReactionScope.Context>.Denied(
+                new ApplicationError("AUTH_DENIED", "Not allowed")));
+
+        var result = await _orchestrator.GetUsersAsync(
+            scopeMock.Object, AnyScope(), AnyMessageId(), TestEmoji,
+            "invalid-cursor", 50, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be("AUTH_DENIED");
+    }
+
+    [Fact]
+    public async Task GetUsersAsync_WhenCursorInvalid_ShouldReturnValidationFailed()
+    {
+        var scope = CreateAuthorizedScope();
+
+        var result = await _orchestrator.GetUsersAsync(
+            scope.Object, AnyScope(), AnyMessageId(), TestEmoji,
+            "not-a-valid-cursor", 50, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
+    }
+
+    [Fact]
+    public async Task GetUsersAsync_WhenMessageNotFound_ShouldReturnMessageNotFound()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Message?)null);
+
+        var result = await _orchestrator.GetUsersAsync(
+            scope.Object, AnyScope(), messageId, TestEmoji,
+            null, 50, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Reaction.MessageNotFound);
+    }
+
+    [Fact]
+    public async Task GetUsersAsync_WhenSuccessful_ShouldClampLimitAndEncodeNextCursor()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var messageScope = AnyScope();
+        SetupMessageExists(messageId, messageScope);
+
+        _reactionRepositoryMock
+            .Setup(x => x.GetReactionUsersAsync(messageId, TestEmoji, 50, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReactionUsersPage(
+                Users: [new ReactionUser(Guid.NewGuid(), "user1", null)],
+                TotalCount: 1,
+                NextCursor: null));
+
+        var result = await _orchestrator.GetUsersAsync(
+            scope.Object, messageScope, messageId, TestEmoji,
+            null, null, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        result.Data!.Users.Should().HaveCount(1);
+        result.Data.TotalCount.Should().Be(1);
+    }
+}

--- a/tests/Harmonie.Application.Tests/Messages/RemoveChannelReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/RemoveChannelReactionHandlerTests.cs
@@ -1,6 +1,9 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Channels.RemoveReaction;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.AddReaction;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
@@ -30,6 +33,7 @@ public sealed class RemoveChannelReactionHandlerTests
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IReactionNotifier> _reactionNotifierMock;
+    private readonly ReactionOrchestrator _orchestrator;
     private readonly RemoveReactionHandler _handler;
 
     public RemoveChannelReactionHandlerTests()
@@ -47,13 +51,16 @@ public sealed class RemoveChannelReactionHandlerTests
             .Setup(x => x.NotifyReactionRemovedFromChannelAsync(It.IsAny<ChannelReactionRemovedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        _handler = new RemoveReactionHandler(
-            _guildChannelRepositoryMock.Object,
+        _orchestrator = new ReactionOrchestrator(
             _messageRepositoryMock.Object,
             _reactionRepositoryMock.Object,
-            _unitOfWorkMock.Object,
+            _unitOfWorkMock.Object);
+
+        _handler = new RemoveReactionHandler(
+            _guildChannelRepositoryMock.Object,
             _reactionNotifierMock.Object,
-            NullLogger<RemoveReactionHandler>.Instance);
+            NullLogger<ChannelReactionScope>.Instance,
+            _orchestrator);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/RemoveChannelReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/RemoveChannelReactionHandlerTests.cs
@@ -1,9 +1,9 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.Reactions;
 using Harmonie.Application.Features.Channels.RemoveReaction;
-using Harmonie.Application.Common.Messages;
-using Harmonie.Application.Features.Channels.AddReaction;
+using Harmonie.Application.Features.Channels.Reactions;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;

--- a/tests/Harmonie.Application.Tests/Messages/RemoveChannelReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/RemoveChannelReactionHandlerTests.cs
@@ -3,7 +3,6 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Channels.Reactions;
 using Harmonie.Application.Features.Channels.RemoveReaction;
-using Harmonie.Application.Features.Channels.Reactions;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;

--- a/tests/Harmonie.Application.Tests/Messages/RemoveConversationReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/RemoveConversationReactionHandlerTests.cs
@@ -1,8 +1,9 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Conversations.Reactions;
 using Harmonie.Application.Features.Conversations.RemoveReaction;
-using Harmonie.Application.Features.Conversations.AddReaction;
+using Harmonie.Application.Features.Conversations.Reactions;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;

--- a/tests/Harmonie.Application.Tests/Messages/RemoveConversationReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/RemoveConversationReactionHandlerTests.cs
@@ -3,7 +3,6 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Conversations.Reactions;
 using Harmonie.Application.Features.Conversations.RemoveReaction;
-using Harmonie.Application.Features.Conversations.Reactions;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;

--- a/tests/Harmonie.Application.Tests/Messages/RemoveConversationReactionHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/RemoveConversationReactionHandlerTests.cs
@@ -1,6 +1,8 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Conversations.RemoveReaction;
+using Harmonie.Application.Features.Conversations.AddReaction;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
@@ -26,6 +28,7 @@ public sealed class RemoveConversationReactionHandlerTests
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IReactionNotifier> _reactionNotifierMock;
+    private readonly ReactionOrchestrator _orchestrator;
     private readonly RemoveReactionHandler _handler;
 
     public RemoveConversationReactionHandlerTests()
@@ -43,13 +46,16 @@ public sealed class RemoveConversationReactionHandlerTests
             .Setup(x => x.NotifyReactionRemovedFromConversationAsync(It.IsAny<ConversationReactionRemovedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        _handler = new RemoveReactionHandler(
-            _conversationRepositoryMock.Object,
+        _orchestrator = new ReactionOrchestrator(
             _messageRepositoryMock.Object,
             _reactionRepositoryMock.Object,
-            _unitOfWorkMock.Object,
+            _unitOfWorkMock.Object);
+
+        _handler = new RemoveReactionHandler(
+            _conversationRepositoryMock.Object,
             _reactionNotifierMock.Object,
-            NullLogger<RemoveReactionHandler>.Instance);
+            NullLogger<ConversationReactionScope>.Instance,
+            _orchestrator);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Step 2 of #382 — consolidate the 6 reaction handlers (AddReaction, RemoveReaction, GetReactionUsers ×2) behind `IReactionScope<TContext>` and `ReactionOrchestrator`.

## New files (4)

| File | Role |
|------|------|
| `IReactionScope.cs` | Interface: `AuthorizeAsync`, `NotifyReactionAddedAsync`, `NotifyReactionRemovedAsync` + `ReactionUsersResult` DTO |
| `ReactionOrchestrator.cs` | Shared class: `AddAsync`, `RemoveAsync`, `GetUsersAsync` — message lookup, domain creation, transaction, response mapping |
| `ChannelReactionScope.cs` | Auth via `IGuildChannelRepository`, notif via `IReactionNotifier.NotifyReactionAddedToChannelAsync` / `NotifyReactionRemovedFromChannelAsync` |
| `ConversationReactionScope.cs` | Auth via `IConversationRepository`, notif via `IReactionNotifier.NotifyReactionAddedToConversationAsync` / `NotifyReactionRemovedFromConversationAsync` |

## Modified files (13)

- **6 handlers** — each drops from ~95-105 to ~40-60 lines
- **6 test files** — updated constructors (mocks moved from handler to orchestrator)
- **`DependencyInjection.cs`** — register `ReactionOrchestrator`

## Net delta

- **+562 / -453 lines**
- ~260 LOC of duplicated code removed from the 6 handlers

## Verification

- Build: 0 errors
- Tests: 1209/1209 passing

Closes #382