### PR TITLE
feat: consolidate EditMessage, DeleteMessage, DeleteMessageAttachment handlers (#382 part 3)

### DIFF
--- a/src/Harmonie.Application/Common/Messages/IMessageEditDeleteScope.cs
+++ b/src/Harmonie.Application/Common/Messages/IMessageEditDeleteScope.cs
@@ -54,3 +54,16 @@ public sealed record MessageEditResult(
     IReadOnlyList<MessageAttachmentDto> Attachments,
     DateTime CreatedAtUtc,
     DateTime? UpdatedAtUtc);
+
+/// <summary>
+/// Discriminated union for the result of <see cref="MessageEditDeleteOrchestrator"/>'s
+/// internal authorization + message fetch step.
+/// </summary>
+public abstract record FetchMessageResult<TContext> where TContext : ScopeContext
+{
+    private FetchMessageResult() { }
+
+    public sealed record Found(TContext Context, Message Message) : FetchMessageResult<TContext>;
+
+    public sealed record Failed(ApplicationError Error) : FetchMessageResult<TContext>;
+}

--- a/src/Harmonie.Application/Common/Messages/IMessageEditDeleteScope.cs
+++ b/src/Harmonie.Application/Common/Messages/IMessageEditDeleteScope.cs
@@ -1,0 +1,56 @@
+using Harmonie.Application.Common;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Common.Messages;
+
+/// <summary>
+/// Scope-specific concerns for message edit/delete operations (authorization and notification).
+/// </summary>
+public interface IMessageEditDeleteScope<TContext> where TContext : ScopeContext
+{
+    /// <summary>
+    /// Authorizes the caller for the scope.
+    /// Returns an error on failure, or a context on success.
+    /// </summary>
+    Task<AuthorizationResult<TContext>> AuthorizeAsync(UserId caller, CancellationToken ct);
+
+    /// <summary>
+    /// Whether the caller (given the authorized context) can delete messages they did not author.
+    /// Returns true for channel admins, false for conversation contexts.
+    /// </summary>
+    bool CanDeleteOthersMessages(TContext context);
+
+    /// <summary>
+    /// Notifies scope participants that a message was updated.
+    /// Implementation must use best-effort notification (fire-and-forget).
+    /// </summary>
+    Task NotifyMessageUpdatedAsync(
+        TContext context,
+        MessageId messageId,
+        string? content,
+        DateTime updatedAtUtc,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Notifies scope participants that a message was deleted.
+    /// Implementation must use best-effort notification (fire-and-forget).
+    /// </summary>
+    Task NotifyMessageDeletedAsync(
+        TContext context,
+        MessageId messageId,
+        CancellationToken ct);
+}
+
+/// <summary>
+/// Result returned by <see cref="MessageEditDeleteOrchestrator.EditAsync"/>.
+/// The caller maps this to the namespace-specific EditMessageResponse DTO.
+/// </summary>
+public sealed record MessageEditResult(
+    Guid MessageId,
+    Guid AuthorUserId,
+    string? Content,
+    IReadOnlyList<MessageAttachmentDto> Attachments,
+    DateTime CreatedAtUtc,
+    DateTime? UpdatedAtUtc);

--- a/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
@@ -54,14 +54,15 @@ public sealed class MessageEditDeleteOrchestrator
         }
 
         // ── Authorization + message fetch ───────────────────────────────
-        var (context, message, authError) = await AuthorizeAndFetchMessageAsync(
+        var fetched = await AuthorizeAndFetchMessageAsync(
             scope, messageScope, messageId, callerId, ct);
-        if (authError is not null)
-            return ApplicationResponse<MessageEditResult>.Fail(authError);
+        if (fetched is FetchMessageResult<TContext>.Failed failed)
+            return ApplicationResponse<MessageEditResult>.Fail(failed.Error);
 
-        // context and message are non-null after the authError guard
+        var (context, message) = (FetchMessageResult<TContext>.Found)fetched;
+
         // ── Author check ────────────────────────────────────────────────
-        if (message!.AuthorUserId != callerId)
+        if (message.AuthorUserId != callerId)
         {
             return ApplicationResponse<MessageEditResult>.Fail(
                 ApplicationErrorCodes.Message.EditForbidden,
@@ -92,9 +93,9 @@ public sealed class MessageEditDeleteOrchestrator
         await _messageRepository.UpdateAsync(message, ct);
         await transaction.CommitAsync(ct);
 
-        // ── Notification ────────────────────────────────────────────────
+        // ── Notify ──────────────────────────────────────────────────────
         await scope.NotifyMessageUpdatedAsync(
-            context!,
+            context,
             message.Id,
             message.Content?.Value,
             updatedAtUtc.Value,
@@ -122,16 +123,17 @@ public sealed class MessageEditDeleteOrchestrator
         where TContext : ScopeContext
     {
         // ── Authorization + message fetch ───────────────────────────────
-        var (context, message, authError) = await AuthorizeAndFetchMessageAsync(
+        var fetched = await AuthorizeAndFetchMessageAsync(
             scope, messageScope, messageId, callerId, ct);
-        if (authError is not null)
-            return ApplicationResponse<bool>.Fail(authError);
+        if (fetched is FetchMessageResult<TContext>.Failed failed)
+            return ApplicationResponse<bool>.Fail(failed.Error);
 
-        // context and message are non-null after the authError guard
+        var (context, message) = (FetchMessageResult<TContext>.Found)fetched;
+
         // ── Author check (with scope-specific admin override) ───────────
         // Channel scopes allow admins to delete others' messages (CanDeleteOthersMessages = true).
         // Conversation scopes never allow non-authors to delete (CanDeleteOthersMessages = false).
-        if (message!.AuthorUserId != callerId && !scope.CanDeleteOthersMessages(context!))
+        if (message.AuthorUserId != callerId && !scope.CanDeleteOthersMessages(context))
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Message.DeleteForbidden,
@@ -152,8 +154,8 @@ public sealed class MessageEditDeleteOrchestrator
         await _messageRepository.SoftDeleteAsync(message, ct);
         await transaction.CommitAsync(ct);
 
-        // ── Notification ────────────────────────────────────────────────
-        await scope.NotifyMessageDeletedAsync(context!, message.Id, ct);
+        // ── Notify ──────────────────────────────────────────────────────
+        await scope.NotifyMessageDeletedAsync(context, message.Id, ct);
 
         return ApplicationResponse<bool>.Ok(true);
     }
@@ -168,14 +170,15 @@ public sealed class MessageEditDeleteOrchestrator
         where TContext : ScopeContext
     {
         // ── Authorization + message fetch ───────────────────────────────
-        var (_, message, authError) = await AuthorizeAndFetchMessageAsync(
+        var fetched = await AuthorizeAndFetchMessageAsync(
             scope, messageScope, messageId, callerId, ct);
-        if (authError is not null)
-            return ApplicationResponse<bool>.Fail(authError);
+        if (fetched is FetchMessageResult<TContext>.Failed failed)
+            return ApplicationResponse<bool>.Fail(failed.Error);
 
-        // message is non-null after the authError guard
+        var (_, message) = (FetchMessageResult<TContext>.Found)fetched;
+
         // ── Author check ────────────────────────────────────────────────
-        if (message!.AuthorUserId != callerId)
+        if (message.AuthorUserId != callerId)
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Message.DeleteForbidden,
@@ -206,32 +209,29 @@ public sealed class MessageEditDeleteOrchestrator
     /// <summary>
     /// Authorizes the caller via the scope and fetches the target message,
     /// validating that it belongs to the expected scope.
-    /// Returns nullable context/message; callers must null-check Error before
-    /// dereferencing them.
     /// </summary>
-    private async Task<(TContext? Context, Message? Message, ApplicationError? Error)>
-        AuthorizeAndFetchMessageAsync<TContext>(
-            IMessageEditDeleteScope<TContext> scope,
-            MessageScope messageScope,
-            MessageId messageId,
-            UserId callerId,
-            CancellationToken ct)
-            where TContext : ScopeContext
+    private async Task<FetchMessageResult<TContext>> AuthorizeAndFetchMessageAsync<TContext>(
+        IMessageEditDeleteScope<TContext> scope,
+        MessageScope messageScope,
+        MessageId messageId,
+        UserId callerId,
+        CancellationToken ct)
+        where TContext : ScopeContext
     {
         var authResult = await scope.AuthorizeAsync(callerId, ct);
         if (authResult is AuthorizationResult<TContext>.Denied denied)
-            return (null, null, denied.Error);
+            return new FetchMessageResult<TContext>.Failed(denied.Error);
 
         var context = ((AuthorizationResult<TContext>.Authorized)authResult).Context;
 
         var message = await _messageRepository.GetByIdAsync(messageId, ct);
         if (message is null || message.Scope != messageScope)
         {
-            return (null, null, new ApplicationError(
+            return new FetchMessageResult<TContext>.Failed(new ApplicationError(
                 ApplicationErrorCodes.Message.NotFound,
                 "Message was not found"));
         }
 
-        return (context, message, null);
+        return new FetchMessageResult<TContext>.Found(context, message);
     }
 }

--- a/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
@@ -53,23 +53,11 @@ public sealed class MessageEditDeleteOrchestrator
                 contentResult.Error ?? "Message content is invalid");
         }
 
-        // ── Authorization ───────────────────────────────────────────────
-        var authResult = await scope.AuthorizeAsync(callerId, ct);
-        if (authResult is AuthorizationResult<TContext>.Denied denied)
-        {
-            return ApplicationResponse<MessageEditResult>.Fail(denied.Error);
-        }
-
-        var context = ((AuthorizationResult<TContext>.Authorized)authResult).Context;
-
-        // ── Message fetch + scope validation ────────────────────────────
-        var message = await _messageRepository.GetByIdAsync(messageId, ct);
-        if (message is null || message.Scope != messageScope)
-        {
-            return ApplicationResponse<MessageEditResult>.Fail(
-                ApplicationErrorCodes.Message.NotFound,
-                "Message was not found");
-        }
+        // ── Authorization + message fetch ───────────────────────────────
+        var (context, message, authError) = await AuthorizeAndFetchMessageAsync(
+            scope, messageScope, messageId, callerId, ct);
+        if (authError is not null)
+            return ApplicationResponse<MessageEditResult>.Fail(authError);
 
         // ── Author check ────────────────────────────────────────────────
         if (message.AuthorUserId != callerId)
@@ -88,12 +76,8 @@ public sealed class MessageEditDeleteOrchestrator
                 updateResult.Error ?? "Message content update failed");
         }
 
-        // ── Persist ─────────────────────────────────────────────────────
-        await using var transaction = await _unitOfWork.BeginAsync(ct);
-        await _messageRepository.UpdateAsync(message, ct);
-        await transaction.CommitAsync(ct);
-
-        // ── Updated timestamp validation ────────────────────────────────
+        // ── Updated timestamp validation (before commit: UpdateContent always sets it,
+        //     this guard is defensive against future domain changes) ─────
         var updatedAtUtc = message.UpdatedAtUtc;
         if (updatedAtUtc is null)
         {
@@ -101,6 +85,11 @@ public sealed class MessageEditDeleteOrchestrator
                 ApplicationErrorCodes.Common.InvalidState,
                 "Message edit succeeded but updated timestamp is missing");
         }
+
+        // ── Persist ─────────────────────────────────────────────────────
+        await using var transaction = await _unitOfWork.BeginAsync(ct);
+        await _messageRepository.UpdateAsync(message, ct);
+        await transaction.CommitAsync(ct);
 
         // ── Notify ──────────────────────────────────────────────────────
         await scope.NotifyMessageUpdatedAsync(
@@ -131,25 +120,15 @@ public sealed class MessageEditDeleteOrchestrator
         CancellationToken ct)
         where TContext : ScopeContext
     {
-        // ── Authorization ───────────────────────────────────────────────
-        var authResult = await scope.AuthorizeAsync(callerId, ct);
-        if (authResult is AuthorizationResult<TContext>.Denied denied)
-        {
-            return ApplicationResponse<bool>.Fail(denied.Error);
-        }
-
-        var context = ((AuthorizationResult<TContext>.Authorized)authResult).Context;
-
-        // ── Message fetch + scope validation ────────────────────────────
-        var message = await _messageRepository.GetByIdAsync(messageId, ct);
-        if (message is null || message.Scope != messageScope)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Message.NotFound,
-                "Message was not found");
-        }
+        // ── Authorization + message fetch ───────────────────────────────
+        var (context, message, authError) = await AuthorizeAndFetchMessageAsync(
+            scope, messageScope, messageId, callerId, ct);
+        if (authError is not null)
+            return ApplicationResponse<bool>.Fail(authError);
 
         // ── Author check (with scope-specific admin override) ───────────
+        // Channel scopes allow admins to delete others' messages (CanDeleteOthersMessages = true).
+        // Conversation scopes never allow non-authors to delete (CanDeleteOthersMessages = false).
         if (message.AuthorUserId != callerId && !scope.CanDeleteOthersMessages(context))
         {
             return ApplicationResponse<bool>.Fail(
@@ -186,21 +165,11 @@ public sealed class MessageEditDeleteOrchestrator
         CancellationToken ct)
         where TContext : ScopeContext
     {
-        // ── Authorization ───────────────────────────────────────────────
-        var authResult = await scope.AuthorizeAsync(callerId, ct);
-        if (authResult is AuthorizationResult<TContext>.Denied denied)
-        {
-            return ApplicationResponse<bool>.Fail(denied.Error);
-        }
-
-        // ── Message fetch + scope validation ────────────────────────────
-        var message = await _messageRepository.GetByIdAsync(messageId, ct);
-        if (message is null || message.Scope != messageScope)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Message.NotFound,
-                "Message was not found");
-        }
+        // ── Authorization + message fetch ───────────────────────────────
+        var (_, message, authError) = await AuthorizeAndFetchMessageAsync(
+            scope, messageScope, messageId, callerId, ct);
+        if (authError is not null)
+            return ApplicationResponse<bool>.Fail(authError);
 
         // ── Author check ────────────────────────────────────────────────
         if (message.AuthorUserId != callerId)
@@ -229,5 +198,35 @@ public sealed class MessageEditDeleteOrchestrator
         await _uploadedFileCleanupService.DeleteIfExistsAsync(attachmentId, ct);
 
         return ApplicationResponse<bool>.Ok(true);
+    }
+
+    /// <summary>
+    /// Authorizes the caller via the scope and fetches the target message,
+    /// validating that it belongs to the expected scope.
+    /// </summary>
+    private async Task<(TContext Context, Message Message, ApplicationError? Error)>
+        AuthorizeAndFetchMessageAsync<TContext>(
+            IMessageEditDeleteScope<TContext> scope,
+            MessageScope messageScope,
+            MessageId messageId,
+            UserId callerId,
+            CancellationToken ct)
+            where TContext : ScopeContext
+    {
+        var authResult = await scope.AuthorizeAsync(callerId, ct);
+        if (authResult is AuthorizationResult<TContext>.Denied denied)
+            return (default!, default!, denied.Error);
+
+        var context = ((AuthorizationResult<TContext>.Authorized)authResult).Context;
+
+        var message = await _messageRepository.GetByIdAsync(messageId, ct);
+        if (message is null || message.Scope != messageScope)
+        {
+            return (default!, default!, new ApplicationError(
+                ApplicationErrorCodes.Message.NotFound,
+                "Message was not found"));
+        }
+
+        return (context, message, null);
     }
 }

--- a/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
@@ -59,8 +59,9 @@ public sealed class MessageEditDeleteOrchestrator
         if (authError is not null)
             return ApplicationResponse<MessageEditResult>.Fail(authError);
 
+        // context and message are non-null after the authError guard
         // ── Author check ────────────────────────────────────────────────
-        if (message.AuthorUserId != callerId)
+        if (message!.AuthorUserId != callerId)
         {
             return ApplicationResponse<MessageEditResult>.Fail(
                 ApplicationErrorCodes.Message.EditForbidden,
@@ -91,9 +92,9 @@ public sealed class MessageEditDeleteOrchestrator
         await _messageRepository.UpdateAsync(message, ct);
         await transaction.CommitAsync(ct);
 
-        // ── Notify ──────────────────────────────────────────────────────
+        // ── Notification ────────────────────────────────────────────────
         await scope.NotifyMessageUpdatedAsync(
-            context,
+            context!,
             message.Id,
             message.Content?.Value,
             updatedAtUtc.Value,
@@ -126,10 +127,11 @@ public sealed class MessageEditDeleteOrchestrator
         if (authError is not null)
             return ApplicationResponse<bool>.Fail(authError);
 
+        // context and message are non-null after the authError guard
         // ── Author check (with scope-specific admin override) ───────────
         // Channel scopes allow admins to delete others' messages (CanDeleteOthersMessages = true).
         // Conversation scopes never allow non-authors to delete (CanDeleteOthersMessages = false).
-        if (message.AuthorUserId != callerId && !scope.CanDeleteOthersMessages(context))
+        if (message!.AuthorUserId != callerId && !scope.CanDeleteOthersMessages(context!))
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Message.DeleteForbidden,
@@ -150,8 +152,8 @@ public sealed class MessageEditDeleteOrchestrator
         await _messageRepository.SoftDeleteAsync(message, ct);
         await transaction.CommitAsync(ct);
 
-        // ── Notify ──────────────────────────────────────────────────────
-        await scope.NotifyMessageDeletedAsync(context, message.Id, ct);
+        // ── Notification ────────────────────────────────────────────────
+        await scope.NotifyMessageDeletedAsync(context!, message.Id, ct);
 
         return ApplicationResponse<bool>.Ok(true);
     }
@@ -171,8 +173,9 @@ public sealed class MessageEditDeleteOrchestrator
         if (authError is not null)
             return ApplicationResponse<bool>.Fail(authError);
 
+        // message is non-null after the authError guard
         // ── Author check ────────────────────────────────────────────────
-        if (message.AuthorUserId != callerId)
+        if (message!.AuthorUserId != callerId)
         {
             return ApplicationResponse<bool>.Fail(
                 ApplicationErrorCodes.Message.DeleteForbidden,
@@ -203,8 +206,10 @@ public sealed class MessageEditDeleteOrchestrator
     /// <summary>
     /// Authorizes the caller via the scope and fetches the target message,
     /// validating that it belongs to the expected scope.
+    /// Returns nullable context/message; callers must null-check Error before
+    /// dereferencing them.
     /// </summary>
-    private async Task<(TContext Context, Message Message, ApplicationError? Error)>
+    private async Task<(TContext? Context, Message? Message, ApplicationError? Error)>
         AuthorizeAndFetchMessageAsync<TContext>(
             IMessageEditDeleteScope<TContext> scope,
             MessageScope messageScope,
@@ -215,14 +220,14 @@ public sealed class MessageEditDeleteOrchestrator
     {
         var authResult = await scope.AuthorizeAsync(callerId, ct);
         if (authResult is AuthorizationResult<TContext>.Denied denied)
-            return (default!, default!, denied.Error);
+            return (null, null, denied.Error);
 
         var context = ((AuthorizationResult<TContext>.Authorized)authResult).Context;
 
         var message = await _messageRepository.GetByIdAsync(messageId, ct);
         if (message is null || message.Scope != messageScope)
         {
-            return (default!, default!, new ApplicationError(
+            return (null, null, new ApplicationError(
                 ApplicationErrorCodes.Message.NotFound,
                 "Message was not found"));
         }

--- a/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
@@ -1,0 +1,233 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Common.Uploads;
+using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Uploads;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Common.Messages;
+
+/// <summary>
+/// Shared orchestrator for message edit, delete, and delete-attachment operations
+/// across all scopes (channels, conversations). Extracts the duplicated logic from
+/// channel and conversation handlers.
+/// </summary>
+public sealed class MessageEditDeleteOrchestrator
+{
+    private readonly IMessageRepository _messageRepository;
+    private readonly IMessageAttachmentRepository _messageAttachmentRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly UploadedFileCleanupService _uploadedFileCleanupService;
+
+    public MessageEditDeleteOrchestrator(
+        IMessageRepository messageRepository,
+        IMessageAttachmentRepository messageAttachmentRepository,
+        IUnitOfWork unitOfWork,
+        UploadedFileCleanupService uploadedFileCleanupService)
+    {
+        _messageRepository = messageRepository;
+        _messageAttachmentRepository = messageAttachmentRepository;
+        _unitOfWork = unitOfWork;
+        _uploadedFileCleanupService = uploadedFileCleanupService;
+    }
+
+    public async Task<ApplicationResponse<MessageEditResult>> EditAsync<TContext>(
+        IMessageEditDeleteScope<TContext> scope,
+        MessageScope messageScope,
+        MessageId messageId,
+        string rawContent,
+        UserId callerId,
+        CancellationToken ct)
+        where TContext : ScopeContext
+    {
+        // ── Content validation ──────────────────────────────────────────
+        var contentResult = MessageContent.Create(rawContent);
+        if (contentResult.IsFailure || contentResult.Value is null)
+        {
+            var code = MessageContentErrorCodeResolver.Resolve(rawContent);
+            return ApplicationResponse<MessageEditResult>.Fail(
+                code,
+                contentResult.Error ?? "Message content is invalid");
+        }
+
+        // ── Authorization ───────────────────────────────────────────────
+        var authResult = await scope.AuthorizeAsync(callerId, ct);
+        if (authResult is AuthorizationResult<TContext>.Denied denied)
+        {
+            return ApplicationResponse<MessageEditResult>.Fail(denied.Error);
+        }
+
+        var context = ((AuthorizationResult<TContext>.Authorized)authResult).Context;
+
+        // ── Message fetch + scope validation ────────────────────────────
+        var message = await _messageRepository.GetByIdAsync(messageId, ct);
+        if (message is null || message.Scope != messageScope)
+        {
+            return ApplicationResponse<MessageEditResult>.Fail(
+                ApplicationErrorCodes.Message.NotFound,
+                "Message was not found");
+        }
+
+        // ── Author check ────────────────────────────────────────────────
+        if (message.AuthorUserId != callerId)
+        {
+            return ApplicationResponse<MessageEditResult>.Fail(
+                ApplicationErrorCodes.Message.EditForbidden,
+                "You can only edit your own messages");
+        }
+
+        // ── Update content ──────────────────────────────────────────────
+        var updateResult = message.UpdateContent(contentResult.Value);
+        if (updateResult.IsFailure)
+        {
+            return ApplicationResponse<MessageEditResult>.Fail(
+                ApplicationErrorCodes.Common.DomainRuleViolation,
+                updateResult.Error ?? "Message content update failed");
+        }
+
+        // ── Persist ─────────────────────────────────────────────────────
+        await using var transaction = await _unitOfWork.BeginAsync(ct);
+        await _messageRepository.UpdateAsync(message, ct);
+        await transaction.CommitAsync(ct);
+
+        // ── Updated timestamp validation ────────────────────────────────
+        var updatedAtUtc = message.UpdatedAtUtc;
+        if (updatedAtUtc is null)
+        {
+            return ApplicationResponse<MessageEditResult>.Fail(
+                ApplicationErrorCodes.Common.InvalidState,
+                "Message edit succeeded but updated timestamp is missing");
+        }
+
+        // ── Notify ──────────────────────────────────────────────────────
+        await scope.NotifyMessageUpdatedAsync(
+            context,
+            message.Id,
+            message.Content?.Value,
+            updatedAtUtc.Value,
+            ct);
+
+        // ── Attachments for response ────────────────────────────────────
+        var attachments = await _messageAttachmentRepository.GetByMessageIdAsync(messageId, ct);
+
+        // ── Result ──────────────────────────────────────────────────────
+        return ApplicationResponse<MessageEditResult>.Ok(new MessageEditResult(
+            MessageId: message.Id.Value,
+            AuthorUserId: message.AuthorUserId.Value,
+            Content: message.Content?.Value,
+            Attachments: attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
+            CreatedAtUtc: message.CreatedAtUtc,
+            UpdatedAtUtc: updatedAtUtc));
+    }
+
+    public async Task<ApplicationResponse<bool>> DeleteAsync<TContext>(
+        IMessageEditDeleteScope<TContext> scope,
+        MessageScope messageScope,
+        MessageId messageId,
+        UserId callerId,
+        CancellationToken ct)
+        where TContext : ScopeContext
+    {
+        // ── Authorization ───────────────────────────────────────────────
+        var authResult = await scope.AuthorizeAsync(callerId, ct);
+        if (authResult is AuthorizationResult<TContext>.Denied denied)
+        {
+            return ApplicationResponse<bool>.Fail(denied.Error);
+        }
+
+        var context = ((AuthorizationResult<TContext>.Authorized)authResult).Context;
+
+        // ── Message fetch + scope validation ────────────────────────────
+        var message = await _messageRepository.GetByIdAsync(messageId, ct);
+        if (message is null || message.Scope != messageScope)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Message.NotFound,
+                "Message was not found");
+        }
+
+        // ── Author check (with scope-specific admin override) ───────────
+        if (message.AuthorUserId != callerId && !scope.CanDeleteOthersMessages(context))
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Message.DeleteForbidden,
+                "You can only delete your own messages");
+        }
+
+        // ── Soft delete ─────────────────────────────────────────────────
+        var deleteResult = message.Delete();
+        if (deleteResult.IsFailure)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Common.DomainRuleViolation,
+                deleteResult.Error ?? "Message deletion failed");
+        }
+
+        // ── Persist ─────────────────────────────────────────────────────
+        await using var transaction = await _unitOfWork.BeginAsync(ct);
+        await _messageRepository.SoftDeleteAsync(message, ct);
+        await transaction.CommitAsync(ct);
+
+        // ── Notify ──────────────────────────────────────────────────────
+        await scope.NotifyMessageDeletedAsync(context, message.Id, ct);
+
+        return ApplicationResponse<bool>.Ok(true);
+    }
+
+    public async Task<ApplicationResponse<bool>> DeleteAttachmentAsync<TContext>(
+        IMessageEditDeleteScope<TContext> scope,
+        MessageScope messageScope,
+        MessageId messageId,
+        UploadedFileId attachmentId,
+        UserId callerId,
+        CancellationToken ct)
+        where TContext : ScopeContext
+    {
+        // ── Authorization ───────────────────────────────────────────────
+        var authResult = await scope.AuthorizeAsync(callerId, ct);
+        if (authResult is AuthorizationResult<TContext>.Denied denied)
+        {
+            return ApplicationResponse<bool>.Fail(denied.Error);
+        }
+
+        // ── Message fetch + scope validation ────────────────────────────
+        var message = await _messageRepository.GetByIdAsync(messageId, ct);
+        if (message is null || message.Scope != messageScope)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Message.NotFound,
+                "Message was not found");
+        }
+
+        // ── Author check ────────────────────────────────────────────────
+        if (message.AuthorUserId != callerId)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Message.DeleteForbidden,
+                "You can only delete attachments from your own messages");
+        }
+
+        // ── Delete attachment + persist ─────────────────────────────────
+        bool deleted;
+        await using (var transaction = await _unitOfWork.BeginAsync(ct))
+        {
+            deleted = await _messageAttachmentRepository.DeleteAsync(messageId, attachmentId, ct);
+            await transaction.CommitAsync(ct);
+        }
+
+        if (!deleted)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Message.AttachmentNotFound,
+                "Attachment was not found on message");
+        }
+
+        // ── Clean up uploaded file ──────────────────────────────────────
+        await _uploadedFileCleanupService.DeleteIfExistsAsync(attachmentId, ct);
+
+        return ApplicationResponse<bool>.Ok(true);
+    }
+}

--- a/src/Harmonie.Application/DependencyInjection.cs
+++ b/src/Harmonie.Application/DependencyInjection.cs
@@ -18,6 +18,7 @@ public static class DependencyInjection
         services.AddScoped<LinkPreviewResolutionService>();
         services.AddScoped<MessageSendOrchestrator>();
         services.AddScoped<ReactionOrchestrator>();
+        services.AddScoped<MessageEditDeleteOrchestrator>();
 
         services.AddAuthHandlers();
         services.AddGuildHandlers();

--- a/src/Harmonie.Application/Features/Channels/DeleteMessage/DeleteMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/DeleteMessage/DeleteMessageHandler.cs
@@ -1,8 +1,7 @@
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.Messages;
 using Harmonie.Application.Interfaces.Channels;
-using Harmonie.Application.Interfaces.Common;
-using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -14,25 +13,21 @@ public sealed record DeleteChannelMessageInput(GuildChannelId ChannelId, Message
 
 public sealed class DeleteMessageHandler : IAuthenticatedHandler<DeleteChannelMessageInput, bool>
 {
-    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
     private readonly IGuildChannelRepository _guildChannelRepository;
-    private readonly IMessageRepository _channelMessageRepository;
-    private readonly IUnitOfWork _unitOfWork;
     private readonly ITextChannelNotifier _textChannelNotifier;
-    private readonly ILogger<DeleteMessageHandler> _logger;
+    private readonly ILogger<ChannelMessageEditDeleteScope> _scopeLogger;
+    private readonly MessageEditDeleteOrchestrator _orchestrator;
 
     public DeleteMessageHandler(
         IGuildChannelRepository guildChannelRepository,
-        IMessageRepository channelMessageRepository,
-        IUnitOfWork unitOfWork,
         ITextChannelNotifier textChannelNotifier,
-        ILogger<DeleteMessageHandler> logger)
+        ILogger<ChannelMessageEditDeleteScope> scopeLogger,
+        MessageEditDeleteOrchestrator orchestrator)
     {
         _guildChannelRepository = guildChannelRepository;
-        _channelMessageRepository = channelMessageRepository;
-        _unitOfWork = unitOfWork;
         _textChannelNotifier = textChannelNotifier;
-        _logger = logger;
+        _scopeLogger = scopeLogger;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<bool>> HandleAsync(
@@ -40,75 +35,17 @@ public sealed class DeleteMessageHandler : IAuthenticatedHandler<DeleteChannelMe
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(request.ChannelId, currentUserId, cancellationToken);
-        if (ctx is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.NotFound,
-                "Channel was not found");
-        }
+        var scope = new ChannelMessageEditDeleteScope(
+            request.ChannelId,
+            _guildChannelRepository,
+            _textChannelNotifier,
+            _scopeLogger);
 
-        if (ctx.Channel.Type != GuildChannelType.Text)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.NotText,
-                "Messages can only be deleted in text channels");
-        }
-
-        if (ctx.CallerRole is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.AccessDenied,
-                "You do not have access to this channel");
-        }
-
-        var message = await _channelMessageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        if (message is null || !message.Scope.Matches(request.ChannelId))
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Message.NotFound,
-                "Message was not found");
-        }
-
-        if (message.AuthorUserId != currentUserId && ctx.CallerRole != GuildRole.Admin)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Message.DeleteForbidden,
-                "You can only delete your own messages unless you are a guild admin");
-        }
-
-        var deleteResult = message.Delete();
-        if (deleteResult.IsFailure)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Common.DomainRuleViolation,
-                deleteResult.Error ?? "Message deletion failed");
-        }
-
-        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
-        await _channelMessageRepository.SoftDeleteAsync(message, cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
-
-        await NotifyMessageDeletedSafelyAsync(
-            new TextChannelMessageDeletedNotification(
-                request.MessageId,
-                request.ChannelId,
-                ctx.Channel.Name,
-                ctx.Channel.GuildId,
-                ctx.GuildName ?? string.Empty));
-
-        return ApplicationResponse<bool>.Ok(true);
-    }
-
-    private async Task NotifyMessageDeletedSafelyAsync(
-        TextChannelMessageDeletedNotification notification)
-    {
-        await BestEffortNotificationHelper.TryNotifyAsync(
-            token => _textChannelNotifier.NotifyMessageDeletedAsync(notification, token),
-            NotificationTimeout,
-            _logger,
-            "DeleteMessage notification failed (best-effort). MessageId={MessageId}, ChannelId={ChannelId}",
-            notification.MessageId,
-            notification.ChannelId);
+        return await _orchestrator.DeleteAsync(
+            scope,
+            new MessageScope.Channel(request.ChannelId),
+            request.MessageId,
+            currentUserId,
+            cancellationToken);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
@@ -1,13 +1,12 @@
 using Harmonie.Application.Common;
-using Harmonie.Application.Common.Uploads;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.Messages;
 using Harmonie.Application.Interfaces.Channels;
-using Harmonie.Application.Interfaces.Common;
-using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Uploads;
 using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging;
 
 namespace Harmonie.Application.Features.Channels.DeleteMessageAttachment;
 
@@ -16,23 +15,20 @@ public sealed record DeleteChannelMessageAttachmentInput(GuildChannelId ChannelI
 public sealed class DeleteMessageAttachmentHandler : IAuthenticatedHandler<DeleteChannelMessageAttachmentInput, bool>
 {
     private readonly IGuildChannelRepository _guildChannelRepository;
-    private readonly IMessageRepository _messageRepository;
-    private readonly IMessageAttachmentRepository _messageAttachmentRepository;
-    private readonly UploadedFileCleanupService _uploadedFileCleanupService;
-    private readonly IUnitOfWork _unitOfWork;
+    private readonly ITextChannelNotifier _textChannelNotifier;
+    private readonly ILogger<ChannelMessageEditDeleteScope> _scopeLogger;
+    private readonly MessageEditDeleteOrchestrator _orchestrator;
 
     public DeleteMessageAttachmentHandler(
         IGuildChannelRepository guildChannelRepository,
-        IMessageRepository messageRepository,
-        IMessageAttachmentRepository messageAttachmentRepository,
-        UploadedFileCleanupService uploadedFileCleanupService,
-        IUnitOfWork unitOfWork)
+        ITextChannelNotifier textChannelNotifier,
+        ILogger<ChannelMessageEditDeleteScope> scopeLogger,
+        MessageEditDeleteOrchestrator orchestrator)
     {
         _guildChannelRepository = guildChannelRepository;
-        _messageRepository = messageRepository;
-        _messageAttachmentRepository = messageAttachmentRepository;
-        _uploadedFileCleanupService = uploadedFileCleanupService;
-        _unitOfWork = unitOfWork;
+        _textChannelNotifier = textChannelNotifier;
+        _scopeLogger = scopeLogger;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<bool>> HandleAsync(
@@ -40,59 +36,18 @@ public sealed class DeleteMessageAttachmentHandler : IAuthenticatedHandler<Delet
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(request.ChannelId, currentUserId, cancellationToken);
-        if (ctx is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.NotFound,
-                "Channel was not found");
-        }
+        var scope = new ChannelMessageEditDeleteScope(
+            request.ChannelId,
+            _guildChannelRepository,
+            _textChannelNotifier,
+            _scopeLogger);
 
-        if (ctx.Channel.Type != GuildChannelType.Text)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.NotText,
-                "Attachments can only be deleted from messages in text channels");
-        }
-
-        if (ctx.CallerRole is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.AccessDenied,
-                "You do not have access to this channel");
-        }
-
-        var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        if (message is null || !message.Scope.Matches(request.ChannelId))
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Message.NotFound,
-                "Message was not found");
-        }
-
-        if (message.AuthorUserId != currentUserId)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Message.DeleteForbidden,
-                "You can only delete attachments from your own messages");
-        }
-
-        bool deleted;
-        await using (var transaction = await _unitOfWork.BeginAsync(cancellationToken))
-        {
-            deleted = await _messageAttachmentRepository.DeleteAsync(message.Id, request.AttachmentId, cancellationToken);
-            await transaction.CommitAsync(cancellationToken);
-        }
-
-        if (!deleted)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Message.AttachmentNotFound,
-                "Attachment was not found on message");
-        }
-
-        await _uploadedFileCleanupService.DeleteIfExistsAsync(request.AttachmentId, cancellationToken);
-
-        return ApplicationResponse<bool>.Ok(true);
+        return await _orchestrator.DeleteAttachmentAsync(
+            scope,
+            new MessageScope.Channel(request.ChannelId),
+            request.MessageId,
+            request.AttachmentId,
+            currentUserId,
+            cancellationToken);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageHandler.cs
@@ -1,9 +1,7 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.Messages;
 using Harmonie.Application.Interfaces.Channels;
-using Harmonie.Application.Interfaces.Common;
-using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -15,29 +13,21 @@ public sealed record EditChannelMessageInput(GuildChannelId ChannelId, MessageId
 
 public sealed class EditMessageHandler : IAuthenticatedHandler<EditChannelMessageInput, EditMessageResponse>
 {
-    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
-
     private readonly IGuildChannelRepository _guildChannelRepository;
-    private readonly IMessageRepository _channelMessageRepository;
-    private readonly IMessageAttachmentRepository _messageAttachmentRepository;
-    private readonly IUnitOfWork _unitOfWork;
     private readonly ITextChannelNotifier _textChannelNotifier;
-    private readonly ILogger<EditMessageHandler> _logger;
+    private readonly ILogger<ChannelMessageEditDeleteScope> _scopeLogger;
+    private readonly MessageEditDeleteOrchestrator _orchestrator;
 
     public EditMessageHandler(
         IGuildChannelRepository guildChannelRepository,
-        IMessageRepository channelMessageRepository,
-        IMessageAttachmentRepository messageAttachmentRepository,
-        IUnitOfWork unitOfWork,
         ITextChannelNotifier textChannelNotifier,
-        ILogger<EditMessageHandler> logger)
+        ILogger<ChannelMessageEditDeleteScope> scopeLogger,
+        MessageEditDeleteOrchestrator orchestrator)
     {
         _guildChannelRepository = guildChannelRepository;
-        _channelMessageRepository = channelMessageRepository;
-        _messageAttachmentRepository = messageAttachmentRepository;
-        _unitOfWork = unitOfWork;
         _textChannelNotifier = textChannelNotifier;
-        _logger = logger;
+        _scopeLogger = scopeLogger;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<EditMessageResponse>> HandleAsync(
@@ -45,105 +35,30 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditChannelMessag
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        var contentResult = MessageContent.Create(request.Content);
-        if (contentResult.IsFailure || contentResult.Value is null)
-        {
-            var code = MessageContentErrorCodeResolver.Resolve(request.Content);
-            return ApplicationResponse<EditMessageResponse>.Fail(
-                code,
-                contentResult.Error ?? "Message content is invalid");
-        }
+        var scope = new ChannelMessageEditDeleteScope(
+            request.ChannelId,
+            _guildChannelRepository,
+            _textChannelNotifier,
+            _scopeLogger);
 
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(request.ChannelId, currentUserId, cancellationToken);
-        if (ctx is null)
-        {
-            return ApplicationResponse<EditMessageResponse>.Fail(
-                ApplicationErrorCodes.Channel.NotFound,
-                "Channel was not found");
-        }
+        var result = await _orchestrator.EditAsync(
+            scope,
+            new MessageScope.Channel(request.ChannelId),
+            request.MessageId,
+            request.Content,
+            currentUserId,
+            cancellationToken);
 
-        if (ctx.Channel.Type != GuildChannelType.Text)
-        {
-            return ApplicationResponse<EditMessageResponse>.Fail(
-                ApplicationErrorCodes.Channel.NotText,
-                "Messages can only be edited in text channels");
-        }
-
-        if (ctx.CallerRole is null)
-        {
-            return ApplicationResponse<EditMessageResponse>.Fail(
-                ApplicationErrorCodes.Channel.AccessDenied,
-                "You do not have access to this channel");
-        }
-
-        var message = await _channelMessageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        if (message is null || !message.Scope.Matches(request.ChannelId))
-        {
-            return ApplicationResponse<EditMessageResponse>.Fail(
-                ApplicationErrorCodes.Message.NotFound,
-                "Message was not found");
-        }
-
-        if (message.AuthorUserId != currentUserId)
-        {
-            return ApplicationResponse<EditMessageResponse>.Fail(
-                ApplicationErrorCodes.Message.EditForbidden,
-                "You can only edit your own messages");
-        }
-
-        var messageChannelId = request.ChannelId;
-
-        var updateResult = message.UpdateContent(contentResult.Value);
-        if (updateResult.IsFailure)
-        {
-            return ApplicationResponse<EditMessageResponse>.Fail(
-                ApplicationErrorCodes.Common.DomainRuleViolation,
-                updateResult.Error ?? "Message content update failed");
-        }
-
-        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
-        await _channelMessageRepository.UpdateAsync(message, cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
-
-        var updatedAtUtc = message.UpdatedAtUtc;
-        if (updatedAtUtc is null)
-        {
-            return ApplicationResponse<EditMessageResponse>.Fail(
-                ApplicationErrorCodes.Common.InvalidState,
-                "Message edit succeeded but updated timestamp is missing");
-        }
-
-        await NotifyMessageUpdatedSafelyAsync(
-            new TextChannelMessageUpdatedNotification(
-                message.Id,
-                messageChannelId,
-                ctx.Channel.Name,
-                ctx.Channel.GuildId,
-                ctx.GuildName ?? string.Empty,
-                message.Content?.Value,
-                updatedAtUtc.Value));
-
-        var attachments = await _messageAttachmentRepository.GetByMessageIdAsync(message.Id, cancellationToken);
+        if (!result.Success)
+            return ApplicationResponse<EditMessageResponse>.Fail(result.Error!);
 
         return ApplicationResponse<EditMessageResponse>.Ok(new EditMessageResponse(
-            MessageId: message.Id.Value,
-            ChannelId: messageChannelId.Value,
-            AuthorUserId: message.AuthorUserId.Value,
-            Content: message.Content?.Value,
-            Attachments: attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
-            CreatedAtUtc: message.CreatedAtUtc,
-            UpdatedAtUtc: message.UpdatedAtUtc));
-    }
-
-    private async Task NotifyMessageUpdatedSafelyAsync(
-        TextChannelMessageUpdatedNotification notification)
-    {
-        await BestEffortNotificationHelper.TryNotifyAsync(
-            token => _textChannelNotifier.NotifyMessageUpdatedAsync(notification, token),
-            NotificationTimeout,
-            _logger,
-            "EditMessage notification failed (best-effort). MessageId={MessageId}, ChannelId={ChannelId}",
-            notification.MessageId,
-            notification.ChannelId);
+            MessageId: result.Data!.MessageId,
+            ChannelId: request.ChannelId.Value,
+            AuthorUserId: result.Data.AuthorUserId,
+            Content: result.Data.Content,
+            Attachments: result.Data.Attachments,
+            CreatedAtUtc: result.Data.CreatedAtUtc,
+            UpdatedAtUtc: result.Data.UpdatedAtUtc));
     }
 }

--- a/src/Harmonie.Application/Features/Channels/Messages/ChannelMessageEditDeleteScope.cs
+++ b/src/Harmonie.Application/Features/Channels/Messages/ChannelMessageEditDeleteScope.cs
@@ -61,6 +61,7 @@ public sealed class ChannelMessageEditDeleteScope : IMessageEditDeleteScope<Chan
             ctx.CallerRole));
     }
 
+    // In channels, admins can delete any message, not just their own.
     public bool CanDeleteOthersMessages(Context context)
         => context.CallerRole == GuildRole.Admin;
 

--- a/src/Harmonie.Application/Features/Channels/Messages/ChannelMessageEditDeleteScope.cs
+++ b/src/Harmonie.Application/Features/Channels/Messages/ChannelMessageEditDeleteScope.cs
@@ -1,0 +1,115 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Guilds;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging;
+
+namespace Harmonie.Application.Features.Channels.Messages;
+
+/// <summary>
+/// Channel-specific implementation of <see cref="IMessageEditDeleteScope{TContext}"/>.
+/// </summary>
+public sealed class ChannelMessageEditDeleteScope : IMessageEditDeleteScope<ChannelMessageEditDeleteScope.Context>
+{
+    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
+
+    public sealed record Context(
+        GuildChannelId ChannelId,
+        string ChannelName,
+        GuildId GuildId,
+        string GuildName,
+        GuildRole? CallerRole) : ScopeContext;
+
+    private readonly GuildChannelId _channelId;
+    private readonly IGuildChannelRepository _guildChannelRepository;
+    private readonly ITextChannelNotifier _textChannelNotifier;
+    private readonly ILogger<ChannelMessageEditDeleteScope> _logger;
+
+    public ChannelMessageEditDeleteScope(
+        GuildChannelId channelId,
+        IGuildChannelRepository guildChannelRepository,
+        ITextChannelNotifier textChannelNotifier,
+        ILogger<ChannelMessageEditDeleteScope> logger)
+    {
+        _channelId = channelId;
+        _guildChannelRepository = guildChannelRepository;
+        _textChannelNotifier = textChannelNotifier;
+        _logger = logger;
+    }
+
+    public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
+    {
+        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(_channelId, caller, ct);
+        if (ctx is null)
+            return Denied(ApplicationErrorCodes.Channel.NotFound, "Channel was not found");
+
+        if (ctx.Channel.Type != GuildChannelType.Text)
+            return Denied(ApplicationErrorCodes.Channel.NotText, "Messages can only be edited in text channels");
+
+        if (ctx.CallerRole is null)
+            return Denied(ApplicationErrorCodes.Channel.AccessDenied, "You do not have access to this channel");
+
+        return new AuthorizationResult<Context>.Authorized(new Context(
+            _channelId,
+            ctx.Channel.Name,
+            ctx.Channel.GuildId,
+            ctx.GuildName ?? string.Empty,
+            ctx.CallerRole));
+    }
+
+    public bool CanDeleteOthersMessages(Context context)
+        => context.CallerRole == GuildRole.Admin;
+
+    public async Task NotifyMessageUpdatedAsync(
+        Context context,
+        MessageId messageId,
+        string? content,
+        DateTime updatedAtUtc,
+        CancellationToken ct)
+    {
+        var notification = new TextChannelMessageUpdatedNotification(
+            messageId,
+            context.ChannelId,
+            context.ChannelName,
+            context.GuildId,
+            context.GuildName,
+            content,
+            updatedAtUtc);
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            token => _textChannelNotifier.NotifyMessageUpdatedAsync(notification, token),
+            NotificationTimeout,
+            _logger,
+            "EditMessage notification failed (best-effort). MessageId={MessageId}, ChannelId={ChannelId}",
+            notification.MessageId,
+            notification.ChannelId);
+    }
+
+    public async Task NotifyMessageDeletedAsync(
+        Context context,
+        MessageId messageId,
+        CancellationToken ct)
+    {
+        var notification = new TextChannelMessageDeletedNotification(
+            messageId,
+            context.ChannelId,
+            context.ChannelName,
+            context.GuildId,
+            context.GuildName);
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            token => _textChannelNotifier.NotifyMessageDeletedAsync(notification, token),
+            NotificationTimeout,
+            _logger,
+            "DeleteMessage notification failed (best-effort). MessageId={MessageId}, ChannelId={ChannelId}",
+            notification.MessageId,
+            notification.ChannelId);
+    }
+
+    private static AuthorizationResult<Context> Denied(string code, string detail)
+        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
+}

--- a/src/Harmonie.Application/Features/Conversations/DeleteMessage/DeleteMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteMessage/DeleteMessageHandler.cs
@@ -1,7 +1,7 @@
 using Harmonie.Application.Common;
-using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Conversations.Messages;
 using Harmonie.Application.Interfaces.Conversations;
-using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -13,26 +13,21 @@ public sealed record DeleteConversationMessageInput(ConversationId ConversationI
 
 public sealed class DeleteMessageHandler : IAuthenticatedHandler<DeleteConversationMessageInput, bool>
 {
-    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
-
     private readonly IConversationRepository _conversationRepository;
-    private readonly IMessageRepository _conversationMessageRepository;
-    private readonly IUnitOfWork _unitOfWork;
     private readonly IConversationMessageNotifier _conversationMessageNotifier;
-    private readonly ILogger<DeleteMessageHandler> _logger;
+    private readonly ILogger<ConversationMessageEditDeleteScope> _scopeLogger;
+    private readonly MessageEditDeleteOrchestrator _orchestrator;
 
     public DeleteMessageHandler(
         IConversationRepository conversationRepository,
-        IMessageRepository conversationMessageRepository,
-        IUnitOfWork unitOfWork,
         IConversationMessageNotifier conversationMessageNotifier,
-        ILogger<DeleteMessageHandler> logger)
+        ILogger<ConversationMessageEditDeleteScope> scopeLogger,
+        MessageEditDeleteOrchestrator orchestrator)
     {
         _conversationRepository = conversationRepository;
-        _conversationMessageRepository = conversationMessageRepository;
-        _unitOfWork = unitOfWork;
         _conversationMessageNotifier = conversationMessageNotifier;
-        _logger = logger;
+        _scopeLogger = scopeLogger;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<bool>> HandleAsync(
@@ -40,62 +35,17 @@ public sealed class DeleteMessageHandler : IAuthenticatedHandler<DeleteConversat
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(request.ConversationId, currentUserId, cancellationToken);
-        if (access is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Conversation.NotFound,
-                "Conversation was not found");
-        }
-        if (access.Participant is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Conversation.AccessDenied,
-                "You do not have access to this conversation");
-        }
+        var scope = new ConversationMessageEditDeleteScope(
+            request.ConversationId,
+            _conversationRepository,
+            _conversationMessageNotifier,
+            _scopeLogger);
 
-        var message = await _conversationMessageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        if (message is null || !message.Scope.Matches(request.ConversationId))
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Message.NotFound,
-                "Message was not found");
-        }
-
-        if (message.AuthorUserId != currentUserId)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Message.DeleteForbidden,
-                "You can only delete your own messages");
-        }
-
-        var deleteResult = message.Delete();
-        if (deleteResult.IsFailure)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Common.DomainRuleViolation,
-                deleteResult.Error ?? "Message deletion failed");
-        }
-
-        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
-        await _conversationMessageRepository.SoftDeleteAsync(message, cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
-
-        await NotifyMessageDeletedSafelyAsync(
-            new ConversationMessageDeletedNotification(request.MessageId, request.ConversationId, access.Conversation.Name, access.Conversation.Type.ToString()));
-
-        return ApplicationResponse<bool>.Ok(true);
-    }
-
-    private async Task NotifyMessageDeletedSafelyAsync(
-        ConversationMessageDeletedNotification notification)
-    {
-        await BestEffortNotificationHelper.TryNotifyAsync(
-            token => _conversationMessageNotifier.NotifyMessageDeletedAsync(notification, token),
-            NotificationTimeout,
-            _logger,
-            "DeleteConversationMessage notification failed (best-effort). MessageId={MessageId}, ConversationId={ConversationId}",
-            notification.MessageId,
-            notification.ConversationId);
+        return await _orchestrator.DeleteAsync(
+            scope,
+            new MessageScope.Conversation(request.ConversationId),
+            request.MessageId,
+            currentUserId,
+            cancellationToken);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
@@ -1,8 +1,7 @@
 using Harmonie.Application.Common;
-using Harmonie.Application.Common.Uploads;
-using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Conversations.Messages;
 using Harmonie.Application.Interfaces.Conversations;
-using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Uploads;
@@ -16,26 +15,20 @@ public sealed record DeleteConversationMessageAttachmentInput(ConversationId Con
 public sealed class DeleteMessageAttachmentHandler : IAuthenticatedHandler<DeleteConversationMessageAttachmentInput, bool>
 {
     private readonly IConversationRepository _conversationRepository;
-    private readonly IMessageRepository _conversationMessageRepository;
-    private readonly IMessageAttachmentRepository _messageAttachmentRepository;
-    private readonly UploadedFileCleanupService _uploadedFileCleanupService;
-    private readonly IUnitOfWork _unitOfWork;
-    private readonly ILogger<DeleteMessageAttachmentHandler> _logger;
+    private readonly IConversationMessageNotifier _conversationMessageNotifier;
+    private readonly ILogger<ConversationMessageEditDeleteScope> _scopeLogger;
+    private readonly MessageEditDeleteOrchestrator _orchestrator;
 
     public DeleteMessageAttachmentHandler(
         IConversationRepository conversationRepository,
-        IMessageRepository conversationMessageRepository,
-        IMessageAttachmentRepository messageAttachmentRepository,
-        UploadedFileCleanupService uploadedFileCleanupService,
-        IUnitOfWork unitOfWork,
-        ILogger<DeleteMessageAttachmentHandler> logger)
+        IConversationMessageNotifier conversationMessageNotifier,
+        ILogger<ConversationMessageEditDeleteScope> scopeLogger,
+        MessageEditDeleteOrchestrator orchestrator)
     {
         _conversationRepository = conversationRepository;
-        _conversationMessageRepository = conversationMessageRepository;
-        _messageAttachmentRepository = messageAttachmentRepository;
-        _uploadedFileCleanupService = uploadedFileCleanupService;
-        _unitOfWork = unitOfWork;
-        _logger = logger;
+        _conversationMessageNotifier = conversationMessageNotifier;
+        _scopeLogger = scopeLogger;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<bool>> HandleAsync(
@@ -43,51 +36,18 @@ public sealed class DeleteMessageAttachmentHandler : IAuthenticatedHandler<Delet
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(request.ConversationId, currentUserId, cancellationToken);
-        if (access is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Conversation.NotFound,
-                "Conversation was not found");
-        }
-        if (access.Participant is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Conversation.AccessDenied,
-                "You do not have access to this conversation");
-        }
+        var scope = new ConversationMessageEditDeleteScope(
+            request.ConversationId,
+            _conversationRepository,
+            _conversationMessageNotifier,
+            _scopeLogger);
 
-        var message = await _conversationMessageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        if (message is null || !message.Scope.Matches(request.ConversationId))
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Message.NotFound,
-                "Message was not found");
-        }
-
-        if (message.AuthorUserId != currentUserId)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Message.DeleteForbidden,
-                "You can only delete attachments from your own messages");
-        }
-
-        bool deleted;
-        await using (var transaction = await _unitOfWork.BeginAsync(cancellationToken))
-        {
-            deleted = await _messageAttachmentRepository.DeleteAsync(message.Id, request.AttachmentId, cancellationToken);
-            await transaction.CommitAsync(cancellationToken);
-        }
-
-        if (!deleted)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Message.AttachmentNotFound,
-                "Attachment was not found on message");
-        }
-
-        await _uploadedFileCleanupService.DeleteIfExistsAsync(request.AttachmentId, cancellationToken);
-
-        return ApplicationResponse<bool>.Ok(true);
+        return await _orchestrator.DeleteAttachmentAsync(
+            scope,
+            new MessageScope.Conversation(request.ConversationId),
+            request.MessageId,
+            request.AttachmentId,
+            currentUserId,
+            cancellationToken);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageHandler.cs
@@ -1,8 +1,7 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
-using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Features.Conversations.Messages;
 using Harmonie.Application.Interfaces.Conversations;
-using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -14,29 +13,21 @@ public sealed record EditConversationMessageInput(ConversationId ConversationId,
 
 public sealed class EditMessageHandler : IAuthenticatedHandler<EditConversationMessageInput, EditMessageResponse>
 {
-    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
-
     private readonly IConversationRepository _conversationRepository;
-    private readonly IMessageRepository _conversationMessageRepository;
-    private readonly IMessageAttachmentRepository _messageAttachmentRepository;
-    private readonly IUnitOfWork _unitOfWork;
     private readonly IConversationMessageNotifier _conversationMessageNotifier;
-    private readonly ILogger<EditMessageHandler> _logger;
+    private readonly ILogger<ConversationMessageEditDeleteScope> _scopeLogger;
+    private readonly MessageEditDeleteOrchestrator _orchestrator;
 
     public EditMessageHandler(
         IConversationRepository conversationRepository,
-        IMessageRepository conversationMessageRepository,
-        IMessageAttachmentRepository messageAttachmentRepository,
-        IUnitOfWork unitOfWork,
         IConversationMessageNotifier conversationMessageNotifier,
-        ILogger<EditMessageHandler> logger)
+        ILogger<ConversationMessageEditDeleteScope> scopeLogger,
+        MessageEditDeleteOrchestrator orchestrator)
     {
         _conversationRepository = conversationRepository;
-        _conversationMessageRepository = conversationMessageRepository;
-        _messageAttachmentRepository = messageAttachmentRepository;
-        _unitOfWork = unitOfWork;
         _conversationMessageNotifier = conversationMessageNotifier;
-        _logger = logger;
+        _scopeLogger = scopeLogger;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<EditMessageResponse>> HandleAsync(
@@ -44,96 +35,30 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditConversationM
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        var contentResult = MessageContent.Create(request.Content);
-        if (contentResult.IsFailure || contentResult.Value is null)
-        {
-            var code = MessageContentErrorCodeResolver.Resolve(request.Content);
-            return ApplicationResponse<EditMessageResponse>.Fail(
-                code,
-                contentResult.Error ?? "Message content is invalid");
-        }
+        var scope = new ConversationMessageEditDeleteScope(
+            request.ConversationId,
+            _conversationRepository,
+            _conversationMessageNotifier,
+            _scopeLogger);
 
-        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(request.ConversationId, currentUserId, cancellationToken);
-        if (access is null)
-        {
-            return ApplicationResponse<EditMessageResponse>.Fail(
-                ApplicationErrorCodes.Conversation.NotFound,
-                "Conversation was not found");
-        }
-        if (access.Participant is null)
-        {
-            return ApplicationResponse<EditMessageResponse>.Fail(
-                ApplicationErrorCodes.Conversation.AccessDenied,
-                "You do not have access to this conversation");
-        }
+        var result = await _orchestrator.EditAsync(
+            scope,
+            new MessageScope.Conversation(request.ConversationId),
+            request.MessageId,
+            request.Content,
+            currentUserId,
+            cancellationToken);
 
-        var message = await _conversationMessageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        if (message is null || !message.Scope.Matches(request.ConversationId))
-        {
-            return ApplicationResponse<EditMessageResponse>.Fail(
-                ApplicationErrorCodes.Message.NotFound,
-                "Message was not found");
-        }
-
-        if (message.AuthorUserId != currentUserId)
-        {
-            return ApplicationResponse<EditMessageResponse>.Fail(
-                ApplicationErrorCodes.Message.EditForbidden,
-                "You can only edit your own messages");
-        }
-
-        var messageConversationId = request.ConversationId;
-
-        var updateResult = message.UpdateContent(contentResult.Value);
-        if (updateResult.IsFailure)
-        {
-            return ApplicationResponse<EditMessageResponse>.Fail(
-                ApplicationErrorCodes.Common.DomainRuleViolation,
-                updateResult.Error ?? "Message content update failed");
-        }
-
-        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
-        await _conversationMessageRepository.UpdateAsync(message, cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
-
-        var updatedAtUtc = message.UpdatedAtUtc;
-        if (updatedAtUtc is null)
-        {
-            return ApplicationResponse<EditMessageResponse>.Fail(
-                ApplicationErrorCodes.Common.InvalidState,
-                "Message edit succeeded but updated timestamp is missing");
-        }
-
-        await NotifyMessageUpdatedSafelyAsync(
-            new ConversationMessageUpdatedNotification(
-                message.Id,
-                messageConversationId,
-                access.Conversation.Name,
-                access.Conversation.Type.ToString(),
-                message.Content?.Value,
-                updatedAtUtc.Value));
-
-        var attachments = await _messageAttachmentRepository.GetByMessageIdAsync(message.Id, cancellationToken);
+        if (!result.Success)
+            return ApplicationResponse<EditMessageResponse>.Fail(result.Error!);
 
         return ApplicationResponse<EditMessageResponse>.Ok(new EditMessageResponse(
-            MessageId: message.Id.Value,
-            ConversationId: messageConversationId.Value,
-            AuthorUserId: message.AuthorUserId.Value,
-            Content: message.Content?.Value,
-            Attachments: attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
-            CreatedAtUtc: message.CreatedAtUtc,
-            UpdatedAtUtc: updatedAtUtc));
-    }
-
-    private async Task NotifyMessageUpdatedSafelyAsync(
-        ConversationMessageUpdatedNotification notification)
-    {
-        await BestEffortNotificationHelper.TryNotifyAsync(
-            token => _conversationMessageNotifier.NotifyMessageUpdatedAsync(notification, token),
-            NotificationTimeout,
-            _logger,
-            "EditConversationMessage notification failed (best-effort). MessageId={MessageId}, ConversationId={ConversationId}",
-            notification.MessageId,
-            notification.ConversationId);
+            MessageId: result.Data!.MessageId,
+            ConversationId: request.ConversationId.Value,
+            AuthorUserId: result.Data.AuthorUserId,
+            Content: result.Data.Content,
+            Attachments: result.Data.Attachments,
+            CreatedAtUtc: result.Data.CreatedAtUtc,
+            UpdatedAtUtc: result.Data.UpdatedAtUtc));
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/Messages/ConversationMessageEditDeleteScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/Messages/ConversationMessageEditDeleteScope.cs
@@ -53,6 +53,7 @@ public sealed class ConversationMessageEditDeleteScope : IMessageEditDeleteScope
             access.Conversation.Type));
     }
 
+    // Conversations have no admin role; only the author can delete their own messages.
     public bool CanDeleteOthersMessages(Context context)
         => false;
 

--- a/src/Harmonie.Application/Features/Conversations/Messages/ConversationMessageEditDeleteScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/Messages/ConversationMessageEditDeleteScope.cs
@@ -1,0 +1,105 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Domain.Entities.Conversations;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging;
+
+namespace Harmonie.Application.Features.Conversations.Messages;
+
+/// <summary>
+/// Conversation-specific implementation of <see cref="IMessageEditDeleteScope{TContext}"/>.
+/// </summary>
+public sealed class ConversationMessageEditDeleteScope : IMessageEditDeleteScope<ConversationMessageEditDeleteScope.Context>
+{
+    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
+
+    public sealed record Context(
+        ConversationId ConversationId,
+        string? ConversationName,
+        ConversationType ConversationType) : ScopeContext;
+
+    private readonly ConversationId _conversationId;
+    private readonly IConversationRepository _conversationRepository;
+    private readonly IConversationMessageNotifier _conversationMessageNotifier;
+    private readonly ILogger<ConversationMessageEditDeleteScope> _logger;
+
+    public ConversationMessageEditDeleteScope(
+        ConversationId conversationId,
+        IConversationRepository conversationRepository,
+        IConversationMessageNotifier conversationMessageNotifier,
+        ILogger<ConversationMessageEditDeleteScope> logger)
+    {
+        _conversationId = conversationId;
+        _conversationRepository = conversationRepository;
+        _conversationMessageNotifier = conversationMessageNotifier;
+        _logger = logger;
+    }
+
+    public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
+    {
+        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(_conversationId, caller, ct);
+        if (access is null)
+            return Denied(ApplicationErrorCodes.Conversation.NotFound, "Conversation was not found");
+
+        if (access.Participant is null)
+            return Denied(ApplicationErrorCodes.Conversation.AccessDenied, "You do not have access to this conversation");
+
+        return new AuthorizationResult<Context>.Authorized(new Context(
+            _conversationId,
+            access.Conversation.Name,
+            access.Conversation.Type));
+    }
+
+    public bool CanDeleteOthersMessages(Context context)
+        => false;
+
+    public async Task NotifyMessageUpdatedAsync(
+        Context context,
+        MessageId messageId,
+        string? content,
+        DateTime updatedAtUtc,
+        CancellationToken ct)
+    {
+        var notification = new ConversationMessageUpdatedNotification(
+            messageId,
+            context.ConversationId,
+            context.ConversationName,
+            context.ConversationType.ToString(),
+            content,
+            updatedAtUtc);
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            token => _conversationMessageNotifier.NotifyMessageUpdatedAsync(notification, token),
+            NotificationTimeout,
+            _logger,
+            "EditConversationMessage notification failed (best-effort). MessageId={MessageId}, ConversationId={ConversationId}",
+            notification.MessageId,
+            notification.ConversationId);
+    }
+
+    public async Task NotifyMessageDeletedAsync(
+        Context context,
+        MessageId messageId,
+        CancellationToken ct)
+    {
+        var notification = new ConversationMessageDeletedNotification(
+            messageId,
+            context.ConversationId,
+            context.ConversationName,
+            context.ConversationType.ToString());
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            token => _conversationMessageNotifier.NotifyMessageDeletedAsync(notification, token),
+            NotificationTimeout,
+            _logger,
+            "DeleteConversationMessage notification failed (best-effort). MessageId={MessageId}, ConversationId={ConversationId}",
+            notification.MessageId,
+            notification.ConversationId);
+    }
+
+    private static AuthorizationResult<Context> Denied(string code, string detail)
+        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
+}

--- a/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageAttachmentHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageAttachmentHandlerTests.cs
@@ -1,7 +1,9 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Features.Conversations.DeleteMessageAttachment;
+using Harmonie.Application.Features.Conversations.Messages;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
@@ -15,7 +17,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
-
 namespace Harmonie.Application.Tests.Messages;
 
 public sealed class DeleteConversationMessageAttachmentHandlerTests
@@ -27,6 +28,7 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
     private readonly Mock<IObjectStorageService> _objectStorageServiceMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly MessageEditDeleteOrchestrator _orchestrator;
     private readonly DeleteMessageAttachmentHandler _handler;
 
     public DeleteConversationMessageAttachmentHandlerTests()
@@ -41,16 +43,22 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
 
         _transactionMock = _unitOfWorkMock.SetupTransactionMock();
 
-        _handler = new DeleteMessageAttachmentHandler(
-            _conversationRepositoryMock.Object,
+        var uploadedFileCleanupService = new UploadedFileCleanupService(
+            _uploadedFileRepositoryMock.Object,
+            _objectStorageServiceMock.Object,
+            NullLogger<UploadedFileCleanupService>.Instance);
+
+        _orchestrator = new MessageEditDeleteOrchestrator(
             _conversationMessageRepositoryMock.Object,
             _messageAttachmentRepositoryMock.Object,
-            new UploadedFileCleanupService(
-                _uploadedFileRepositoryMock.Object,
-                _objectStorageServiceMock.Object,
-                NullLogger<UploadedFileCleanupService>.Instance),
             _unitOfWorkMock.Object,
-            NullLogger<DeleteMessageAttachmentHandler>.Instance);
+            uploadedFileCleanupService);
+
+        _handler = new DeleteMessageAttachmentHandler(
+            _conversationRepositoryMock.Object,
+            new Mock<IConversationMessageNotifier>().Object,
+            NullLogger<ConversationMessageEditDeleteScope>.Instance,
+            _orchestrator);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageHandlerTests.cs
@@ -1,9 +1,13 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Features.Conversations.DeleteMessage;
+using Harmonie.Application.Features.Conversations.Messages;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
@@ -13,22 +17,24 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
-
 namespace Harmonie.Application.Tests.Messages;
 
 public sealed class DeleteConversationMessageHandlerTests
 {
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IMessageRepository> _directMessageRepositoryMock;
+    private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IConversationMessageNotifier> _directMessageNotifierMock;
+    private readonly MessageEditDeleteOrchestrator _orchestrator;
     private readonly DeleteMessageHandler _handler;
 
     public DeleteConversationMessageHandlerTests()
     {
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _directMessageRepositoryMock = new Mock<IMessageRepository>();
+        _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
         _directMessageNotifierMock = new Mock<IConversationMessageNotifier>();
@@ -39,12 +45,22 @@ public sealed class DeleteConversationMessageHandlerTests
             .Setup(x => x.NotifyMessageDeletedAsync(It.IsAny<ConversationMessageDeletedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
+        var uploadedFileCleanupService = new UploadedFileCleanupService(
+            new Mock<IUploadedFileRepository>().Object,
+            new Mock<IObjectStorageService>().Object,
+            NullLogger<UploadedFileCleanupService>.Instance);
+
+        _orchestrator = new MessageEditDeleteOrchestrator(
+            _directMessageRepositoryMock.Object,
+            _messageAttachmentRepositoryMock.Object,
+            _unitOfWorkMock.Object,
+            uploadedFileCleanupService);
+
         _handler = new DeleteMessageHandler(
             _conversationRepositoryMock.Object,
-            _directMessageRepositoryMock.Object,
-            _unitOfWorkMock.Object,
             _directMessageNotifierMock.Object,
-            NullLogger<DeleteMessageHandler>.Instance);
+            NullLogger<ConversationMessageEditDeleteScope>.Instance,
+            _orchestrator);
     }
 
     [Fact]
@@ -217,7 +233,7 @@ public sealed class DeleteConversationMessageHandlerTests
         _directMessageNotifierMock.Verify(
             x => x.NotifyMessageDeletedAsync(
                 It.Is<ConversationMessageDeletedNotification>(n =>
-                    n.MessageId == messageId
+                    n.MessageId == message.Id
                     && n.ConversationId == conversation.Id
                     && n.ConversationName == null
                     && n.ConversationType == "Direct"),
@@ -254,5 +270,4 @@ public sealed class DeleteConversationMessageHandlerTests
         response.Error.Should().BeNull();
         _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
-
 }

--- a/tests/Harmonie.Application.Tests/Messages/DeleteMessageAttachmentHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/DeleteMessageAttachmentHandlerTests.cs
@@ -1,7 +1,9 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Features.Channels.DeleteMessageAttachment;
+using Harmonie.Application.Features.Channels.Messages;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
@@ -17,7 +19,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
-
 namespace Harmonie.Application.Tests.Messages;
 
 public sealed class DeleteMessageAttachmentHandlerTests
@@ -29,6 +30,7 @@ public sealed class DeleteMessageAttachmentHandlerTests
     private readonly Mock<IObjectStorageService> _objectStorageServiceMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly MessageEditDeleteOrchestrator _orchestrator;
     private readonly DeleteMessageAttachmentHandler _handler;
 
     public DeleteMessageAttachmentHandlerTests()
@@ -43,15 +45,22 @@ public sealed class DeleteMessageAttachmentHandlerTests
 
         _transactionMock = _unitOfWorkMock.SetupTransactionMock();
 
-        _handler = new DeleteMessageAttachmentHandler(
-            _guildChannelRepositoryMock.Object,
+        var uploadedFileCleanupService = new UploadedFileCleanupService(
+            _uploadedFileRepositoryMock.Object,
+            _objectStorageServiceMock.Object,
+            NullLogger<UploadedFileCleanupService>.Instance);
+
+        _orchestrator = new MessageEditDeleteOrchestrator(
             _messageRepositoryMock.Object,
             _messageAttachmentRepositoryMock.Object,
-            new UploadedFileCleanupService(
-                _uploadedFileRepositoryMock.Object,
-                _objectStorageServiceMock.Object,
-                NullLogger<UploadedFileCleanupService>.Instance),
-            _unitOfWorkMock.Object);
+            _unitOfWorkMock.Object,
+            uploadedFileCleanupService);
+
+        _handler = new DeleteMessageAttachmentHandler(
+            _guildChannelRepositoryMock.Object,
+            new Mock<ITextChannelNotifier>().Object,
+            NullLogger<ChannelMessageEditDeleteScope>.Instance,
+            _orchestrator);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/DeleteMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/DeleteMessageHandlerTests.cs
@@ -1,9 +1,13 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Features.Channels.DeleteMessage;
+using Harmonie.Application.Features.Channels.Messages;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Guilds;
 using Harmonie.Domain.Entities.Messages;
@@ -22,15 +26,18 @@ public sealed class DeleteMessageHandlerTests
 {
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IMessageRepository> _channelMessageRepositoryMock;
+    private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<ITextChannelNotifier> _textChannelNotifierMock;
+    private readonly MessageEditDeleteOrchestrator _orchestrator;
     private readonly DeleteMessageHandler _handler;
 
     public DeleteMessageHandlerTests()
     {
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
         _channelMessageRepositoryMock = new Mock<IMessageRepository>();
+        _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
         _textChannelNotifierMock = new Mock<ITextChannelNotifier>();
@@ -40,12 +47,23 @@ public sealed class DeleteMessageHandlerTests
         _textChannelNotifierMock
             .Setup(x => x.NotifyMessageDeletedAsync(It.IsAny<TextChannelMessageDeletedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
+
+        var uploadedFileCleanupService = new UploadedFileCleanupService(
+            new Mock<IUploadedFileRepository>().Object,
+            new Mock<IObjectStorageService>().Object,
+            NullLogger<UploadedFileCleanupService>.Instance);
+
+        _orchestrator = new MessageEditDeleteOrchestrator(
+            _channelMessageRepositoryMock.Object,
+            _messageAttachmentRepositoryMock.Object,
+            _unitOfWorkMock.Object,
+            uploadedFileCleanupService);
+
         _handler = new DeleteMessageHandler(
             _guildChannelRepositoryMock.Object,
-            _channelMessageRepositoryMock.Object,
-            _unitOfWorkMock.Object,
             _textChannelNotifierMock.Object,
-            NullLogger<DeleteMessageHandler>.Instance);
+            NullLogger<ChannelMessageEditDeleteScope>.Instance,
+            _orchestrator);
     }
 
     [Fact]
@@ -306,7 +324,7 @@ public sealed class DeleteMessageHandlerTests
         _textChannelNotifierMock.Verify(
             x => x.NotifyMessageDeletedAsync(
                 It.Is<TextChannelMessageDeletedNotification>(n =>
-                    n.MessageId == messageId &&
+                    n.MessageId == message.Id &&
                     n.ChannelId == channel.Id &&
                     n.GuildId == channel.GuildId),
                 It.IsAny<CancellationToken>()),

--- a/tests/Harmonie.Application.Tests/Messages/EditConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/EditConversationMessageHandlerTests.cs
@@ -1,9 +1,13 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Features.Conversations.EditMessage;
+using Harmonie.Application.Features.Conversations.Messages;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
@@ -12,7 +16,6 @@ using Harmonie.Domain.ValueObjects.Users;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
-
 
 namespace Harmonie.Application.Tests.Messages;
 
@@ -24,6 +27,7 @@ public sealed class EditConversationMessageHandlerTests
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IConversationMessageNotifier> _directMessageNotifierMock;
+    private readonly MessageEditDeleteOrchestrator _orchestrator;
     private readonly EditMessageHandler _handler;
 
     public EditConversationMessageHandlerTests()
@@ -45,13 +49,22 @@ public sealed class EditConversationMessageHandlerTests
             .Setup(x => x.GetByMessageIdAsync(It.IsAny<MessageId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<MessageAttachment>());
 
-        _handler = new EditMessageHandler(
-            _conversationRepositoryMock.Object,
+        var uploadedFileCleanupService = new UploadedFileCleanupService(
+            new Mock<IUploadedFileRepository>().Object,
+            new Mock<IObjectStorageService>().Object,
+            NullLogger<UploadedFileCleanupService>.Instance);
+
+        _orchestrator = new MessageEditDeleteOrchestrator(
             _directMessageRepositoryMock.Object,
             _messageAttachmentRepositoryMock.Object,
             _unitOfWorkMock.Object,
+            uploadedFileCleanupService);
+
+        _handler = new EditMessageHandler(
+            _conversationRepositoryMock.Object,
             _directMessageNotifierMock.Object,
-            NullLogger<EditMessageHandler>.Instance);
+            NullLogger<ConversationMessageEditDeleteScope>.Instance,
+            _orchestrator);
     }
 
     [Fact]
@@ -302,5 +315,4 @@ public sealed class EditConversationMessageHandlerTests
         response.Error.Should().BeNull();
         _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
-
 }

--- a/tests/Harmonie.Application.Tests/Messages/EditMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/EditMessageHandlerTests.cs
@@ -1,9 +1,13 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Features.Channels.EditMessage;
+using Harmonie.Application.Features.Channels.Messages;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Guilds;
 using Harmonie.Domain.Entities.Messages;
@@ -26,12 +30,14 @@ public sealed class EditMessageHandlerTests
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<ITextChannelNotifier> _textChannelNotifierMock;
+    private readonly MessageEditDeleteOrchestrator _orchestrator;
     private readonly EditMessageHandler _handler;
 
     public EditMessageHandlerTests()
     {
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
         _channelMessageRepositoryMock = new Mock<IMessageRepository>();
+        _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
         _textChannelNotifierMock = new Mock<ITextChannelNotifier>();
@@ -42,18 +48,26 @@ public sealed class EditMessageHandlerTests
             .Setup(x => x.NotifyMessageUpdatedAsync(It.IsAny<TextChannelMessageUpdatedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
         _messageAttachmentRepositoryMock
             .Setup(x => x.GetByMessageIdAsync(It.IsAny<MessageId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<MessageAttachment>());
 
-        _handler = new EditMessageHandler(
-            _guildChannelRepositoryMock.Object,
+        var uploadedFileCleanupService = new UploadedFileCleanupService(
+            new Mock<IUploadedFileRepository>().Object,
+            new Mock<IObjectStorageService>().Object,
+            NullLogger<UploadedFileCleanupService>.Instance);
+
+        _orchestrator = new MessageEditDeleteOrchestrator(
             _channelMessageRepositoryMock.Object,
             _messageAttachmentRepositoryMock.Object,
             _unitOfWorkMock.Object,
+            uploadedFileCleanupService);
+
+        _handler = new EditMessageHandler(
+            _guildChannelRepositoryMock.Object,
             _textChannelNotifierMock.Object,
-            NullLogger<EditMessageHandler>.Instance);
+            NullLogger<ChannelMessageEditDeleteScope>.Instance,
+            _orchestrator);
     }
 
     [Fact]
@@ -332,5 +346,4 @@ public sealed class EditMessageHandlerTests
 
         response.Success.Should().BeTrue();
     }
-
 }

--- a/tests/Harmonie.Application.Tests/Messages/MessageEditDeleteOrchestratorTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/MessageEditDeleteOrchestratorTests.cs
@@ -1,0 +1,567 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Common.Uploads;
+using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Uploads;
+using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.Entities.Uploads;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Uploads;
+using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Messages;
+
+public sealed class MessageEditDeleteOrchestratorTests
+{
+    // Simple test context used across both channel and conversation scope mocks.
+    public sealed record OrchestratorTestContext : ScopeContext;
+
+    private readonly Mock<IMessageRepository> _messageRepositoryMock;
+    private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly Mock<IUploadedFileRepository> _uploadedFileRepositoryMock;
+    private readonly Mock<IObjectStorageService> _objectStorageServiceMock;
+    private readonly MessageEditDeleteOrchestrator _orchestrator;
+
+    private static readonly OrchestratorTestContext Ctx = new();
+
+    public MessageEditDeleteOrchestratorTests()
+    {
+        _messageRepositoryMock = new Mock<IMessageRepository>();
+        _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _transactionMock = _unitOfWorkMock.SetupTransactionMock();
+        _uploadedFileRepositoryMock = new Mock<IUploadedFileRepository>();
+        _objectStorageServiceMock = new Mock<IObjectStorageService>();
+
+        var uploadedFileCleanupService = new UploadedFileCleanupService(
+            _uploadedFileRepositoryMock.Object,
+            _objectStorageServiceMock.Object,
+            NullLogger<UploadedFileCleanupService>.Instance);
+
+        _orchestrator = new MessageEditDeleteOrchestrator(
+            _messageRepositoryMock.Object,
+            _messageAttachmentRepositoryMock.Object,
+            _unitOfWorkMock.Object,
+            uploadedFileCleanupService);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private static MessageScope ChannelScope() => new MessageScope.Channel(GuildChannelId.New());
+    private static MessageScope ConversationScope() => new MessageScope.Conversation(ConversationId.New());
+    private static MessageId AnyMessageId() => MessageId.New();
+    private static UserId AnyUser() => UserId.New();
+    private static UploadedFileId AnyAttachmentId() => UploadedFileId.New();
+    private const string TestContent = "updated content";
+
+    /// <summary>Creates a scope mock that authorizes successfully and allows notifications.</summary>
+    private static Mock<IMessageEditDeleteScope<OrchestratorTestContext>> CreateAuthorizedScope(
+        bool canDeleteOthers = false)
+    {
+        var mock = new Mock<IMessageEditDeleteScope<OrchestratorTestContext>>();
+        mock.Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<OrchestratorTestContext>.Authorized(Ctx));
+        mock.Setup(x => x.CanDeleteOthersMessages(Ctx)).Returns(canDeleteOthers);
+        mock.Setup(x => x.NotifyMessageUpdatedAsync(
+            Ctx, It.IsAny<MessageId>(), It.IsAny<string?>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        mock.Setup(x => x.NotifyMessageDeletedAsync(
+            Ctx, It.IsAny<MessageId>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        return mock;
+    }
+
+    /// <summary>Creates a scope mock that denies authorization with the given error code.</summary>
+    private static Mock<IMessageEditDeleteScope<OrchestratorTestContext>> CreateDeniedScope(string code, string detail)
+    {
+        var mock = new Mock<IMessageEditDeleteScope<OrchestratorTestContext>>();
+        mock.Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<OrchestratorTestContext>.Denied(new ApplicationError(code, detail)));
+        return mock;
+    }
+
+    /// <summary>Registers a message in the mock repository and returns it (its Id may differ from messageId).</summary>
+    private Message SetupMessageExists(MessageId messageId, MessageScope scope, UserId? authorId = null)
+    {
+        Message message;
+        if (scope is MessageScope.Channel c)
+            message = ApplicationTestBuilders.CreateChannelMessage(c.ChannelId, authorId ?? AnyUser(), "original");
+        else
+            message = ApplicationTestBuilders.CreateConversationMessage(
+                ((MessageScope.Conversation)scope).ConversationId, authorId ?? AnyUser(), "original");
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+        return message;
+    }
+
+    private void SetupMessageNotFound(MessageId messageId)
+    {
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Message?)null);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  EditAsync
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task EditAsync_WithEmptyContent_ShouldReturnContentEmpty()
+    {
+        var scope = CreateAuthorizedScope();
+        var result = await _orchestrator.EditAsync(
+            scope.Object, ChannelScope(), AnyMessageId(), "   ", AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.ContentEmpty);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task EditAsync_WhenAuthorizationDenied_ShouldReturnAuthError()
+    {
+        var scope = CreateDeniedScope("AUTH_DENIED", "Not allowed");
+        var result = await _orchestrator.EditAsync(
+            scope.Object, ChannelScope(), AnyMessageId(), TestContent, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be("AUTH_DENIED");
+    }
+
+    [Fact]
+    public async Task EditAsync_WhenMessageNotFound_ShouldReturnMessageNotFound()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        SetupMessageNotFound(messageId);
+
+        var result = await _orchestrator.EditAsync(
+            scope.Object, ChannelScope(), messageId, TestContent, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
+    }
+
+    [Fact]
+    public async Task EditAsync_WhenMessageInWrongScope_ShouldReturnMessageNotFound()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var wrongScope = new MessageScope.Conversation(ConversationId.New());
+        SetupMessageExists(messageId, wrongScope);
+
+        var result = await _orchestrator.EditAsync(
+            scope.Object, ChannelScope(), messageId, TestContent, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
+    }
+
+    [Fact]
+    public async Task EditAsync_WhenCallerIsNotAuthor_ShouldReturnEditForbidden()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var messageScope = ChannelScope();
+        var authorId = UserId.New();
+        var callerId = UserId.New();
+        SetupMessageExists(messageId, messageScope, authorId);
+
+        var result = await _orchestrator.EditAsync(
+            scope.Object, messageScope, messageId, TestContent, callerId, TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.EditForbidden);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task EditAsync_WhenAuthorEditsOwnMessage_ShouldPersistCommitAndNotify()
+    {
+        var scopeMock = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var messageScope = ChannelScope();
+        var authorId = UserId.New();
+        var message = SetupMessageExists(messageId, messageScope, authorId);
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.GetByMessageIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<MessageAttachment>());
+
+        var callOrder = new List<string>();
+        _messageRepositoryMock
+            .Setup(x => x.UpdateAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("update"))
+            .Returns(Task.CompletedTask);
+        _transactionMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("commit"))
+            .Returns(Task.CompletedTask);
+        scopeMock
+            .Setup(x => x.NotifyMessageUpdatedAsync(
+                Ctx, message.Id, TestContent, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("notify"))
+            .Returns(Task.CompletedTask);
+
+        var result = await _orchestrator.EditAsync(
+            scopeMock.Object, messageScope, messageId, TestContent, authorId, TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        result.Data!.Content.Should().Be(TestContent);
+        result.Data.UpdatedAtUtc.Should().NotBeNull();
+        _messageRepositoryMock.Verify(x => x.UpdateAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()), Times.Once);
+        _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+        scopeMock.Verify(
+            x => x.NotifyMessageUpdatedAsync(Ctx, message.Id, TestContent, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        // UpdatedAtUtc is validated before commit → callOrder is: update, commit, notify
+        callOrder.Should().Equal("update", "commit", "notify");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  DeleteAsync
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task DeleteAsync_WhenAuthorizationDenied_ShouldReturnAuthError()
+    {
+        var scope = CreateDeniedScope("AUTH_DENIED", "Not allowed");
+        var result = await _orchestrator.DeleteAsync(
+            scope.Object, ChannelScope(), AnyMessageId(), AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be("AUTH_DENIED");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenMessageNotFound_ShouldReturnMessageNotFound()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        SetupMessageNotFound(messageId);
+
+        var result = await _orchestrator.DeleteAsync(
+            scope.Object, ChannelScope(), messageId, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenMessageInWrongScope_ShouldReturnMessageNotFound()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var wrongScope = new MessageScope.Conversation(ConversationId.New());
+        SetupMessageExists(messageId, wrongScope);
+
+        var result = await _orchestrator.DeleteAsync(
+            scope.Object, ChannelScope(), messageId, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenAuthorDeletesOwnMessage_ShouldPersistCommitAndNotify()
+    {
+        var scopeMock = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var messageScope = ChannelScope();
+        var authorId = UserId.New();
+        var message = SetupMessageExists(messageId, messageScope, authorId);
+
+        var callOrder = new List<string>();
+        _messageRepositoryMock
+            .Setup(x => x.SoftDeleteAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("softDelete"))
+            .Returns(Task.CompletedTask);
+        _transactionMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("commit"))
+            .Returns(Task.CompletedTask);
+        scopeMock
+            .Setup(x => x.NotifyMessageDeletedAsync(Ctx, message.Id, It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("notify"))
+            .Returns(Task.CompletedTask);
+
+        var result = await _orchestrator.DeleteAsync(
+            scopeMock.Object, messageScope, messageId, authorId, TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        _messageRepositoryMock.Verify(x => x.SoftDeleteAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()), Times.Once);
+        _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+        scopeMock.Verify(
+            x => x.NotifyMessageDeletedAsync(Ctx, message.Id, It.IsAny<CancellationToken>()), Times.Once);
+        callOrder.Should().Equal("softDelete", "commit", "notify");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenAdminInChannel_ShouldDeleteOthersMessage()
+    {
+        // Admin override: CanDeleteOthersMessages = true
+        var scopeMock = CreateAuthorizedScope(canDeleteOthers: true);
+        var messageId = AnyMessageId();
+        var messageScope = ChannelScope();
+        var authorId = UserId.New();
+        var adminId = UserId.New();
+        SetupMessageExists(messageId, messageScope, authorId);
+
+        _messageRepositoryMock
+            .Setup(x => x.SoftDeleteAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _orchestrator.DeleteAsync(
+            scopeMock.Object, messageScope, messageId, adminId, TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        _messageRepositoryMock.Verify(x => x.SoftDeleteAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()), Times.Once);
+        _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenNonAdminInChannel_ShouldReturnDeleteForbidden()
+    {
+        // Non-admin cannot delete others' messages: CanDeleteOthersMessages = false
+        var scope = CreateAuthorizedScope(canDeleteOthers: false);
+        var messageId = AnyMessageId();
+        var messageScope = ChannelScope();
+        var authorId = UserId.New();
+        var memberId = UserId.New();
+        SetupMessageExists(messageId, messageScope, authorId);
+
+        var result = await _orchestrator.DeleteAsync(
+            scope.Object, messageScope, messageId, memberId, TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.DeleteForbidden);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenAuthorInConversation_ShouldDeleteOwnMessage()
+    {
+        var scopeMock = CreateAuthorizedScope(canDeleteOthers: false);
+        var messageId = AnyMessageId();
+        var messageScope = ConversationScope();
+        var authorId = UserId.New();
+        SetupMessageExists(messageId, messageScope, authorId);
+
+        _messageRepositoryMock
+            .Setup(x => x.SoftDeleteAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _orchestrator.DeleteAsync(
+            scopeMock.Object, messageScope, messageId, authorId, TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        _messageRepositoryMock.Verify(x => x.SoftDeleteAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenNonAuthorInConversation_ShouldReturnDeleteForbidden()
+    {
+        // Conversations never allow non-author deletion: CanDeleteOthersMessages = false
+        var scope = CreateAuthorizedScope(canDeleteOthers: false);
+        var messageId = AnyMessageId();
+        var messageScope = ConversationScope();
+        var authorId = UserId.New();
+        var otherUserId = UserId.New();
+        SetupMessageExists(messageId, messageScope, authorId);
+
+        var result = await _orchestrator.DeleteAsync(
+            scope.Object, messageScope, messageId, otherUserId, TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.DeleteForbidden);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  DeleteAttachmentAsync
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task DeleteAttachmentAsync_WhenAuthorizationDenied_ShouldReturnAuthError()
+    {
+        var scope = CreateDeniedScope("AUTH_DENIED", "Not allowed");
+        var result = await _orchestrator.DeleteAttachmentAsync(
+            scope.Object, ChannelScope(), AnyMessageId(), AnyAttachmentId(), AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be("AUTH_DENIED");
+    }
+
+    [Fact]
+    public async Task DeleteAttachmentAsync_WhenMessageNotFound_ShouldReturnMessageNotFound()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        SetupMessageNotFound(messageId);
+
+        var result = await _orchestrator.DeleteAttachmentAsync(
+            scope.Object, ChannelScope(), messageId, AnyAttachmentId(), AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteAttachmentAsync_WhenMessageInWrongScope_ShouldReturnMessageNotFound()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var wrongScope = new MessageScope.Conversation(ConversationId.New());
+        SetupMessageExists(messageId, wrongScope);
+
+        var result = await _orchestrator.DeleteAttachmentAsync(
+            scope.Object, ChannelScope(), messageId, AnyAttachmentId(), AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteAttachmentAsync_WhenCallerIsNotAuthor_ShouldReturnDeleteForbidden()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var messageScope = ChannelScope();
+        var authorId = UserId.New();
+        var callerId = UserId.New();
+        SetupMessageExists(messageId, messageScope, authorId);
+
+        var result = await _orchestrator.DeleteAttachmentAsync(
+            scope.Object, messageScope, messageId, AnyAttachmentId(), callerId, TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.DeleteForbidden);
+    }
+
+    [Fact]
+    public async Task DeleteAttachmentAsync_WhenAttachmentNotFound_ShouldReturnAttachmentNotFound()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var messageScope = ChannelScope();
+        var authorId = UserId.New();
+        var attachmentId = AnyAttachmentId();
+        SetupMessageExists(messageId, messageScope, authorId);
+
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.DeleteAsync(messageId, attachmentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _orchestrator.DeleteAttachmentAsync(
+            scope.Object, messageScope, messageId, attachmentId, authorId, TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.AttachmentNotFound);
+    }
+
+    [Fact]
+    public async Task DeleteAttachmentAsync_WhenAuthorDeletesAttachment_ShouldDeleteCommitAndCleanupFile()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var messageScope = ChannelScope();
+        var authorId = UserId.New();
+        var attachmentId = AnyAttachmentId();
+        SetupMessageExists(messageId, messageScope, authorId);
+
+        var uploadedFile = ApplicationTestBuilders.CreateUploadedFile(
+            id: attachmentId, uploaderUserId: authorId, storageKey: "attachments/file.txt");
+
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.DeleteAsync(messageId, attachmentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _uploadedFileRepositoryMock
+            .Setup(x => x.GetByIdAsync(attachmentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(uploadedFile);
+
+        _objectStorageServiceMock
+            .Setup(x => x.DeleteIfExistsAsync(uploadedFile.StorageKey, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _uploadedFileRepositoryMock
+            .Setup(x => x.DeleteAsync(attachmentId, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _orchestrator.DeleteAttachmentAsync(
+            scope.Object, messageScope, messageId, attachmentId, authorId, TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        _messageAttachmentRepositoryMock.Verify(
+            x => x.DeleteAsync(messageId, attachmentId, It.IsAny<CancellationToken>()), Times.Once);
+        _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _uploadedFileRepositoryMock.Verify(
+            x => x.DeleteAsync(attachmentId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Call order: delete reference → commit → cleanup file
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task DeleteAttachmentAsync_ShouldDeleteThenCommitThenCleanupFile()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var messageScope = ChannelScope();
+        var authorId = UserId.New();
+        var attachmentId = AnyAttachmentId();
+        SetupMessageExists(messageId, messageScope, authorId);
+
+        var uploadedFile = ApplicationTestBuilders.CreateUploadedFile(
+            id: attachmentId, uploaderUserId: authorId, storageKey: "attachments/file.txt");
+
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.DeleteAsync(messageId, attachmentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _uploadedFileRepositoryMock
+            .Setup(x => x.GetByIdAsync(attachmentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(uploadedFile);
+
+        _objectStorageServiceMock
+            .Setup(x => x.DeleteIfExistsAsync(uploadedFile.StorageKey, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _uploadedFileRepositoryMock
+            .Setup(x => x.DeleteAsync(attachmentId, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var callOrder = new List<string>();
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.DeleteAsync(messageId, attachmentId, It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("deleteRef"))
+            .ReturnsAsync(true);
+        _transactionMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("commit"))
+            .Returns(Task.CompletedTask);
+
+        // Track cleanup by watching DeleteAsync on the uploaded file repo.
+        // Since cleanup happens outside the transaction, it should be after commit.
+        _uploadedFileRepositoryMock
+            .Setup(x => x.DeleteAsync(attachmentId, It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("cleanup"))
+            .Returns(Task.CompletedTask);
+
+        await _orchestrator.DeleteAttachmentAsync(
+            scope.Object, messageScope, messageId, attachmentId, authorId, TestContext.Current.CancellationToken);
+
+        callOrder.Should().Equal("deleteRef", "commit", "cleanup");
+    }
+}

--- a/tests/Harmonie.Application.Tests/Messages/MessageEditDeleteOrchestratorTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/MessageEditDeleteOrchestratorTests.cs
@@ -526,20 +526,12 @@ public sealed class MessageEditDeleteOrchestratorTests
         var uploadedFile = ApplicationTestBuilders.CreateUploadedFile(
             id: attachmentId, uploaderUserId: authorId, storageKey: "attachments/file.txt");
 
-        _messageAttachmentRepositoryMock
-            .Setup(x => x.DeleteAsync(messageId, attachmentId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
-
         _uploadedFileRepositoryMock
             .Setup(x => x.GetByIdAsync(attachmentId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(uploadedFile);
 
         _objectStorageServiceMock
             .Setup(x => x.DeleteIfExistsAsync(uploadedFile.StorageKey, It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-
-        _uploadedFileRepositoryMock
-            .Setup(x => x.DeleteAsync(attachmentId, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         var callOrder = new List<string>();
@@ -552,8 +544,13 @@ public sealed class MessageEditDeleteOrchestratorTests
             .Callback(() => callOrder.Add("commit"))
             .Returns(Task.CompletedTask);
 
+        // Track transaction dispose to verify cleanup happens after the using block exits.
+        _transactionMock.As<IAsyncDisposable>()
+            .Setup(x => x.DisposeAsync())
+            .Callback(() => callOrder.Add("txDispose"))
+            .Returns(ValueTask.CompletedTask);
+
         // Track cleanup by watching DeleteAsync on the uploaded file repo.
-        // Since cleanup happens outside the transaction, it should be after commit.
         _uploadedFileRepositoryMock
             .Setup(x => x.DeleteAsync(attachmentId, It.IsAny<CancellationToken>()))
             .Callback(() => callOrder.Add("cleanup"))
@@ -562,6 +559,7 @@ public sealed class MessageEditDeleteOrchestratorTests
         await _orchestrator.DeleteAttachmentAsync(
             scope.Object, messageScope, messageId, attachmentId, authorId, TestContext.Current.CancellationToken);
 
-        callOrder.Should().Equal("deleteRef", "commit", "cleanup");
+        // Cleanup must happen outside the transaction: delete → commit → dispose → cleanup
+        callOrder.Should().Equal("deleteRef", "commit", "txDispose", "cleanup");
     }
 }


### PR DESCRIPTION
## Summary

Consolidates the duplicated logic between Channel and Conversation variants of EditMessage, DeleteMessage, and DeleteMessageAttachment handlers into a shared orchestrator + scope pattern, following the same architecture established by ReactionOrchestrator (#382 parts 1-2).

### Changes

#### New files
- `IMessageEditDeleteScope<TContext>` — scope interface (authorization + notification)
- `MessageEditDeleteOrchestrator` — shared orchestrator with `EditAsync`, `DeleteAsync`, `DeleteAttachmentAsync`
- `ChannelMessageEditDeleteScope` — channel auth (admin can delete others' messages)
- `ConversationMessageEditDeleteScope` — conversation auth (author-only delete)

#### Modified files
- 6 handlers simplified to thin wrappers (~50% reduction in handler code)
- `DependencyInjection.cs` — registered orchestrator
- 6 test files updated for new constructor signatures

### Design
The orchestrator handles common logic (content validation, message fetch, scope validation, author check, persistence), while each scope implementation handles authorization and scope-specific notifications through the `IMessageEditDeleteScope` interface.

Closes #382