### PR TITLE
feat: consolidate Read & Pin handlers (#382 part 4)

### DIFF
--- a/src/Harmonie.Application/Common/ApplicationResponse.cs
+++ b/src/Harmonie.Application/Common/ApplicationResponse.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Harmonie.Application.Common;
 
 /// <summary>
@@ -5,6 +7,8 @@ namespace Harmonie.Application.Common;
 /// </summary>
 public sealed record ApplicationResponse<T>
 {
+    [MemberNotNullWhen(true, nameof(Data))]
+    [MemberNotNullWhen(false, nameof(Error))]
     public bool Success { get; init; }
     public T? Data { get; init; }
     public ApplicationError? Error { get; init; }

--- a/src/Harmonie.Application/Common/ChannelScopeAuthorizer.cs
+++ b/src/Harmonie.Application/Common/ChannelScopeAuthorizer.cs
@@ -1,0 +1,47 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Common;
+
+/// <summary>
+/// Discriminated union for channel scope authorization results.
+/// </summary>
+public abstract record ChannelAuthResult
+{
+    private ChannelAuthResult() { }
+    public sealed record Authorized(ChannelAccessContext Context) : ChannelAuthResult;
+    public sealed record Denied(ApplicationError Error) : ChannelAuthResult;
+}
+
+/// <summary>
+/// Shared authorization logic for channel scopes. Eliminates the duplicated
+/// GetWithCallerRoleAsync + 3 checks present in every channel scope.
+/// Each scope maps the returned <see cref="ChannelAccessContext"/> to its own Context type.
+/// </summary>
+public static class ChannelScopeAuthorizer
+{
+    public static async Task<ChannelAuthResult> AuthorizeAsync(
+        IGuildChannelRepository repository,
+        GuildChannelId channelId,
+        UserId caller,
+        CancellationToken ct)
+    {
+        var ctx = await repository.GetWithCallerRoleAsync(channelId, caller, ct);
+        if (ctx is null)
+            return new ChannelAuthResult.Denied(
+                new ApplicationError(ApplicationErrorCodes.Channel.NotFound, "Channel was not found"));
+
+        if (ctx.Channel.Type != GuildChannelType.Text)
+            return new ChannelAuthResult.Denied(
+                new ApplicationError(ApplicationErrorCodes.Channel.NotText, "Messages can only be used in text channels"));
+
+        if (ctx.CallerRole is null)
+            return new ChannelAuthResult.Denied(
+                new ApplicationError(ApplicationErrorCodes.Channel.AccessDenied, "You do not have access to this channel"));
+
+        return new ChannelAuthResult.Authorized(ctx);
+    }
+}

--- a/src/Harmonie.Application/Common/ConversationScopeAuthorizer.cs
+++ b/src/Harmonie.Application/Common/ConversationScopeAuthorizer.cs
@@ -1,0 +1,42 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Common;
+
+/// <summary>
+/// Discriminated union for conversation scope authorization results.
+/// </summary>
+public abstract record ConversationAuthResult
+{
+    private ConversationAuthResult() { }
+    public sealed record Authorized(ConversationAccess Context) : ConversationAuthResult;
+    public sealed record Denied(ApplicationError Error) : ConversationAuthResult;
+}
+
+/// <summary>
+/// Shared authorization logic for conversation scopes. Eliminates the duplicated
+/// GetByIdWithParticipantCheckAsync + 2 checks present in every conversation scope.
+/// Each scope maps the returned <see cref="ConversationAccess"/> to its own Context type.
+/// </summary>
+public static class ConversationScopeAuthorizer
+{
+    public static async Task<ConversationAuthResult> AuthorizeAsync(
+        IConversationRepository repository,
+        ConversationId conversationId,
+        UserId caller,
+        CancellationToken ct)
+    {
+        var access = await repository.GetByIdWithParticipantCheckAsync(conversationId, caller, ct);
+        if (access is null)
+            return new ConversationAuthResult.Denied(
+                new ApplicationError(ApplicationErrorCodes.Conversation.NotFound, "Conversation was not found"));
+
+        if (access.Participant is null)
+            return new ConversationAuthResult.Denied(
+                new ApplicationError(ApplicationErrorCodes.Conversation.AccessDenied, "You do not have access to this conversation"));
+
+        return new ConversationAuthResult.Authorized(access);
+    }
+}

--- a/src/Harmonie.Application/Common/Messages/GetMessagesItemResponse.cs
+++ b/src/Harmonie.Application/Common/Messages/GetMessagesItemResponse.cs
@@ -1,0 +1,19 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+
+namespace Harmonie.Application.Common.Messages;
+
+/// <summary>
+/// Single message item returned by GetMessages across all scopes.
+/// </summary>
+public sealed record GetMessagesItemResponse(
+    Guid MessageId,
+    Guid AuthorUserId,
+    string? Content,
+    IReadOnlyList<MessageAttachmentDto> Attachments,
+    IReadOnlyList<MessageReactionDto> Reactions,
+    IReadOnlyList<LinkPreviewDto>? LinkPreviews,
+    bool IsPinned,
+    ReplyPreviewDto? ReplyTo,
+    DateTime CreatedAtUtc,
+    DateTime? UpdatedAtUtc);

--- a/src/Harmonie.Application/Common/Messages/GetPinnedMessagesItemResponse.cs
+++ b/src/Harmonie.Application/Common/Messages/GetPinnedMessagesItemResponse.cs
@@ -1,0 +1,19 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+
+namespace Harmonie.Application.Common.Messages;
+
+/// <summary>
+/// Single pinned message item returned by GetPinnedMessages across all scopes.
+/// </summary>
+public sealed record GetPinnedMessagesItemResponse(
+    Guid MessageId,
+    Guid AuthorUserId,
+    string AuthorUsername,
+    string? AuthorDisplayName,
+    string? Content,
+    IReadOnlyList<MessageAttachmentDto> Attachments,
+    DateTime CreatedAtUtc,
+    DateTime? UpdatedAtUtc,
+    Guid PinnedByUserId,
+    DateTime PinnedAtUtc);

--- a/src/Harmonie.Application/Common/Messages/IMessagePageScope.cs
+++ b/src/Harmonie.Application/Common/Messages/IMessagePageScope.cs
@@ -1,0 +1,16 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Common.Messages;
+
+/// <summary>
+/// Scope-specific concerns for message pagination (authorization and page fetching).
+/// Used by GetMessages where GetChannelPageAsync vs GetConversationPageAsync differ.
+/// </summary>
+public interface IMessagePageScope<TContext> where TContext : ScopeContext
+{
+    Task<AuthorizationResult<TContext>> AuthorizeAsync(UserId caller, CancellationToken ct);
+    Task<MessagePage> GetPageAsync(MessageCursor? cursor, int limit, UserId callerId, CancellationToken ct);
+}

--- a/src/Harmonie.Application/Common/Messages/IPinScope.cs
+++ b/src/Harmonie.Application/Common/Messages/IPinScope.cs
@@ -1,0 +1,17 @@
+using Harmonie.Application.Common;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Common.Messages;
+
+/// <summary>
+/// Scope-specific concerns for pin/unpin operations (authorization and notification).
+/// </summary>
+public interface IPinScope<TContext> where TContext : ScopeContext
+{
+    Task<AuthorizationResult<TContext>> AuthorizeAsync(UserId caller, CancellationToken ct);
+
+    Task NotifyPinAddedAsync(TContext context, MessageId messageId, UserId userId, DateTime pinnedAtUtc, CancellationToken ct);
+
+    Task NotifyPinRemovedAsync(TContext context, MessageId messageId, UserId userId, DateTime unpinnedAtUtc, CancellationToken ct);
+}

--- a/src/Harmonie.Application/Common/Messages/IPinnedMessageFetchScope.cs
+++ b/src/Harmonie.Application/Common/Messages/IPinnedMessageFetchScope.cs
@@ -1,0 +1,14 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Common.Messages;
+
+/// <summary>
+/// Scope-specific concerns for listing pinned messages (authorization and page fetch).
+/// </summary>
+public interface IPinnedMessageFetchScope<TContext> where TContext : ScopeContext
+{
+    Task<AuthorizationResult<TContext>> AuthorizeAsync(UserId caller, CancellationToken ct);
+    Task<PinnedMessagesPage> GetPinnedPageAsync(UserId callerId, PinnedMessagesCursor? cursor, int limit, CancellationToken ct);
+}

--- a/src/Harmonie.Application/Common/Messages/IReadScope.cs
+++ b/src/Harmonie.Application/Common/Messages/IReadScope.cs
@@ -1,0 +1,17 @@
+using Harmonie.Application.Common;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Common.Messages;
+
+/// <summary>
+/// Scope-specific concerns for read acknowledgement operations (authorization,
+/// latest message resolution, and read state persistence).
+/// </summary>
+public interface IReadScope<TContext> where TContext : ScopeContext
+{
+    Task<AuthorizationResult<TContext>> AuthorizeAsync(UserId caller, CancellationToken ct);
+    Task<MessageId?> GetLatestMessageIdAsync(CancellationToken ct);
+    Task UpsertReadStateAsync(MessageReadState state, CancellationToken ct);
+}

--- a/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
@@ -54,8 +54,11 @@ public sealed class MessageEditDeleteOrchestrator
         }
 
         // ── Authorization + message fetch ───────────────────────────────
-        var fetched = await AuthorizeAndFetchMessageAsync(
-            scope, messageScope, messageId, callerId, ct);
+        var fetched = await MessageScopeAuthorizer.AuthorizeAndFetchAsync(
+            _messageRepository,
+            (caller, ct) => scope.AuthorizeAsync(caller, ct),
+            messageScope, messageId, callerId,
+            ApplicationErrorCodes.Message.NotFound, ct);
         if (fetched is FetchMessageResult<TContext>.Failed failed)
             return ApplicationResponse<MessageEditResult>.Fail(failed.Error);
 
@@ -123,8 +126,11 @@ public sealed class MessageEditDeleteOrchestrator
         where TContext : ScopeContext
     {
         // ── Authorization + message fetch ───────────────────────────────
-        var fetched = await AuthorizeAndFetchMessageAsync(
-            scope, messageScope, messageId, callerId, ct);
+        var fetched = await MessageScopeAuthorizer.AuthorizeAndFetchAsync(
+            _messageRepository,
+            (caller, ct) => scope.AuthorizeAsync(caller, ct),
+            messageScope, messageId, callerId,
+            ApplicationErrorCodes.Message.NotFound, ct);
         if (fetched is FetchMessageResult<TContext>.Failed failed)
             return ApplicationResponse<bool>.Fail(failed.Error);
 
@@ -170,8 +176,11 @@ public sealed class MessageEditDeleteOrchestrator
         where TContext : ScopeContext
     {
         // ── Authorization + message fetch ───────────────────────────────
-        var fetched = await AuthorizeAndFetchMessageAsync(
-            scope, messageScope, messageId, callerId, ct);
+        var fetched = await MessageScopeAuthorizer.AuthorizeAndFetchAsync(
+            _messageRepository,
+            (caller, ct) => scope.AuthorizeAsync(caller, ct),
+            messageScope, messageId, callerId,
+            ApplicationErrorCodes.Message.NotFound, ct);
         if (fetched is FetchMessageResult<TContext>.Failed failed)
             return ApplicationResponse<bool>.Fail(failed.Error);
 
@@ -204,34 +213,5 @@ public sealed class MessageEditDeleteOrchestrator
         await _uploadedFileCleanupService.DeleteIfExistsAsync(attachmentId, ct);
 
         return ApplicationResponse<bool>.Ok(true);
-    }
-
-    /// <summary>
-    /// Authorizes the caller via the scope and fetches the target message,
-    /// validating that it belongs to the expected scope.
-    /// </summary>
-    private async Task<FetchMessageResult<TContext>> AuthorizeAndFetchMessageAsync<TContext>(
-        IMessageEditDeleteScope<TContext> scope,
-        MessageScope messageScope,
-        MessageId messageId,
-        UserId callerId,
-        CancellationToken ct)
-        where TContext : ScopeContext
-    {
-        var authResult = await scope.AuthorizeAsync(callerId, ct);
-        if (authResult is AuthorizationResult<TContext>.Denied denied)
-            return new FetchMessageResult<TContext>.Failed(denied.Error);
-
-        var context = ((AuthorizationResult<TContext>.Authorized)authResult).Context;
-
-        var message = await _messageRepository.GetByIdAsync(messageId, ct);
-        if (message is null || message.Scope != messageScope)
-        {
-            return new FetchMessageResult<TContext>.Failed(new ApplicationError(
-                ApplicationErrorCodes.Message.NotFound,
-                "Message was not found"));
-        }
-
-        return new FetchMessageResult<TContext>.Found(context, message);
     }
 }

--- a/src/Harmonie.Application/Common/Messages/MessageFetchOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageFetchOrchestrator.cs
@@ -1,0 +1,103 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Common.Messages;
+
+/// <summary>
+/// Result returned by <see cref="MessageFetchOrchestrator"/> when messages are
+/// successfully fetched. The caller maps this to the scope-specific response DTO.
+/// </summary>
+public sealed record MessageFetchResult(
+    IReadOnlyList<GetMessagesItemResponse> Items,
+    string? NextCursor,
+    Guid? LastReadMessageId,
+    DateTime? LastReadAtUtc);
+
+/// <summary>
+/// Shared orchestrator for GetMessages across all scopes.
+/// Extracts the duplicated cursor parsing, item mapping, and response assembly.
+/// </summary>
+public sealed class MessageFetchOrchestrator
+{
+    private const int DefaultLimit = 50;
+
+    public async Task<ApplicationResponse<MessageFetchResult>> FetchAsync<TContext>(
+        IMessagePageScope<TContext> scope,
+        string? rawCursor,
+        int? rawLimit,
+        UserId callerId,
+        CancellationToken ct)
+        where TContext : ScopeContext
+    {
+        // ── Cursor parsing ──────────────────────────────────────────────
+        MessageCursor? cursor = null;
+        if (rawCursor is not null)
+        {
+            if (!MessageCursorCodec.TryParse(rawCursor, out var parsedCursor) || parsedCursor is null)
+            {
+                return ApplicationResponse<MessageFetchResult>.Fail(
+                    ApplicationErrorCodes.Common.ValidationFailed,
+                    "Request validation failed",
+                    EndpointExtensions.SingleValidationError(
+                        "cursor",
+                        ApplicationErrorCodes.Validation.InvalidFormat,
+                        "Cursor is invalid"));
+            }
+
+            cursor = parsedCursor;
+        }
+
+        var limit = Math.Clamp(rawLimit ?? DefaultLimit, 1, 100);
+
+        // ── Authorization ───────────────────────────────────────────────
+        var authResult = await scope.AuthorizeAsync(callerId, ct);
+        if (authResult is AuthorizationResult<TContext>.Denied denied)
+            return ApplicationResponse<MessageFetchResult>.Fail(denied.Error);
+
+        // ── Fetch page ──────────────────────────────────────────────────
+        var page = await scope.GetPageAsync(cursor, limit, callerId, ct);
+
+        // ── Map items ───────────────────────────────────────────────────
+        var items = page.Items
+            .OrderBy(x => x.CreatedAtUtc)
+            .ThenBy(x => x.Id.Value)
+            .Select(x =>
+            {
+                page.ReactionsByMessageId.TryGetValue(x.Id.Value, out var reactions);
+                page.AttachmentsByMessageId.TryGetValue(x.Id.Value, out var attachments);
+                IReadOnlyList<LinkPreviewDto>? previews = null;
+                page.LinkPreviewsByMessageId?.TryGetValue(x.Id.Value, out previews);
+                var isPinned = page.PinnedMessageIds?.Contains(x.Id.Value) == true;
+                ReplyPreviewDto? replyTo = null;
+                if (x.ReplyToMessageId is not null)
+                {
+                    page.ReplyPreviewsByTargetMessageId?.TryGetValue(x.ReplyToMessageId.Value, out replyTo);
+                }
+                return new GetMessagesItemResponse(
+                    MessageId: x.Id.Value,
+                    AuthorUserId: x.AuthorUserId.Value,
+                    Content: x.Content?.Value,
+                    Attachments: attachments?.Select(MessageAttachmentDto.FromDomain).ToArray()
+                                 ?? Array.Empty<MessageAttachmentDto>(),
+                    Reactions: reactions?.Select(r => new MessageReactionDto(r.Emoji, r.Count, r.ReactedByCaller,
+                        r.Users.Select(u => new ReactionUserDto(u.UserId, u.Username, u.DisplayName)).ToArray())).ToArray()
+                              ?? Array.Empty<MessageReactionDto>(),
+                    LinkPreviews: previews?.ToArray(),
+                    IsPinned: isPinned,
+                    ReplyTo: replyTo,
+                    CreatedAtUtc: x.CreatedAtUtc,
+                    UpdatedAtUtc: x.UpdatedAtUtc);
+            })
+            .ToArray();
+
+        // ── Build result ────────────────────────────────────────────────
+        return ApplicationResponse<MessageFetchResult>.Ok(new MessageFetchResult(
+            Items: items,
+            NextCursor: page.NextCursor is null ? null : MessageCursorCodec.Encode(page.NextCursor),
+            LastReadMessageId: page.LastReadState?.LastReadMessageId.Value,
+            LastReadAtUtc: page.LastReadState?.ReadAtUtc));
+    }
+}

--- a/src/Harmonie.Application/Common/Messages/MessageScopeAuthorizer.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageScopeAuthorizer.cs
@@ -1,0 +1,49 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Common.Messages;
+
+/// <summary>
+/// Shared helpers for authorizing and fetching a message in orchestrators
+/// that need both auth and message validation.
+/// </summary>
+public static class MessageScopeAuthorizer
+{
+    /// <summary>
+    /// Authorizes the caller via the scope and fetches the target message,
+    /// validating that it belongs to the expected scope.
+    /// </summary>
+    /// <param name="notFoundErrorCode">Error code to return when the message is not found
+    /// (e.g. <see cref="ApplicationErrorCodes.Message.NotFound"/> or
+    /// <see cref="ApplicationErrorCodes.Pin.MessageNotFound"/>).</param>
+    public static async Task<FetchMessageResult<TContext>> AuthorizeAndFetchAsync<TContext>(
+        IMessageRepository messageRepository,
+        Func<UserId, CancellationToken, Task<AuthorizationResult<TContext>>> authorizeAsync,
+        MessageScope messageScope,
+        MessageId messageId,
+        UserId callerId,
+        string notFoundErrorCode,
+        CancellationToken ct)
+        where TContext : ScopeContext
+    {
+        var authResult = await authorizeAsync(callerId, ct);
+        if (authResult is AuthorizationResult<TContext>.Denied denied)
+            return new FetchMessageResult<TContext>.Failed(denied.Error);
+
+        var context = ((AuthorizationResult<TContext>.Authorized)authResult).Context;
+
+        var message = await messageRepository.GetByIdAsync(messageId, ct);
+        if (message is null || message.Scope != messageScope)
+        {
+            return new FetchMessageResult<TContext>.Failed(new ApplicationError(
+                notFoundErrorCode,
+                "Message was not found"));
+        }
+
+        return new FetchMessageResult<TContext>.Found(context, message);
+    }
+}

--- a/src/Harmonie.Application/Common/Messages/PinOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/PinOrchestrator.cs
@@ -1,0 +1,119 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Common.Messages;
+
+/// <summary>
+/// Shared orchestrator for pin and unpin operations across all scopes.
+/// </summary>
+public sealed class PinOrchestrator
+{
+    private readonly IMessageRepository _messageRepository;
+    private readonly IPinnedMessageRepository _pinnedMessageRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public PinOrchestrator(
+        IMessageRepository messageRepository,
+        IPinnedMessageRepository pinnedMessageRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _messageRepository = messageRepository;
+        _pinnedMessageRepository = pinnedMessageRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<ApplicationResponse<bool>> PinAsync<TContext>(
+        IPinScope<TContext> scope,
+        MessageScope messageScope,
+        MessageId messageId,
+        UserId callerId,
+        CancellationToken ct)
+        where TContext : ScopeContext
+    {
+        // ── Authorization + message fetch ───────────────────────────────
+        var fetched = await AuthorizeAndFetchMessageAsync(scope, messageScope, messageId, callerId, ct);
+        if (fetched is FetchMessageResult<TContext>.Failed failed)
+            return ApplicationResponse<bool>.Fail(failed.Error);
+
+        var (context, _) = (FetchMessageResult<TContext>.Found)fetched;
+
+        // ── Create pin ──────────────────────────────────────────────────
+        var pinnedMessage = PinnedMessage.Create(messageId, callerId);
+        if (pinnedMessage.IsFailure || pinnedMessage.Value is null)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Common.DomainRuleViolation,
+                pinnedMessage.Error ?? "Invalid pin");
+        }
+
+        // ── Persist ─────────────────────────────────────────────────────
+        await using var transaction = await _unitOfWork.BeginAsync(ct);
+        await _pinnedMessageRepository.AddAsync(pinnedMessage.Value, ct);
+        await transaction.CommitAsync(ct);
+
+        // ── Notify ──────────────────────────────────────────────────────
+        await scope.NotifyPinAddedAsync(context, messageId, callerId, pinnedMessage.Value.PinnedAtUtc, ct);
+
+        return ApplicationResponse<bool>.Ok(true);
+    }
+
+    public async Task<ApplicationResponse<bool>> UnpinAsync<TContext>(
+        IPinScope<TContext> scope,
+        MessageScope messageScope,
+        MessageId messageId,
+        UserId callerId,
+        CancellationToken ct)
+        where TContext : ScopeContext
+    {
+        // ── Authorization + message fetch ───────────────────────────────
+        var fetched = await AuthorizeAndFetchMessageAsync(scope, messageScope, messageId, callerId, ct);
+        if (fetched is FetchMessageResult<TContext>.Failed failed)
+            return ApplicationResponse<bool>.Fail(failed.Error);
+
+        var (context, _) = (FetchMessageResult<TContext>.Found)fetched;
+
+        // ── Persist ─────────────────────────────────────────────────────
+        await using var transaction = await _unitOfWork.BeginAsync(ct);
+        await _pinnedMessageRepository.RemoveAsync(messageId, ct);
+        await transaction.CommitAsync(ct);
+
+        // ── Notify ──────────────────────────────────────────────────────
+        await scope.NotifyPinRemovedAsync(context, messageId, callerId, DateTime.UtcNow, ct);
+
+        return ApplicationResponse<bool>.Ok(true);
+    }
+
+    /// <summary>
+    /// Authorizes the caller via the scope and fetches the target message,
+    /// validating that it belongs to the expected scope.
+    /// </summary>
+    private async Task<FetchMessageResult<TContext>> AuthorizeAndFetchMessageAsync<TContext>(
+        IPinScope<TContext> scope,
+        MessageScope messageScope,
+        MessageId messageId,
+        UserId callerId,
+        CancellationToken ct)
+        where TContext : ScopeContext
+    {
+        var authResult = await scope.AuthorizeAsync(callerId, ct);
+        if (authResult is AuthorizationResult<TContext>.Denied denied)
+            return new FetchMessageResult<TContext>.Failed(denied.Error);
+
+        var context = ((AuthorizationResult<TContext>.Authorized)authResult).Context;
+
+        var message = await _messageRepository.GetByIdAsync(messageId, ct);
+        if (message is null || message.Scope != messageScope)
+        {
+            return new FetchMessageResult<TContext>.Failed(new ApplicationError(
+                ApplicationErrorCodes.Pin.MessageNotFound,
+                "Message was not found"));
+        }
+
+        return new FetchMessageResult<TContext>.Found(context, message);
+    }
+}

--- a/src/Harmonie.Application/Common/Messages/PinOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/PinOrchestrator.cs
@@ -36,7 +36,11 @@ public sealed class PinOrchestrator
         where TContext : ScopeContext
     {
         // ── Authorization + message fetch ───────────────────────────────
-        var fetched = await AuthorizeAndFetchMessageAsync(scope, messageScope, messageId, callerId, ct);
+        var fetched = await MessageScopeAuthorizer.AuthorizeAndFetchAsync(
+            _messageRepository,
+            (caller, ct) => scope.AuthorizeAsync(caller, ct),
+            messageScope, messageId, callerId,
+            ApplicationErrorCodes.Pin.MessageNotFound, ct);
         if (fetched is FetchMessageResult<TContext>.Failed failed)
             return ApplicationResponse<bool>.Fail(failed.Error);
 
@@ -71,7 +75,11 @@ public sealed class PinOrchestrator
         where TContext : ScopeContext
     {
         // ── Authorization + message fetch ───────────────────────────────
-        var fetched = await AuthorizeAndFetchMessageAsync(scope, messageScope, messageId, callerId, ct);
+        var fetched = await MessageScopeAuthorizer.AuthorizeAndFetchAsync(
+            _messageRepository,
+            (caller, ct) => scope.AuthorizeAsync(caller, ct),
+            messageScope, messageId, callerId,
+            ApplicationErrorCodes.Pin.MessageNotFound, ct);
         if (fetched is FetchMessageResult<TContext>.Failed failed)
             return ApplicationResponse<bool>.Fail(failed.Error);
 
@@ -86,34 +94,5 @@ public sealed class PinOrchestrator
         await scope.NotifyPinRemovedAsync(context, messageId, callerId, DateTime.UtcNow, ct);
 
         return ApplicationResponse<bool>.Ok(true);
-    }
-
-    /// <summary>
-    /// Authorizes the caller via the scope and fetches the target message,
-    /// validating that it belongs to the expected scope.
-    /// </summary>
-    private async Task<FetchMessageResult<TContext>> AuthorizeAndFetchMessageAsync<TContext>(
-        IPinScope<TContext> scope,
-        MessageScope messageScope,
-        MessageId messageId,
-        UserId callerId,
-        CancellationToken ct)
-        where TContext : ScopeContext
-    {
-        var authResult = await scope.AuthorizeAsync(callerId, ct);
-        if (authResult is AuthorizationResult<TContext>.Denied denied)
-            return new FetchMessageResult<TContext>.Failed(denied.Error);
-
-        var context = ((AuthorizationResult<TContext>.Authorized)authResult).Context;
-
-        var message = await _messageRepository.GetByIdAsync(messageId, ct);
-        if (message is null || message.Scope != messageScope)
-        {
-            return new FetchMessageResult<TContext>.Failed(new ApplicationError(
-                ApplicationErrorCodes.Pin.MessageNotFound,
-                "Message was not found"));
-        }
-
-        return new FetchMessageResult<TContext>.Found(context, message);
     }
 }

--- a/src/Harmonie.Application/Common/Messages/PinnedMessageFetchOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/PinnedMessageFetchOrchestrator.cs
@@ -1,0 +1,86 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Common.Messages;
+
+/// <summary>
+/// Result returned by <see cref="PinnedMessageFetchOrchestrator"/>.
+/// The caller maps this to the scope-specific response DTO.
+/// </summary>
+public sealed record PinnedMessageFetchResult(
+    IReadOnlyList<GetPinnedMessagesItemResponse> Items,
+    string? NextCursor);
+
+/// <summary>
+/// Shared orchestrator for GetPinnedMessages across all scopes.
+/// Extracts cursor parsing, page fetching, and item mapping.
+/// </summary>
+public sealed class PinnedMessageFetchOrchestrator
+{
+    private const int DefaultLimit = 50;
+
+    public async Task<ApplicationResponse<PinnedMessageFetchResult>> FetchAsync<TContext>(
+        IPinnedMessageFetchScope<TContext> scope,
+        string? rawCursor,
+        int? rawLimit,
+        UserId callerId,
+        CancellationToken ct)
+        where TContext : ScopeContext
+    {
+        // ── Cursor parsing ──────────────────────────────────────────────
+        PinnedMessagesCursor? cursor = null;
+        if (rawCursor is not null)
+        {
+            if (!PinnedMessagesCursorCodec.TryParse(rawCursor, out var parsed) || parsed is null)
+            {
+                return ApplicationResponse<PinnedMessageFetchResult>.Fail(
+                    ApplicationErrorCodes.Common.ValidationFailed,
+                    "Request validation failed",
+                    EndpointExtensions.SingleValidationError(
+                        "cursor",
+                        ApplicationErrorCodes.Validation.InvalidFormat,
+                        "Cursor is invalid"));
+            }
+
+            cursor = parsed;
+        }
+
+        var limit = Math.Clamp(rawLimit ?? DefaultLimit, 1, 100);
+
+        // ── Authorization ───────────────────────────────────────────────
+        var authResult = await scope.AuthorizeAsync(callerId, ct);
+        if (authResult is AuthorizationResult<TContext>.Denied denied)
+            return ApplicationResponse<PinnedMessageFetchResult>.Fail(denied.Error);
+
+        // ── Fetch page ──────────────────────────────────────────────────
+        var page = await scope.GetPinnedPageAsync(callerId, cursor, limit, ct);
+
+        // ── Map items ───────────────────────────────────────────────────
+        var items = page.Items
+            .Select(x =>
+            {
+                page.AttachmentsByMessageId.TryGetValue(MessageId.From(x.MessageId), out var attachments);
+                return new GetPinnedMessagesItemResponse(
+                    MessageId: x.MessageId,
+                    AuthorUserId: x.AuthorUserId,
+                    AuthorUsername: x.AuthorUsername,
+                    AuthorDisplayName: x.AuthorDisplayName,
+                    Content: x.Content,
+                    Attachments: attachments?.Select(MessageAttachmentDto.FromDomain).ToArray()
+                                 ?? Array.Empty<MessageAttachmentDto>(),
+                    CreatedAtUtc: x.CreatedAtUtc,
+                    UpdatedAtUtc: x.UpdatedAtUtc,
+                    PinnedByUserId: x.PinnedByUserId,
+                    PinnedAtUtc: x.PinnedAtUtc);
+            })
+            .ToArray();
+
+        // ── Build result ────────────────────────────────────────────────
+        return ApplicationResponse<PinnedMessageFetchResult>.Ok(new PinnedMessageFetchResult(
+            Items: items,
+            NextCursor: page.NextCursor is null ? null : PinnedMessagesCursorCodec.Encode(page.NextCursor)));
+    }
+}

--- a/src/Harmonie.Application/Common/Messages/ReadOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/ReadOrchestrator.cs
@@ -1,0 +1,80 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Common.Messages;
+
+/// <summary>
+/// Shared orchestrator for read acknowledgement operations across all scopes.
+/// </summary>
+public sealed class ReadOrchestrator
+{
+    private readonly IMessageRepository _messageRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public ReadOrchestrator(
+        IMessageRepository messageRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _messageRepository = messageRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<ApplicationResponse<bool>> AcknowledgeAsync<TContext>(
+        IReadScope<TContext> scope,
+        MessageScope messageScope,
+        MessageId? requestMessageId,
+        UserId callerId,
+        CancellationToken ct)
+        where TContext : ScopeContext
+    {
+        // ── Authorization ───────────────────────────────────────────────
+        var authResult = await scope.AuthorizeAsync(callerId, ct);
+        if (authResult is AuthorizationResult<TContext>.Denied denied)
+            return ApplicationResponse<bool>.Fail(denied.Error);
+
+        // ── Resolve target message ──────────────────────────────────────
+        MessageId resolvedMessageId;
+
+        if (requestMessageId is not null)
+        {
+            var message = await _messageRepository.GetByIdAsync(requestMessageId, ct);
+            if (message is null || message.Scope != messageScope)
+            {
+                return ApplicationResponse<bool>.Fail(
+                    ApplicationErrorCodes.Message.NotFound,
+                    "Message was not found in this scope");
+            }
+
+            resolvedMessageId = requestMessageId;
+        }
+        else
+        {
+            var latestMessageId = await scope.GetLatestMessageIdAsync(ct);
+            if (latestMessageId is null)
+                return ApplicationResponse<bool>.Ok(true);
+
+            resolvedMessageId = latestMessageId;
+        }
+
+        // ── Create read state ───────────────────────────────────────────
+        var state = MessageReadState.Create(callerId, messageScope, resolvedMessageId);
+        if (state.IsFailure || state.Value is null)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.Common.DomainRuleViolation,
+                state.Error ?? "Invalid read state");
+        }
+
+        // ── Persist ─────────────────────────────────────────────────────
+        await using var transaction = await _unitOfWork.BeginAsync(ct);
+        await scope.UpsertReadStateAsync(state.Value, ct);
+        await transaction.CommitAsync(ct);
+
+        return ApplicationResponse<bool>.Ok(true);
+    }
+}

--- a/src/Harmonie.Application/DependencyInjection.cs
+++ b/src/Harmonie.Application/DependencyInjection.cs
@@ -19,6 +19,10 @@ public static class DependencyInjection
         services.AddScoped<MessageSendOrchestrator>();
         services.AddScoped<ReactionOrchestrator>();
         services.AddScoped<MessageEditDeleteOrchestrator>();
+        services.AddScoped<PinOrchestrator>();
+        services.AddScoped<ReadOrchestrator>();
+        services.AddScoped<MessageFetchOrchestrator>();
+        services.AddScoped<PinnedMessageFetchOrchestrator>();
 
         services.AddAuthHandlers();
         services.AddGuildHandlers();

--- a/src/Harmonie.Application/Features/Channels/AcknowledgeRead/AcknowledgeReadHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/AcknowledgeRead/AcknowledgeReadHandler.cs
@@ -1,9 +1,8 @@
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.Reads;
 using Harmonie.Application.Interfaces.Channels;
-using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Domain.Entities.Messages;
-using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -17,18 +16,18 @@ public sealed class AcknowledgeReadHandler : IAuthenticatedHandler<AcknowledgeCh
     private readonly IGuildChannelRepository _guildChannelRepository;
     private readonly IMessageRepository _messageRepository;
     private readonly IChannelReadStateRepository _channelReadStateRepository;
-    private readonly IUnitOfWork _unitOfWork;
+    private readonly ReadOrchestrator _orchestrator;
 
     public AcknowledgeReadHandler(
         IGuildChannelRepository guildChannelRepository,
         IMessageRepository messageRepository,
         IChannelReadStateRepository channelReadStateRepository,
-        IUnitOfWork unitOfWork)
+        ReadOrchestrator orchestrator)
     {
         _guildChannelRepository = guildChannelRepository;
         _messageRepository = messageRepository;
         _channelReadStateRepository = channelReadStateRepository;
-        _unitOfWork = unitOfWork;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<bool>> HandleAsync(
@@ -36,65 +35,14 @@ public sealed class AcknowledgeReadHandler : IAuthenticatedHandler<AcknowledgeCh
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(request.ChannelId, currentUserId, cancellationToken);
-        if (ctx is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.NotFound,
-                "Channel was not found");
-        }
+        var scope = new ChannelReadScope(
+            request.ChannelId, _guildChannelRepository, _messageRepository, _channelReadStateRepository);
 
-        if (ctx.Channel.Type != GuildChannelType.Text)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.NotText,
-                "Read acknowledgement is only available in text channels");
-        }
-
-        if (ctx.CallerRole is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.AccessDenied,
-                "You do not have access to this channel");
-        }
-
-        MessageId resolvedMessageId;
-
-        if (request.MessageId is not null)
-        {
-            var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-            if (message is null || !message.Scope.Matches(request.ChannelId))
-            {
-                return ApplicationResponse<bool>.Fail(
-                    ApplicationErrorCodes.Message.NotFound,
-                    "Message was not found in this channel");
-            }
-
-            resolvedMessageId = request.MessageId;
-        }
-        else
-        {
-            var latestMessageId = await _messageRepository.GetLatestChannelMessageIdAsync(request.ChannelId, cancellationToken);
-            if (latestMessageId is null)
-            {
-                return ApplicationResponse<bool>.Ok(true);
-            }
-
-            resolvedMessageId = latestMessageId;
-        }
-
-        var state = MessageReadState.Create(currentUserId, new MessageScope.Channel(request.ChannelId), resolvedMessageId);
-        if (state.IsFailure || state.Value is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Common.DomainRuleViolation,
-                state.Error ?? "Invalid read state");
-        }
-
-        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
-        await _channelReadStateRepository.UpsertAsync(state.Value, cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
-
-        return ApplicationResponse<bool>.Ok(true);
+        return await _orchestrator.AcknowledgeAsync(
+            scope,
+            new MessageScope.Channel(request.ChannelId),
+            request.MessageId,
+            currentUserId,
+            cancellationToken);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageHandler.cs
@@ -50,10 +50,10 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditChannelMessag
             cancellationToken);
 
         if (!result.Success)
-            return ApplicationResponse<EditMessageResponse>.Fail(result.Error!);
+            return ApplicationResponse<EditMessageResponse>.Fail(result.Error);
 
         return ApplicationResponse<EditMessageResponse>.Ok(new EditMessageResponse(
-            MessageId: result.Data!.MessageId,
+            MessageId: result.Data.MessageId,
             ChannelId: request.ChannelId.Value,
             AuthorUserId: result.Data.AuthorUserId,
             Content: result.Data.Content,

--- a/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesHandler.cs
@@ -38,11 +38,11 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetChannelMessage
             scope, request.Before, request.Limit, currentUserId, cancellationToken);
 
         if (!result.Success)
-            return ApplicationResponse<GetMessagesResponse>.Fail(result.Error!);
+            return ApplicationResponse<GetMessagesResponse>.Fail(result.Error);
 
         return ApplicationResponse<GetMessagesResponse>.Ok(new GetMessagesResponse(
             ChannelId: request.ChannelId.Value,
-            Items: result.Data!.Items,
+            Items: result.Data.Items,
             NextCursor: result.Data.NextCursor,
             LastReadMessageId: result.Data.LastReadMessageId,
             LastReadAtUtc: result.Data.LastReadAtUtc));

--- a/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesHandler.cs
@@ -1,8 +1,8 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.Messages;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Users;
 
@@ -12,17 +12,18 @@ public sealed record GetChannelMessagesInput(GuildChannelId ChannelId, string? B
 
 public sealed class GetMessagesHandler : IAuthenticatedHandler<GetChannelMessagesInput, GetMessagesResponse>
 {
-    private const int DefaultLimit = 50;
-
     private readonly IGuildChannelRepository _guildChannelRepository;
-    private readonly IMessagePaginationRepository _channelMessageRepository;
+    private readonly IMessagePaginationRepository _paginationRepository;
+    private readonly MessageFetchOrchestrator _orchestrator;
 
     public GetMessagesHandler(
         IGuildChannelRepository guildChannelRepository,
-        IMessagePaginationRepository channelMessageRepository)
+        IMessagePaginationRepository paginationRepository,
+        MessageFetchOrchestrator orchestrator)
     {
         _guildChannelRepository = guildChannelRepository;
-        _channelMessageRepository = channelMessageRepository;
+        _paginationRepository = paginationRepository;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<GetMessagesResponse>> HandleAsync(
@@ -30,95 +31,20 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetChannelMessage
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        MessageCursor? beforeCursor = null;
-        if (request.Before is not null)
-        {
-            if (!MessageCursorCodec.TryParse(request.Before, out var parsedCursor) || parsedCursor is null)
-            {
-                return ApplicationResponse<GetMessagesResponse>.Fail(
-                    ApplicationErrorCodes.Common.ValidationFailed,
-                    "Request validation failed",
-                    EndpointExtensions.SingleValidationError(
-                        nameof(request.Before),
-                        ApplicationErrorCodes.Validation.InvalidFormat,
-                        "Before cursor is invalid"));
-            }
+        var scope = new ChannelMessagePageScope(
+            request.ChannelId, _guildChannelRepository, _paginationRepository);
 
-            beforeCursor = parsedCursor;
-        }
+        var result = await _orchestrator.FetchAsync(
+            scope, request.Before, request.Limit, currentUserId, cancellationToken);
 
-        var limit = request.Limit ?? DefaultLimit;
+        if (!result.Success)
+            return ApplicationResponse<GetMessagesResponse>.Fail(result.Error!);
 
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(request.ChannelId, currentUserId, cancellationToken);
-        if (ctx is null)
-        {
-            return ApplicationResponse<GetMessagesResponse>.Fail(
-                ApplicationErrorCodes.Channel.NotFound,
-                "Channel was not found");
-        }
-
-        if (ctx.Channel.Type != GuildChannelType.Text)
-        {
-            return ApplicationResponse<GetMessagesResponse>.Fail(
-                ApplicationErrorCodes.Channel.NotText,
-                "Messages can only be read from text channels");
-        }
-
-        if (ctx.CallerRole is null)
-        {
-            return ApplicationResponse<GetMessagesResponse>.Fail(
-                ApplicationErrorCodes.Channel.AccessDenied,
-                "You do not have access to this channel");
-        }
-
-        var page = await _channelMessageRepository.GetChannelPageAsync(
-            request.ChannelId,
-            beforeCursor,
-            limit,
-            currentUserId,
-            cancellationToken);
-
-        var items = page.Items
-            .OrderBy(x => x.CreatedAtUtc)
-            .ThenBy(x => x.Id.Value)
-            .Select(x =>
-            {
-                page.ReactionsByMessageId.TryGetValue(x.Id.Value, out var reactions);
-                page.AttachmentsByMessageId.TryGetValue(x.Id.Value, out var attachments);
-                IReadOnlyList<LinkPreviewDto>? previews = null;
-                page.LinkPreviewsByMessageId?.TryGetValue(x.Id.Value, out previews);
-                var isPinned = page.PinnedMessageIds?.Contains(x.Id.Value) == true;
-                ReplyPreviewDto? replyTo = null;
-                if (x.ReplyToMessageId is not null)
-                {
-                    page.ReplyPreviewsByTargetMessageId?.TryGetValue(x.ReplyToMessageId.Value, out replyTo);
-                }
-                return new GetMessagesItemResponse(
-                    MessageId: x.Id.Value,
-                    AuthorUserId: x.AuthorUserId.Value,
-                    Content: x.Content?.Value,
-                    Attachments: attachments?.Select(MessageAttachmentDto.FromDomain).ToArray()
-                                 ?? Array.Empty<MessageAttachmentDto>(),
-                    Reactions: reactions?.Select(r => new MessageReactionDto(r.Emoji, r.Count, r.ReactedByCaller,
-                        r.Users.Select(u => new ReactionUserDto(u.UserId, u.Username, u.DisplayName)).ToArray())).ToArray()
-                              ?? Array.Empty<MessageReactionDto>(),
-                    LinkPreviews: previews?.ToArray(),
-                    IsPinned: isPinned,
-                    ReplyTo: replyTo,
-                    CreatedAtUtc: x.CreatedAtUtc,
-                    UpdatedAtUtc: x.UpdatedAtUtc);
-            })
-            .ToArray();
-
-        var payload = new GetMessagesResponse(
+        return ApplicationResponse<GetMessagesResponse>.Ok(new GetMessagesResponse(
             ChannelId: request.ChannelId.Value,
-            Items: items,
-            NextCursor: page.NextCursor is null
-                ? null
-                : MessageCursorCodec.Encode(page.NextCursor),
-            LastReadMessageId: page.LastReadState?.LastReadMessageId.Value,
-            LastReadAtUtc: page.LastReadState?.ReadAtUtc);
-
-        return ApplicationResponse<GetMessagesResponse>.Ok(payload);
+            Items: result.Data!.Items,
+            NextCursor: result.Data.NextCursor,
+            LastReadMessageId: result.Data.LastReadMessageId,
+            LastReadAtUtc: result.Data.LastReadAtUtc));
     }
 }

--- a/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesResponse.cs
+++ b/src/Harmonie.Application/Features/Channels/GetMessages/GetMessagesResponse.cs
@@ -9,15 +9,3 @@ public sealed record GetMessagesResponse(
     string? NextCursor,
     Guid? LastReadMessageId,
     DateTime? LastReadAtUtc);
-
-public sealed record GetMessagesItemResponse(
-    Guid MessageId,
-    Guid AuthorUserId,
-    string? Content,
-    IReadOnlyList<MessageAttachmentDto> Attachments,
-    IReadOnlyList<MessageReactionDto> Reactions,
-    IReadOnlyList<LinkPreviewDto>? LinkPreviews,
-    bool IsPinned,
-    ReplyPreviewDto? ReplyTo,
-    DateTime CreatedAtUtc,
-    DateTime? UpdatedAtUtc);

--- a/src/Harmonie.Application/Features/Channels/GetPinnedMessages/GetPinnedMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/GetPinnedMessages/GetPinnedMessagesHandler.cs
@@ -38,11 +38,11 @@ public sealed class GetPinnedMessagesHandler : IAuthenticatedHandler<GetChannelP
             scope, request.Before, request.Limit, currentUserId, cancellationToken);
 
         if (!result.Success)
-            return ApplicationResponse<GetPinnedMessagesResponse>.Fail(result.Error!);
+            return ApplicationResponse<GetPinnedMessagesResponse>.Fail(result.Error);
 
         return ApplicationResponse<GetPinnedMessagesResponse>.Ok(new GetPinnedMessagesResponse(
             ChannelId: request.ChannelId.Value,
-            Items: result.Data!.Items,
+            Items: result.Data.Items,
             NextCursor: result.Data.NextCursor));
     }
 }

--- a/src/Harmonie.Application/Features/Channels/GetPinnedMessages/GetPinnedMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/GetPinnedMessages/GetPinnedMessagesHandler.cs
@@ -1,10 +1,9 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.Pins;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
-using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
 
 namespace Harmonie.Application.Features.Channels.GetPinnedMessages;
@@ -13,17 +12,18 @@ public sealed record GetChannelPinnedMessagesInput(GuildChannelId ChannelId, str
 
 public sealed class GetPinnedMessagesHandler : IAuthenticatedHandler<GetChannelPinnedMessagesInput, GetPinnedMessagesResponse>
 {
-    private const int DefaultLimit = 50;
-
     private readonly IGuildChannelRepository _guildChannelRepository;
     private readonly IPinnedMessageRepository _pinnedMessageRepository;
+    private readonly PinnedMessageFetchOrchestrator _orchestrator;
 
     public GetPinnedMessagesHandler(
         IGuildChannelRepository guildChannelRepository,
-        IPinnedMessageRepository pinnedMessageRepository)
+        IPinnedMessageRepository pinnedMessageRepository,
+        PinnedMessageFetchOrchestrator orchestrator)
     {
         _guildChannelRepository = guildChannelRepository;
         _pinnedMessageRepository = pinnedMessageRepository;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<GetPinnedMessagesResponse>> HandleAsync(
@@ -31,79 +31,18 @@ public sealed class GetPinnedMessagesHandler : IAuthenticatedHandler<GetChannelP
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        PinnedMessagesCursor? cursor = null;
-        if (request.Before is not null)
-        {
-            if (!PinnedMessagesCursorCodec.TryParse(request.Before, out var parsed) || parsed is null)
-            {
-                return ApplicationResponse<GetPinnedMessagesResponse>.Fail(
-                    ApplicationErrorCodes.Common.ValidationFailed,
-                    "Request validation failed",
-                    EndpointExtensions.SingleValidationError(
-                        nameof(request.Before),
-                        ApplicationErrorCodes.Validation.InvalidFormat,
-                        "Before cursor is invalid"));
-            }
+        var scope = new ChannelPinnedMessageFetchScope(
+            request.ChannelId, _guildChannelRepository, _pinnedMessageRepository);
 
-            cursor = parsed;
-        }
+        var result = await _orchestrator.FetchAsync(
+            scope, request.Before, request.Limit, currentUserId, cancellationToken);
 
-        var limit = request.Limit ?? DefaultLimit;
+        if (!result.Success)
+            return ApplicationResponse<GetPinnedMessagesResponse>.Fail(result.Error!);
 
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(request.ChannelId, currentUserId, cancellationToken);
-        if (ctx is null)
-        {
-            return ApplicationResponse<GetPinnedMessagesResponse>.Fail(
-                ApplicationErrorCodes.Channel.NotFound,
-                "Channel was not found");
-        }
-
-        if (ctx.Channel.Type != GuildChannelType.Text)
-        {
-            return ApplicationResponse<GetPinnedMessagesResponse>.Fail(
-                ApplicationErrorCodes.Channel.NotText,
-                "Pinned messages can only be listed in text channels");
-        }
-
-        if (ctx.CallerRole is null)
-        {
-            return ApplicationResponse<GetPinnedMessagesResponse>.Fail(
-                ApplicationErrorCodes.Channel.AccessDenied,
-                "You do not have access to this channel");
-        }
-
-        var page = await _pinnedMessageRepository.GetPinnedMessagesAsync(
-            request.ChannelId,
-            currentUserId,
-            cursor,
-            limit,
-            cancellationToken);
-
-        var items = page.Items
-            .Select(x =>
-            {
-                page.AttachmentsByMessageId.TryGetValue(MessageId.From(x.MessageId), out var attachments);
-                return new GetPinnedMessagesItemResponse(
-                    MessageId: x.MessageId,
-                    AuthorUserId: x.AuthorUserId,
-                    AuthorUsername: x.AuthorUsername,
-                    AuthorDisplayName: x.AuthorDisplayName,
-                    Content: x.Content,
-                    Attachments: attachments?.Select(MessageAttachmentDto.FromDomain).ToArray()
-                                 ?? Array.Empty<MessageAttachmentDto>(),
-                    CreatedAtUtc: x.CreatedAtUtc,
-                    UpdatedAtUtc: x.UpdatedAtUtc,
-                    PinnedByUserId: x.PinnedByUserId,
-                    PinnedAtUtc: x.PinnedAtUtc);
-            })
-            .ToArray();
-
-        return ApplicationResponse<GetPinnedMessagesResponse>.Ok(
-            new GetPinnedMessagesResponse(
-                ChannelId: request.ChannelId.Value,
-                Items: items,
-                NextCursor: page.NextCursor is null
-                    ? null
-                    : PinnedMessagesCursorCodec.Encode(page.NextCursor)));
+        return ApplicationResponse<GetPinnedMessagesResponse>.Ok(new GetPinnedMessagesResponse(
+            ChannelId: request.ChannelId.Value,
+            Items: result.Data!.Items,
+            NextCursor: result.Data.NextCursor));
     }
 }

--- a/src/Harmonie.Application/Features/Channels/GetPinnedMessages/GetPinnedMessagesResponse.cs
+++ b/src/Harmonie.Application/Features/Channels/GetPinnedMessages/GetPinnedMessagesResponse.cs
@@ -6,15 +6,3 @@ public sealed record GetPinnedMessagesResponse(
     Guid ChannelId,
     IReadOnlyList<GetPinnedMessagesItemResponse> Items,
     string? NextCursor);
-
-public sealed record GetPinnedMessagesItemResponse(
-    Guid MessageId,
-    Guid AuthorUserId,
-    string AuthorUsername,
-    string? AuthorDisplayName,
-    string? Content,
-    IReadOnlyList<MessageAttachmentDto> Attachments,
-    DateTime CreatedAtUtc,
-    DateTime? UpdatedAtUtc,
-    Guid PinnedByUserId,
-    DateTime PinnedAtUtc);

--- a/src/Harmonie.Application/Features/Channels/GetReactionUsers/GetReactionUsersHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/GetReactionUsers/GetReactionUsersHandler.cs
@@ -55,10 +55,10 @@ public sealed class GetReactionUsersHandler : IAuthenticatedHandler<GetChannelRe
             cancellationToken);
 
         if (!result.Success)
-            return ApplicationResponse<GetReactionUsersResponse>.Fail(result.Error!);
+            return ApplicationResponse<GetReactionUsersResponse>.Fail(result.Error);
 
         return ApplicationResponse<GetReactionUsersResponse>.Ok(new GetReactionUsersResponse(
-            result.Data!.MessageId,
+            result.Data.MessageId,
             result.Data.Emoji,
             result.Data.TotalCount,
             result.Data.Users,

--- a/src/Harmonie.Application/Features/Channels/Messages/ChannelMessageEditDeleteScope.cs
+++ b/src/Harmonie.Application/Features/Channels/Messages/ChannelMessageEditDeleteScope.cs
@@ -43,22 +43,17 @@ public sealed class ChannelMessageEditDeleteScope : IMessageEditDeleteScope<Chan
 
     public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
     {
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(_channelId, caller, ct);
-        if (ctx is null)
-            return Denied(ApplicationErrorCodes.Channel.NotFound, "Channel was not found");
+        var result = await ChannelScopeAuthorizer.AuthorizeAsync(_guildChannelRepository, _channelId, caller, ct);
+        if (result is ChannelAuthResult.Denied denied)
+            return new AuthorizationResult<Context>.Denied(denied.Error);
 
-        if (ctx.Channel.Type != GuildChannelType.Text)
-            return Denied(ApplicationErrorCodes.Channel.NotText, "Messages can only be edited in text channels");
-
-        if (ctx.CallerRole is null)
-            return Denied(ApplicationErrorCodes.Channel.AccessDenied, "You do not have access to this channel");
-
+        var access = ((ChannelAuthResult.Authorized)result).Context;
         return new AuthorizationResult<Context>.Authorized(new Context(
             _channelId,
-            ctx.Channel.Name,
-            ctx.Channel.GuildId,
-            ctx.GuildName ?? string.Empty,
-            ctx.CallerRole));
+            access.Channel.Name,
+            access.Channel.GuildId,
+            access.GuildName ?? string.Empty,
+            access.CallerRole));
     }
 
     // In channels, admins can delete any message, not just their own.
@@ -110,7 +105,4 @@ public sealed class ChannelMessageEditDeleteScope : IMessageEditDeleteScope<Chan
             notification.MessageId,
             notification.ChannelId);
     }
-
-    private static AuthorizationResult<Context> Denied(string code, string detail)
-        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
 }

--- a/src/Harmonie.Application/Features/Channels/Messages/ChannelMessagePageScope.cs
+++ b/src/Harmonie.Application/Features/Channels/Messages/ChannelMessagePageScope.cs
@@ -1,0 +1,50 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Features.Channels.Messages;
+
+public sealed class ChannelMessagePageScope : IMessagePageScope<ChannelMessagePageScope.Context>
+{
+    public sealed record Context : ScopeContext;
+
+    private readonly GuildChannelId _channelId;
+    private readonly IGuildChannelRepository _guildChannelRepository;
+    private readonly IMessagePaginationRepository _paginationRepository;
+
+    public ChannelMessagePageScope(
+        GuildChannelId channelId,
+        IGuildChannelRepository guildChannelRepository,
+        IMessagePaginationRepository paginationRepository)
+    {
+        _channelId = channelId;
+        _guildChannelRepository = guildChannelRepository;
+        _paginationRepository = paginationRepository;
+    }
+
+    public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
+    {
+        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(_channelId, caller, ct);
+        if (ctx is null)
+            return Denied(ApplicationErrorCodes.Channel.NotFound, "Channel was not found");
+
+        if (ctx.Channel.Type != GuildChannelType.Text)
+            return Denied(ApplicationErrorCodes.Channel.NotText, "Messages can only be read from text channels");
+
+        if (ctx.CallerRole is null)
+            return Denied(ApplicationErrorCodes.Channel.AccessDenied, "You do not have access to this channel");
+
+        return new AuthorizationResult<Context>.Authorized(new Context());
+    }
+
+    public Task<MessagePage> GetPageAsync(MessageCursor? cursor, int limit, UserId callerId, CancellationToken ct)
+        => _paginationRepository.GetChannelPageAsync(_channelId, cursor, limit, callerId, ct);
+
+    private static AuthorizationResult<Context> Denied(string code, string detail)
+        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
+}

--- a/src/Harmonie.Application/Features/Channels/Messages/ChannelMessagePageScope.cs
+++ b/src/Harmonie.Application/Features/Channels/Messages/ChannelMessagePageScope.cs
@@ -29,22 +29,13 @@ public sealed class ChannelMessagePageScope : IMessagePageScope<ChannelMessagePa
 
     public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
     {
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(_channelId, caller, ct);
-        if (ctx is null)
-            return Denied(ApplicationErrorCodes.Channel.NotFound, "Channel was not found");
-
-        if (ctx.Channel.Type != GuildChannelType.Text)
-            return Denied(ApplicationErrorCodes.Channel.NotText, "Messages can only be read from text channels");
-
-        if (ctx.CallerRole is null)
-            return Denied(ApplicationErrorCodes.Channel.AccessDenied, "You do not have access to this channel");
+        var result = await ChannelScopeAuthorizer.AuthorizeAsync(_guildChannelRepository, _channelId, caller, ct);
+        if (result is ChannelAuthResult.Denied denied)
+            return new AuthorizationResult<Context>.Denied(denied.Error);
 
         return new AuthorizationResult<Context>.Authorized(new Context());
     }
 
     public Task<MessagePage> GetPageAsync(MessageCursor? cursor, int limit, UserId callerId, CancellationToken ct)
         => _paginationRepository.GetChannelPageAsync(_channelId, cursor, limit, callerId, ct);
-
-    private static AuthorizationResult<Context> Denied(string code, string detail)
-        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
 }

--- a/src/Harmonie.Application/Features/Channels/PinMessage/PinMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/PinMessage/PinMessageHandler.cs
@@ -1,9 +1,8 @@
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.Pins;
 using Harmonie.Application.Interfaces.Channels;
-using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Domain.Entities.Messages;
-using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -15,29 +14,21 @@ public sealed record ChannelPinMessageInput(GuildChannelId ChannelId, MessageId 
 
 public sealed class PinMessageHandler : IAuthenticatedHandler<ChannelPinMessageInput, bool>
 {
-    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
-
     private readonly IGuildChannelRepository _guildChannelRepository;
-    private readonly IMessageRepository _messageRepository;
-    private readonly IPinnedMessageRepository _pinnedMessageRepository;
-    private readonly IUnitOfWork _unitOfWork;
     private readonly IPinNotifier _pinNotifier;
-    private readonly ILogger<PinMessageHandler> _logger;
+    private readonly ILogger<ChannelPinScope> _scopeLogger;
+    private readonly PinOrchestrator _orchestrator;
 
     public PinMessageHandler(
         IGuildChannelRepository guildChannelRepository,
-        IMessageRepository messageRepository,
-        IPinnedMessageRepository pinnedMessageRepository,
-        IUnitOfWork unitOfWork,
         IPinNotifier pinNotifier,
-        ILogger<PinMessageHandler> logger)
+        ILogger<ChannelPinScope> scopeLogger,
+        PinOrchestrator orchestrator)
     {
         _guildChannelRepository = guildChannelRepository;
-        _messageRepository = messageRepository;
-        _pinnedMessageRepository = pinnedMessageRepository;
-        _unitOfWork = unitOfWork;
         _pinNotifier = pinNotifier;
-        _logger = logger;
+        _scopeLogger = scopeLogger;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<bool>> HandleAsync(
@@ -45,72 +36,14 @@ public sealed class PinMessageHandler : IAuthenticatedHandler<ChannelPinMessageI
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(request.ChannelId, currentUserId, cancellationToken);
-        if (ctx is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.NotFound,
-                "Channel was not found");
-        }
+        var scope = new ChannelPinScope(
+            request.ChannelId, _guildChannelRepository, _pinNotifier, _scopeLogger);
 
-        if (ctx.Channel.Type != GuildChannelType.Text)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.NotText,
-                "Messages can only be pinned in text channels");
-        }
-
-        if (ctx.CallerRole is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.AccessDenied,
-                "You do not have access to this channel");
-        }
-
-        var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        if (message is null || !message.Scope.Matches(request.ChannelId))
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Pin.MessageNotFound,
-                "Message was not found");
-        }
-
-        var pinnedMessage = PinnedMessage.Create(request.MessageId, currentUserId);
-        if (pinnedMessage.IsFailure || pinnedMessage.Value is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Common.DomainRuleViolation,
-                pinnedMessage.Error ?? "Invalid pin");
-        }
-
-        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
-        await _pinnedMessageRepository.AddAsync(pinnedMessage.Value, cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
-
-        await NotifyPinAddedSafelyAsync(
-            new ChannelPinAddedNotification(
-                request.MessageId,
-                request.ChannelId,
-                ctx.Channel.Name,
-                ctx.Channel.GuildId,
-                ctx.GuildName ?? string.Empty,
-                currentUserId,
-                ctx.CallerUsername ?? string.Empty,
-                ctx.CallerDisplayName,
-                pinnedMessage.Value.PinnedAtUtc));
-
-        return ApplicationResponse<bool>.Ok(true);
-    }
-
-    private async Task NotifyPinAddedSafelyAsync(
-        ChannelPinAddedNotification notification)
-    {
-        await BestEffortNotificationHelper.TryNotifyAsync(
-            token => _pinNotifier.NotifyMessagePinnedInChannelAsync(notification, token),
-            NotificationTimeout,
-            _logger,
-            "Channel pin notification failed (best-effort). MessageId={MessageId}, ChannelId={ChannelId}",
-            notification.MessageId,
-            notification.ChannelId);
+        return await _orchestrator.PinAsync(
+            scope,
+            new MessageScope.Channel(request.ChannelId),
+            request.MessageId,
+            currentUserId,
+            cancellationToken);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/Pins/ChannelPinScope.cs
+++ b/src/Harmonie.Application/Features/Channels/Pins/ChannelPinScope.cs
@@ -42,21 +42,16 @@ public sealed class ChannelPinScope : IPinScope<ChannelPinScope.Context>
 
     public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
     {
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(_channelId, caller, ct);
-        if (ctx is null)
-            return Denied(ApplicationErrorCodes.Channel.NotFound, "Channel was not found");
+        var result = await ChannelScopeAuthorizer.AuthorizeAsync(_guildChannelRepository, _channelId, caller, ct);
+        if (result is ChannelAuthResult.Denied denied)
+            return new AuthorizationResult<Context>.Denied(denied.Error);
 
-        if (ctx.Channel.Type != GuildChannelType.Text)
-            return Denied(ApplicationErrorCodes.Channel.NotText, "Messages can only be pinned in text channels");
-
-        if (ctx.CallerRole is null)
-            return Denied(ApplicationErrorCodes.Channel.AccessDenied, "You do not have access to this channel");
-
+        var access = ((ChannelAuthResult.Authorized)result).Context;
         return new AuthorizationResult<Context>.Authorized(new Context(
-            _channelId, ctx.Channel.Name, ctx.Channel.GuildId,
-            ctx.GuildName ?? string.Empty,
-            ctx.CallerUsername ?? string.Empty,
-            ctx.CallerDisplayName));
+            _channelId, access.Channel.Name, access.Channel.GuildId,
+            access.GuildName ?? string.Empty,
+            access.CallerUsername ?? string.Empty,
+            access.CallerDisplayName));
     }
 
     public async Task NotifyPinAddedAsync(
@@ -89,6 +84,4 @@ public sealed class ChannelPinScope : IPinScope<ChannelPinScope.Context>
             messageId, context.ChannelId);
     }
 
-    private static AuthorizationResult<Context> Denied(string code, string detail)
-        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
 }

--- a/src/Harmonie.Application/Features/Channels/Pins/ChannelPinScope.cs
+++ b/src/Harmonie.Application/Features/Channels/Pins/ChannelPinScope.cs
@@ -1,0 +1,94 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Guilds;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging;
+
+namespace Harmonie.Application.Features.Channels.Pins;
+
+public sealed class ChannelPinScope : IPinScope<ChannelPinScope.Context>
+{
+    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
+
+    public sealed record Context(
+        GuildChannelId ChannelId,
+        string ChannelName,
+        GuildId GuildId,
+        string GuildName,
+        string CallerUsername,
+        string? CallerDisplayName) : ScopeContext;
+
+    private readonly GuildChannelId _channelId;
+    private readonly IGuildChannelRepository _guildChannelRepository;
+    private readonly IPinNotifier _pinNotifier;
+    private readonly ILogger<ChannelPinScope> _logger;
+
+    public ChannelPinScope(
+        GuildChannelId channelId,
+        IGuildChannelRepository guildChannelRepository,
+        IPinNotifier pinNotifier,
+        ILogger<ChannelPinScope> logger)
+    {
+        _channelId = channelId;
+        _guildChannelRepository = guildChannelRepository;
+        _pinNotifier = pinNotifier;
+        _logger = logger;
+    }
+
+    public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
+    {
+        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(_channelId, caller, ct);
+        if (ctx is null)
+            return Denied(ApplicationErrorCodes.Channel.NotFound, "Channel was not found");
+
+        if (ctx.Channel.Type != GuildChannelType.Text)
+            return Denied(ApplicationErrorCodes.Channel.NotText, "Messages can only be pinned in text channels");
+
+        if (ctx.CallerRole is null)
+            return Denied(ApplicationErrorCodes.Channel.AccessDenied, "You do not have access to this channel");
+
+        return new AuthorizationResult<Context>.Authorized(new Context(
+            _channelId, ctx.Channel.Name, ctx.Channel.GuildId,
+            ctx.GuildName ?? string.Empty,
+            ctx.CallerUsername ?? string.Empty,
+            ctx.CallerDisplayName));
+    }
+
+    public async Task NotifyPinAddedAsync(
+        Context context, MessageId messageId, UserId userId, DateTime pinnedAtUtc, CancellationToken ct)
+    {
+        var notification = new ChannelPinAddedNotification(
+            messageId, context.ChannelId, context.ChannelName,
+            context.GuildId, context.GuildName,
+            userId, context.CallerUsername, context.CallerDisplayName, pinnedAtUtc);
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            token => _pinNotifier.NotifyMessagePinnedInChannelAsync(notification, token),
+            NotificationTimeout, _logger,
+            "Channel pin notification failed (best-effort). MessageId={MessageId}, ChannelId={ChannelId}",
+            messageId, context.ChannelId);
+    }
+
+    public async Task NotifyPinRemovedAsync(
+        Context context, MessageId messageId, UserId userId, DateTime unpinnedAtUtc, CancellationToken ct)
+    {
+        var notification = new ChannelPinRemovedNotification(
+            messageId, context.ChannelId, context.ChannelName,
+            context.GuildId, context.GuildName,
+            userId, context.CallerUsername, context.CallerDisplayName, unpinnedAtUtc);
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            token => _pinNotifier.NotifyMessageUnpinnedInChannelAsync(notification, token),
+            NotificationTimeout, _logger,
+            "Channel unpin notification failed (best-effort). MessageId={MessageId}, ChannelId={ChannelId}",
+            messageId, context.ChannelId);
+    }
+
+    private static AuthorizationResult<Context> Denied(string code, string detail)
+        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
+}

--- a/src/Harmonie.Application/Features/Channels/Pins/ChannelPinnedMessageFetchScope.cs
+++ b/src/Harmonie.Application/Features/Channels/Pins/ChannelPinnedMessageFetchScope.cs
@@ -28,15 +28,9 @@ public sealed class ChannelPinnedMessageFetchScope : IPinnedMessageFetchScope<Ch
 
     public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
     {
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(_channelId, caller, ct);
-        if (ctx is null)
-            return Denied(ApplicationErrorCodes.Channel.NotFound, "Channel was not found");
-
-        if (ctx.Channel.Type != GuildChannelType.Text)
-            return Denied(ApplicationErrorCodes.Channel.NotText, "Pinned messages can only be listed in text channels");
-
-        if (ctx.CallerRole is null)
-            return Denied(ApplicationErrorCodes.Channel.AccessDenied, "You do not have access to this channel");
+        var result = await ChannelScopeAuthorizer.AuthorizeAsync(_guildChannelRepository, _channelId, caller, ct);
+        if (result is ChannelAuthResult.Denied denied)
+            return new AuthorizationResult<Context>.Denied(denied.Error);
 
         return new AuthorizationResult<Context>.Authorized(new Context());
     }
@@ -44,7 +38,4 @@ public sealed class ChannelPinnedMessageFetchScope : IPinnedMessageFetchScope<Ch
     public Task<PinnedMessagesPage> GetPinnedPageAsync(
         UserId callerId, PinnedMessagesCursor? cursor, int limit, CancellationToken ct)
         => _pinnedMessageRepository.GetPinnedMessagesAsync(_channelId, callerId, cursor, limit, ct);
-
-    private static AuthorizationResult<Context> Denied(string code, string detail)
-        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
 }

--- a/src/Harmonie.Application/Features/Channels/Pins/ChannelPinnedMessageFetchScope.cs
+++ b/src/Harmonie.Application/Features/Channels/Pins/ChannelPinnedMessageFetchScope.cs
@@ -1,0 +1,50 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Features.Channels.Pins;
+
+public sealed class ChannelPinnedMessageFetchScope : IPinnedMessageFetchScope<ChannelPinnedMessageFetchScope.Context>
+{
+    public sealed record Context : ScopeContext;
+
+    private readonly GuildChannelId _channelId;
+    private readonly IGuildChannelRepository _guildChannelRepository;
+    private readonly IPinnedMessageRepository _pinnedMessageRepository;
+
+    public ChannelPinnedMessageFetchScope(
+        GuildChannelId channelId,
+        IGuildChannelRepository guildChannelRepository,
+        IPinnedMessageRepository pinnedMessageRepository)
+    {
+        _channelId = channelId;
+        _guildChannelRepository = guildChannelRepository;
+        _pinnedMessageRepository = pinnedMessageRepository;
+    }
+
+    public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
+    {
+        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(_channelId, caller, ct);
+        if (ctx is null)
+            return Denied(ApplicationErrorCodes.Channel.NotFound, "Channel was not found");
+
+        if (ctx.Channel.Type != GuildChannelType.Text)
+            return Denied(ApplicationErrorCodes.Channel.NotText, "Pinned messages can only be listed in text channels");
+
+        if (ctx.CallerRole is null)
+            return Denied(ApplicationErrorCodes.Channel.AccessDenied, "You do not have access to this channel");
+
+        return new AuthorizationResult<Context>.Authorized(new Context());
+    }
+
+    public Task<PinnedMessagesPage> GetPinnedPageAsync(
+        UserId callerId, PinnedMessagesCursor? cursor, int limit, CancellationToken ct)
+        => _pinnedMessageRepository.GetPinnedMessagesAsync(_channelId, callerId, cursor, limit, ct);
+
+    private static AuthorizationResult<Context> Denied(string code, string detail)
+        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
+}

--- a/src/Harmonie.Application/Features/Channels/Reactions/ChannelReactionScope.cs
+++ b/src/Harmonie.Application/Features/Channels/Reactions/ChannelReactionScope.cs
@@ -42,21 +42,18 @@ public sealed class ChannelReactionScope : IReactionScope<ChannelReactionScope.C
 
     public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
     {
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(_channelId, caller, ct);
-        if (ctx is null)
-            return Denied(ApplicationErrorCodes.Channel.NotFound, "Channel was not found");
+        var result = await ChannelScopeAuthorizer.AuthorizeAsync(_guildChannelRepository, _channelId, caller, ct);
+        if (result is ChannelAuthResult.Denied denied)
+            return new AuthorizationResult<Context>.Denied(denied.Error);
 
-        if (ctx.Channel.Type != GuildChannelType.Text)
-            return Denied(ApplicationErrorCodes.Channel.NotText, "Reactions can only be used in text channels");
-
-        if (ctx.CallerRole is null)
-            return Denied(ApplicationErrorCodes.Channel.AccessDenied, "You do not have access to this channel");
-
+        var access = ((ChannelAuthResult.Authorized)result).Context;
         return new AuthorizationResult<Context>.Authorized(new Context(
-            _channelId, ctx.Channel.Name, ctx.Channel.GuildId,
-            ctx.GuildName ?? string.Empty,
-            ctx.CallerUsername ?? string.Empty,
-            ctx.CallerDisplayName ?? string.Empty));
+            _channelId,
+            access.Channel.Name,
+            access.Channel.GuildId,
+            access.GuildName ?? string.Empty,
+            access.CallerUsername ?? string.Empty,
+            access.CallerDisplayName ?? string.Empty));
     }
 
     public async Task NotifyReactionAddedAsync(
@@ -88,7 +85,4 @@ public sealed class ChannelReactionScope : IReactionScope<ChannelReactionScope.C
             "RemoveChannelReaction notification failed (best-effort). MessageId={MessageId}, ChannelId={ChannelId}",
             notification.MessageId, notification.ChannelId);
     }
-
-    private static AuthorizationResult<Context> Denied(string code, string detail)
-        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
 }

--- a/src/Harmonie.Application/Features/Channels/Reads/ChannelReadScope.cs
+++ b/src/Harmonie.Application/Features/Channels/Reads/ChannelReadScope.cs
@@ -1,0 +1,57 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.Enums;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Features.Channels.Reads;
+
+public sealed class ChannelReadScope : IReadScope<ChannelReadScope.Context>
+{
+    public sealed record Context : ScopeContext;
+
+    private readonly GuildChannelId _channelId;
+    private readonly IGuildChannelRepository _guildChannelRepository;
+    private readonly IMessageRepository _messageRepository;
+    private readonly IChannelReadStateRepository _channelReadStateRepository;
+
+    public ChannelReadScope(
+        GuildChannelId channelId,
+        IGuildChannelRepository guildChannelRepository,
+        IMessageRepository messageRepository,
+        IChannelReadStateRepository channelReadStateRepository)
+    {
+        _channelId = channelId;
+        _guildChannelRepository = guildChannelRepository;
+        _messageRepository = messageRepository;
+        _channelReadStateRepository = channelReadStateRepository;
+    }
+
+    public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
+    {
+        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(_channelId, caller, ct);
+        if (ctx is null)
+            return Denied(ApplicationErrorCodes.Channel.NotFound, "Channel was not found");
+
+        if (ctx.Channel.Type != GuildChannelType.Text)
+            return Denied(ApplicationErrorCodes.Channel.NotText, "Read acknowledgement is only available in text channels");
+
+        if (ctx.CallerRole is null)
+            return Denied(ApplicationErrorCodes.Channel.AccessDenied, "You do not have access to this channel");
+
+        return new AuthorizationResult<Context>.Authorized(new Context());
+    }
+
+    public Task<MessageId?> GetLatestMessageIdAsync(CancellationToken ct)
+        => _messageRepository.GetLatestChannelMessageIdAsync(_channelId, ct);
+
+    public Task UpsertReadStateAsync(MessageReadState state, CancellationToken ct)
+        => _channelReadStateRepository.UpsertAsync(state, ct);
+
+    private static AuthorizationResult<Context> Denied(string code, string detail)
+        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
+}

--- a/src/Harmonie.Application/Features/Channels/Reads/ChannelReadScope.cs
+++ b/src/Harmonie.Application/Features/Channels/Reads/ChannelReadScope.cs
@@ -3,7 +3,6 @@ using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.Entities.Messages;
-using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -33,15 +32,9 @@ public sealed class ChannelReadScope : IReadScope<ChannelReadScope.Context>
 
     public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
     {
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(_channelId, caller, ct);
-        if (ctx is null)
-            return Denied(ApplicationErrorCodes.Channel.NotFound, "Channel was not found");
-
-        if (ctx.Channel.Type != GuildChannelType.Text)
-            return Denied(ApplicationErrorCodes.Channel.NotText, "Read acknowledgement is only available in text channels");
-
-        if (ctx.CallerRole is null)
-            return Denied(ApplicationErrorCodes.Channel.AccessDenied, "You do not have access to this channel");
+        var result = await ChannelScopeAuthorizer.AuthorizeAsync(_guildChannelRepository, _channelId, caller, ct);
+        if (result is ChannelAuthResult.Denied denied)
+            return new AuthorizationResult<Context>.Denied(denied.Error);
 
         return new AuthorizationResult<Context>.Authorized(new Context());
     }
@@ -51,7 +44,4 @@ public sealed class ChannelReadScope : IReadScope<ChannelReadScope.Context>
 
     public Task UpsertReadStateAsync(MessageReadState state, CancellationToken ct)
         => _channelReadStateRepository.UpsertAsync(state, ct);
-
-    private static AuthorizationResult<Context> Denied(string code, string detail)
-        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
 }

--- a/src/Harmonie.Application/Features/Channels/SendMessage/ChannelSendMessageScope.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/ChannelSendMessageScope.cs
@@ -48,35 +48,18 @@ public sealed class ChannelSendMessageScope : ISendMessageScope<ChannelSendMessa
 
     public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
     {
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(_channelId, caller, ct);
-        if (ctx is null)
-        {
-            return new AuthorizationResult<Context>.Denied(new ApplicationError(
-                ApplicationErrorCodes.Channel.NotFound,
-                "Channel was not found"));
-        }
+        var result = await ChannelScopeAuthorizer.AuthorizeAsync(_guildChannelRepository, _channelId, caller, ct);
+        if (result is ChannelAuthResult.Denied denied)
+            return new AuthorizationResult<Context>.Denied(denied.Error);
 
-        if (ctx.Channel.Type != GuildChannelType.Text)
-        {
-            return new AuthorizationResult<Context>.Denied(new ApplicationError(
-                ApplicationErrorCodes.Channel.NotText,
-                "Messages can only be sent to text channels"));
-        }
-
-        if (ctx.CallerRole is null)
-        {
-            return new AuthorizationResult<Context>.Denied(new ApplicationError(
-                ApplicationErrorCodes.Channel.AccessDenied,
-                "You do not have access to this channel"));
-        }
-
+        var access = ((ChannelAuthResult.Authorized)result).Context;
         return new AuthorizationResult<Context>.Authorized(new Context(
             _channelId,
-            ctx.Channel.Name,
-            ctx.Channel.GuildId,
-            ctx.GuildName ?? string.Empty,
-            ctx.CallerUsername ?? string.Empty,
-            ctx.CallerDisplayName ?? string.Empty));
+            access.Channel.Name,
+            access.Channel.GuildId,
+            access.GuildName ?? string.Empty,
+            access.CallerUsername ?? string.Empty,
+            access.CallerDisplayName ?? string.Empty));
     }
 
     public Task ApplyInTransactionSideEffectsAsync(Context context, CancellationToken ct)

--- a/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageHandler.cs
@@ -55,10 +55,10 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessag
             cancellationToken);
 
         if (!result.Success)
-            return ApplicationResponse<SendMessageResponse>.Fail(result.Error!);
+            return ApplicationResponse<SendMessageResponse>.Fail(result.Error);
 
         return ApplicationResponse<SendMessageResponse>.Ok(new SendMessageResponse(
-            result.Data!.MessageId,
+            result.Data.MessageId,
             request.ChannelId.Value,
             result.Data.AuthorUserId,
             result.Data.Content,

--- a/src/Harmonie.Application/Features/Channels/UnpinMessage/UnpinMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/UnpinMessage/UnpinMessageHandler.cs
@@ -1,8 +1,8 @@
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.Pins;
 using Harmonie.Application.Interfaces.Channels;
-using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -14,29 +14,21 @@ public sealed record ChannelUnpinMessageInput(GuildChannelId ChannelId, MessageI
 
 public sealed class UnpinMessageHandler : IAuthenticatedHandler<ChannelUnpinMessageInput, bool>
 {
-    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
-
     private readonly IGuildChannelRepository _guildChannelRepository;
-    private readonly IMessageRepository _messageRepository;
-    private readonly IPinnedMessageRepository _pinnedMessageRepository;
-    private readonly IUnitOfWork _unitOfWork;
     private readonly IPinNotifier _pinNotifier;
-    private readonly ILogger<UnpinMessageHandler> _logger;
+    private readonly ILogger<ChannelPinScope> _scopeLogger;
+    private readonly PinOrchestrator _orchestrator;
 
     public UnpinMessageHandler(
         IGuildChannelRepository guildChannelRepository,
-        IMessageRepository messageRepository,
-        IPinnedMessageRepository pinnedMessageRepository,
-        IUnitOfWork unitOfWork,
         IPinNotifier pinNotifier,
-        ILogger<UnpinMessageHandler> logger)
+        ILogger<ChannelPinScope> scopeLogger,
+        PinOrchestrator orchestrator)
     {
         _guildChannelRepository = guildChannelRepository;
-        _messageRepository = messageRepository;
-        _pinnedMessageRepository = pinnedMessageRepository;
-        _unitOfWork = unitOfWork;
         _pinNotifier = pinNotifier;
-        _logger = logger;
+        _scopeLogger = scopeLogger;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<bool>> HandleAsync(
@@ -44,64 +36,14 @@ public sealed class UnpinMessageHandler : IAuthenticatedHandler<ChannelUnpinMess
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        var ctx = await _guildChannelRepository.GetWithCallerRoleAsync(request.ChannelId, currentUserId, cancellationToken);
-        if (ctx is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.NotFound,
-                "Channel was not found");
-        }
+        var scope = new ChannelPinScope(
+            request.ChannelId, _guildChannelRepository, _pinNotifier, _scopeLogger);
 
-        if (ctx.Channel.Type != GuildChannelType.Text)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.NotText,
-                "Messages can only be unpinned in text channels");
-        }
-
-        if (ctx.CallerRole is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Channel.AccessDenied,
-                "You do not have access to this channel");
-        }
-
-        var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        if (message is null || !message.Scope.Matches(request.ChannelId))
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Pin.MessageNotFound,
-                "Message was not found");
-        }
-
-        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
-        await _pinnedMessageRepository.RemoveAsync(request.MessageId, cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
-
-        await NotifyPinRemovedSafelyAsync(
-            new ChannelPinRemovedNotification(
-                request.MessageId,
-                request.ChannelId,
-                ctx.Channel.Name,
-                ctx.Channel.GuildId,
-                ctx.GuildName ?? string.Empty,
-                currentUserId,
-                ctx.CallerUsername ?? string.Empty,
-                ctx.CallerDisplayName,
-                DateTime.UtcNow));
-
-        return ApplicationResponse<bool>.Ok(true);
-    }
-
-    private async Task NotifyPinRemovedSafelyAsync(
-        ChannelPinRemovedNotification notification)
-    {
-        await BestEffortNotificationHelper.TryNotifyAsync(
-            token => _pinNotifier.NotifyMessageUnpinnedInChannelAsync(notification, token),
-            NotificationTimeout,
-            _logger,
-            "Channel unpin notification failed (best-effort). MessageId={MessageId}, ChannelId={ChannelId}",
-            notification.MessageId,
-            notification.ChannelId);
+        return await _orchestrator.UnpinAsync(
+            scope,
+            new MessageScope.Channel(request.ChannelId),
+            request.MessageId,
+            currentUserId,
+            cancellationToken);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/AcknowledgeRead/AcknowledgeReadHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/AcknowledgeRead/AcknowledgeReadHandler.cs
@@ -1,8 +1,8 @@
 using Harmonie.Application.Common;
-using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Conversations.Reads;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -16,18 +16,18 @@ public sealed class AcknowledgeReadHandler : IAuthenticatedHandler<AcknowledgeCo
     private readonly IConversationRepository _conversationRepository;
     private readonly IMessageRepository _messageRepository;
     private readonly IConversationReadStateRepository _conversationReadStateRepository;
-    private readonly IUnitOfWork _unitOfWork;
+    private readonly ReadOrchestrator _orchestrator;
 
     public AcknowledgeReadHandler(
         IConversationRepository conversationRepository,
         IMessageRepository messageRepository,
         IConversationReadStateRepository conversationReadStateRepository,
-        IUnitOfWork unitOfWork)
+        ReadOrchestrator orchestrator)
     {
         _conversationRepository = conversationRepository;
         _messageRepository = messageRepository;
         _conversationReadStateRepository = conversationReadStateRepository;
-        _unitOfWork = unitOfWork;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<bool>> HandleAsync(
@@ -35,57 +35,14 @@ public sealed class AcknowledgeReadHandler : IAuthenticatedHandler<AcknowledgeCo
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(request.ConversationId, currentUserId, cancellationToken);
-        if (access is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Conversation.NotFound,
-                "Conversation was not found");
-        }
-        if (access.Participant is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Conversation.AccessDenied,
-                "You do not have access to this conversation");
-        }
+        var scope = new ConversationReadScope(
+            request.ConversationId, _conversationRepository, _messageRepository, _conversationReadStateRepository);
 
-        MessageId resolvedMessageId;
-
-        if (request.MessageId is not null)
-        {
-            var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-            if (message is null || !message.Scope.Matches(request.ConversationId))
-            {
-                return ApplicationResponse<bool>.Fail(
-                    ApplicationErrorCodes.Message.NotFound,
-                    "Message was not found in this conversation");
-            }
-
-            resolvedMessageId = request.MessageId;
-        }
-        else
-        {
-            var latestMessageId = await _messageRepository.GetLatestConversationMessageIdAsync(request.ConversationId, cancellationToken);
-            if (latestMessageId is null)
-            {
-                return ApplicationResponse<bool>.Ok(true);
-            }
-
-            resolvedMessageId = latestMessageId;
-        }
-
-        var state = MessageReadState.Create(currentUserId, new MessageScope.Conversation(request.ConversationId), resolvedMessageId);
-        if (state.IsFailure || state.Value is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Common.DomainRuleViolation,
-                state.Error ?? "Invalid read state");
-        }
-
-        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
-        await _conversationReadStateRepository.UpsertAsync(state.Value, cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
-
-        return ApplicationResponse<bool>.Ok(true);
+        return await _orchestrator.AcknowledgeAsync(
+            scope,
+            new MessageScope.Conversation(request.ConversationId),
+            request.MessageId,
+            currentUserId,
+            cancellationToken);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageHandler.cs
@@ -50,10 +50,10 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditConversationM
             cancellationToken);
 
         if (!result.Success)
-            return ApplicationResponse<EditMessageResponse>.Fail(result.Error!);
+            return ApplicationResponse<EditMessageResponse>.Fail(result.Error);
 
         return ApplicationResponse<EditMessageResponse>.Ok(new EditMessageResponse(
-            MessageId: result.Data!.MessageId,
+            MessageId: result.Data.MessageId,
             ConversationId: request.ConversationId.Value,
             AuthorUserId: result.Data.AuthorUserId,
             Content: result.Data.Content,

--- a/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesHandler.cs
@@ -38,11 +38,11 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetConversationMe
             scope, request.Cursor, request.Limit, currentUserId, cancellationToken);
 
         if (!result.Success)
-            return ApplicationResponse<GetMessagesResponse>.Fail(result.Error!);
+            return ApplicationResponse<GetMessagesResponse>.Fail(result.Error);
 
         return ApplicationResponse<GetMessagesResponse>.Ok(new GetMessagesResponse(
             ConversationId: request.ConversationId.Value,
-            Items: result.Data!.Items,
+            Items: result.Data.Items,
             NextCursor: result.Data.NextCursor,
             LastReadMessageId: result.Data.LastReadMessageId,
             LastReadAtUtc: result.Data.LastReadAtUtc));

--- a/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesHandler.cs
@@ -1,5 +1,6 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Conversations.Messages;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
@@ -11,17 +12,18 @@ public sealed record GetConversationMessagesInput(ConversationId ConversationId,
 
 public sealed class GetMessagesHandler : IAuthenticatedHandler<GetConversationMessagesInput, GetMessagesResponse>
 {
-    private const int DefaultLimit = 50;
-
     private readonly IConversationRepository _conversationRepository;
-    private readonly IMessagePaginationRepository _conversationMessageRepository;
+    private readonly IMessagePaginationRepository _paginationRepository;
+    private readonly MessageFetchOrchestrator _orchestrator;
 
     public GetMessagesHandler(
         IConversationRepository conversationRepository,
-        IMessagePaginationRepository conversationMessageRepository)
+        IMessagePaginationRepository paginationRepository,
+        MessageFetchOrchestrator orchestrator)
     {
         _conversationRepository = conversationRepository;
-        _conversationMessageRepository = conversationMessageRepository;
+        _paginationRepository = paginationRepository;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<GetMessagesResponse>> HandleAsync(
@@ -29,87 +31,20 @@ public sealed class GetMessagesHandler : IAuthenticatedHandler<GetConversationMe
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        MessageCursor? cursor = null;
-        if (request.Cursor is not null)
-        {
-            if (!MessageCursorCodec.TryParse(request.Cursor, out var parsedCursor) || parsedCursor is null)
-            {
-                return ApplicationResponse<GetMessagesResponse>.Fail(
-                    ApplicationErrorCodes.Common.ValidationFailed,
-                    "Request validation failed",
-                    EndpointExtensions.SingleValidationError(
-                        nameof(request.Cursor),
-                        ApplicationErrorCodes.Validation.InvalidFormat,
-                        "Cursor is invalid"));
-            }
+        var scope = new ConversationMessagePageScope(
+            request.ConversationId, _conversationRepository, _paginationRepository);
 
-            cursor = parsedCursor;
-        }
+        var result = await _orchestrator.FetchAsync(
+            scope, request.Cursor, request.Limit, currentUserId, cancellationToken);
 
-        var limit = request.Limit ?? DefaultLimit;
+        if (!result.Success)
+            return ApplicationResponse<GetMessagesResponse>.Fail(result.Error!);
 
-        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(request.ConversationId, currentUserId, cancellationToken);
-        if (access is null)
-        {
-            return ApplicationResponse<GetMessagesResponse>.Fail(
-                ApplicationErrorCodes.Conversation.NotFound,
-                "Conversation was not found");
-        }
-        if (access.Participant is null)
-        {
-            return ApplicationResponse<GetMessagesResponse>.Fail(
-                ApplicationErrorCodes.Conversation.AccessDenied,
-                "You do not have access to this conversation");
-        }
-
-        var page = await _conversationMessageRepository.GetConversationPageAsync(
-            request.ConversationId,
-            cursor,
-            limit,
-            currentUserId,
-            cancellationToken);
-
-        var items = page.Items
-            .OrderBy(x => x.CreatedAtUtc)
-            .ThenBy(x => x.Id.Value)
-            .Select(x =>
-            {
-                page.ReactionsByMessageId.TryGetValue(x.Id.Value, out var reactions);
-                page.AttachmentsByMessageId.TryGetValue(x.Id.Value, out var attachments);
-                IReadOnlyList<LinkPreviewDto>? previews = null;
-                page.LinkPreviewsByMessageId?.TryGetValue(x.Id.Value, out previews);
-                var isPinned = page.PinnedMessageIds?.Contains(x.Id.Value) == true;
-                ReplyPreviewDto? replyTo = null;
-                if (x.ReplyToMessageId is not null)
-                {
-                    page.ReplyPreviewsByTargetMessageId?.TryGetValue(x.ReplyToMessageId.Value, out replyTo);
-                }
-                return new GetMessagesItemResponse(
-                    MessageId: x.Id.Value,
-                    AuthorUserId: x.AuthorUserId.Value,
-                    Content: x.Content?.Value,
-                    Attachments: attachments?.Select(MessageAttachmentDto.FromDomain).ToArray()
-                                 ?? Array.Empty<MessageAttachmentDto>(),
-                    Reactions: reactions?.Select(r => new MessageReactionDto(r.Emoji, r.Count, r.ReactedByCaller,
-                        r.Users.Select(u => new ReactionUserDto(u.UserId, u.Username, u.DisplayName)).ToArray())).ToArray()
-                              ?? Array.Empty<MessageReactionDto>(),
-                    LinkPreviews: previews?.ToArray(),
-                    IsPinned: isPinned,
-                    ReplyTo: replyTo,
-                    CreatedAtUtc: x.CreatedAtUtc,
-                    UpdatedAtUtc: x.UpdatedAtUtc);
-            })
-            .ToArray();
-
-        var payload = new GetMessagesResponse(
+        return ApplicationResponse<GetMessagesResponse>.Ok(new GetMessagesResponse(
             ConversationId: request.ConversationId.Value,
-            Items: items,
-            NextCursor: page.NextCursor is null
-                ? null
-                : MessageCursorCodec.Encode(page.NextCursor),
-            LastReadMessageId: page.LastReadState?.LastReadMessageId.Value,
-            LastReadAtUtc: page.LastReadState?.ReadAtUtc);
-
-        return ApplicationResponse<GetMessagesResponse>.Ok(payload);
+            Items: result.Data!.Items,
+            NextCursor: result.Data.NextCursor,
+            LastReadMessageId: result.Data.LastReadMessageId,
+            LastReadAtUtc: result.Data.LastReadAtUtc));
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesResponse.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetMessages/GetMessagesResponse.cs
@@ -9,15 +9,3 @@ public sealed record GetMessagesResponse(
     string? NextCursor,
     Guid? LastReadMessageId,
     DateTime? LastReadAtUtc);
-
-public sealed record GetMessagesItemResponse(
-    Guid MessageId,
-    Guid AuthorUserId,
-    string? Content,
-    IReadOnlyList<MessageAttachmentDto> Attachments,
-    IReadOnlyList<MessageReactionDto> Reactions,
-    IReadOnlyList<LinkPreviewDto>? LinkPreviews,
-    bool IsPinned,
-    ReplyPreviewDto? ReplyTo,
-    DateTime CreatedAtUtc,
-    DateTime? UpdatedAtUtc);

--- a/src/Harmonie.Application/Features/Conversations/GetPinnedMessages/GetPinnedMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetPinnedMessages/GetPinnedMessagesHandler.cs
@@ -38,11 +38,11 @@ public sealed class GetPinnedMessagesHandler : IAuthenticatedHandler<GetConversa
             scope, request.Before, request.Limit, currentUserId, cancellationToken);
 
         if (!result.Success)
-            return ApplicationResponse<GetConversationPinnedMessagesResponse>.Fail(result.Error!);
+            return ApplicationResponse<GetConversationPinnedMessagesResponse>.Fail(result.Error);
 
         return ApplicationResponse<GetConversationPinnedMessagesResponse>.Ok(new GetConversationPinnedMessagesResponse(
             ConversationId: request.ConversationId.Value,
-            Items: result.Data!.Items,
+            Items: result.Data.Items,
             NextCursor: result.Data.NextCursor));
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/GetPinnedMessages/GetPinnedMessagesHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetPinnedMessages/GetPinnedMessagesHandler.cs
@@ -1,9 +1,9 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Conversations.Pins;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
-using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
 
 namespace Harmonie.Application.Features.Conversations.GetPinnedMessages;
@@ -12,17 +12,18 @@ public sealed record GetConversationPinnedMessagesInput(ConversationId Conversat
 
 public sealed class GetPinnedMessagesHandler : IAuthenticatedHandler<GetConversationPinnedMessagesInput, GetConversationPinnedMessagesResponse>
 {
-    private const int DefaultLimit = 50;
-
     private readonly IConversationRepository _conversationRepository;
     private readonly IPinnedMessageRepository _pinnedMessageRepository;
+    private readonly PinnedMessageFetchOrchestrator _orchestrator;
 
     public GetPinnedMessagesHandler(
         IConversationRepository conversationRepository,
-        IPinnedMessageRepository pinnedMessageRepository)
+        IPinnedMessageRepository pinnedMessageRepository,
+        PinnedMessageFetchOrchestrator orchestrator)
     {
         _conversationRepository = conversationRepository;
         _pinnedMessageRepository = pinnedMessageRepository;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<GetConversationPinnedMessagesResponse>> HandleAsync(
@@ -30,72 +31,18 @@ public sealed class GetPinnedMessagesHandler : IAuthenticatedHandler<GetConversa
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        PinnedMessagesCursor? cursor = null;
-        if (request.Before is not null)
-        {
-            if (!PinnedMessagesCursorCodec.TryParse(request.Before, out var parsed) || parsed is null)
-            {
-                return ApplicationResponse<GetConversationPinnedMessagesResponse>.Fail(
-                    ApplicationErrorCodes.Common.ValidationFailed,
-                    "Request validation failed",
-                    EndpointExtensions.SingleValidationError(
-                        nameof(request.Before),
-                        ApplicationErrorCodes.Validation.InvalidFormat,
-                        "Before cursor is invalid"));
-            }
+        var scope = new ConversationPinnedMessageFetchScope(
+            request.ConversationId, _conversationRepository, _pinnedMessageRepository);
 
-            cursor = parsed;
-        }
+        var result = await _orchestrator.FetchAsync(
+            scope, request.Before, request.Limit, currentUserId, cancellationToken);
 
-        var limit = request.Limit ?? DefaultLimit;
+        if (!result.Success)
+            return ApplicationResponse<GetConversationPinnedMessagesResponse>.Fail(result.Error!);
 
-        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(
-            request.ConversationId, currentUserId, cancellationToken);
-        if (access is null)
-        {
-            return ApplicationResponse<GetConversationPinnedMessagesResponse>.Fail(
-                ApplicationErrorCodes.Conversation.NotFound,
-                "Conversation was not found");
-        }
-        if (access.Participant is null)
-        {
-            return ApplicationResponse<GetConversationPinnedMessagesResponse>.Fail(
-                ApplicationErrorCodes.Conversation.AccessDenied,
-                "You do not have access to this conversation");
-        }
-
-        var page = await _pinnedMessageRepository.GetPinnedMessagesAsync(
-            request.ConversationId,
-            currentUserId,
-            cursor,
-            limit,
-            cancellationToken);
-
-        var items = page.Items
-            .Select(x =>
-            {
-                page.AttachmentsByMessageId.TryGetValue(MessageId.From(x.MessageId), out var attachments);
-                return new GetPinnedMessagesItemResponse(
-                    MessageId: x.MessageId,
-                    AuthorUserId: x.AuthorUserId,
-                    AuthorUsername: x.AuthorUsername,
-                    AuthorDisplayName: x.AuthorDisplayName,
-                    Content: x.Content,
-                    Attachments: attachments?.Select(MessageAttachmentDto.FromDomain).ToArray()
-                                 ?? Array.Empty<MessageAttachmentDto>(),
-                    CreatedAtUtc: x.CreatedAtUtc,
-                    UpdatedAtUtc: x.UpdatedAtUtc,
-                    PinnedByUserId: x.PinnedByUserId,
-                    PinnedAtUtc: x.PinnedAtUtc);
-            })
-            .ToArray();
-
-        return ApplicationResponse<GetConversationPinnedMessagesResponse>.Ok(
-            new GetConversationPinnedMessagesResponse(
-                ConversationId: request.ConversationId.Value,
-                Items: items,
-                NextCursor: page.NextCursor is null
-                    ? null
-                    : PinnedMessagesCursorCodec.Encode(page.NextCursor)));
+        return ApplicationResponse<GetConversationPinnedMessagesResponse>.Ok(new GetConversationPinnedMessagesResponse(
+            ConversationId: request.ConversationId.Value,
+            Items: result.Data!.Items,
+            NextCursor: result.Data.NextCursor));
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/GetPinnedMessages/GetPinnedMessagesResponse.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetPinnedMessages/GetPinnedMessagesResponse.cs
@@ -6,15 +6,3 @@ public sealed record GetConversationPinnedMessagesResponse(
     Guid ConversationId,
     IReadOnlyList<GetPinnedMessagesItemResponse> Items,
     string? NextCursor);
-
-public sealed record GetPinnedMessagesItemResponse(
-    Guid MessageId,
-    Guid AuthorUserId,
-    string AuthorUsername,
-    string? AuthorDisplayName,
-    string? Content,
-    IReadOnlyList<MessageAttachmentDto> Attachments,
-    DateTime CreatedAtUtc,
-    DateTime? UpdatedAtUtc,
-    Guid PinnedByUserId,
-    DateTime PinnedAtUtc);

--- a/src/Harmonie.Application/Features/Conversations/GetReactionUsers/GetReactionUsersHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/GetReactionUsers/GetReactionUsersHandler.cs
@@ -55,10 +55,10 @@ public sealed class GetReactionUsersHandler : IAuthenticatedHandler<GetConversat
             cancellationToken);
 
         if (!result.Success)
-            return ApplicationResponse<GetReactionUsersResponse>.Fail(result.Error!);
+            return ApplicationResponse<GetReactionUsersResponse>.Fail(result.Error);
 
         return ApplicationResponse<GetReactionUsersResponse>.Ok(new GetReactionUsersResponse(
-            result.Data!.MessageId,
+            result.Data.MessageId,
             result.Data.Emoji,
             result.Data.TotalCount,
             result.Data.Users,

--- a/src/Harmonie.Application/Features/Conversations/Messages/ConversationMessageEditDeleteScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/Messages/ConversationMessageEditDeleteScope.cs
@@ -40,13 +40,11 @@ public sealed class ConversationMessageEditDeleteScope : IMessageEditDeleteScope
 
     public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
     {
-        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(_conversationId, caller, ct);
-        if (access is null)
-            return Denied(ApplicationErrorCodes.Conversation.NotFound, "Conversation was not found");
+        var result = await ConversationScopeAuthorizer.AuthorizeAsync(_conversationRepository, _conversationId, caller, ct);
+        if (result is ConversationAuthResult.Denied denied)
+            return new AuthorizationResult<Context>.Denied(denied.Error);
 
-        if (access.Participant is null)
-            return Denied(ApplicationErrorCodes.Conversation.AccessDenied, "You do not have access to this conversation");
-
+        var access = ((ConversationAuthResult.Authorized)result).Context;
         return new AuthorizationResult<Context>.Authorized(new Context(
             _conversationId,
             access.Conversation.Name,
@@ -100,7 +98,4 @@ public sealed class ConversationMessageEditDeleteScope : IMessageEditDeleteScope
             notification.MessageId,
             notification.ConversationId);
     }
-
-    private static AuthorizationResult<Context> Denied(string code, string detail)
-        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
 }

--- a/src/Harmonie.Application/Features/Conversations/Messages/ConversationMessagePageScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/Messages/ConversationMessagePageScope.cs
@@ -28,19 +28,13 @@ public sealed class ConversationMessagePageScope : IMessagePageScope<Conversatio
 
     public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
     {
-        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(_conversationId, caller, ct);
-        if (access is null)
-            return Denied(ApplicationErrorCodes.Conversation.NotFound, "Conversation was not found");
-
-        if (access.Participant is null)
-            return Denied(ApplicationErrorCodes.Conversation.AccessDenied, "You do not have access to this conversation");
+        var result = await ConversationScopeAuthorizer.AuthorizeAsync(_conversationRepository, _conversationId, caller, ct);
+        if (result is ConversationAuthResult.Denied denied)
+            return new AuthorizationResult<Context>.Denied(denied.Error);
 
         return new AuthorizationResult<Context>.Authorized(new Context());
     }
 
     public Task<MessagePage> GetPageAsync(MessageCursor? cursor, int limit, UserId callerId, CancellationToken ct)
         => _paginationRepository.GetConversationPageAsync(_conversationId, cursor, limit, callerId, ct);
-
-    private static AuthorizationResult<Context> Denied(string code, string detail)
-        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
 }

--- a/src/Harmonie.Application/Features/Conversations/Messages/ConversationMessagePageScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/Messages/ConversationMessagePageScope.cs
@@ -1,0 +1,46 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Features.Conversations.Messages;
+
+public sealed class ConversationMessagePageScope : IMessagePageScope<ConversationMessagePageScope.Context>
+{
+    public sealed record Context : ScopeContext;
+
+    private readonly ConversationId _conversationId;
+    private readonly IConversationRepository _conversationRepository;
+    private readonly IMessagePaginationRepository _paginationRepository;
+
+    public ConversationMessagePageScope(
+        ConversationId conversationId,
+        IConversationRepository conversationRepository,
+        IMessagePaginationRepository paginationRepository)
+    {
+        _conversationId = conversationId;
+        _conversationRepository = conversationRepository;
+        _paginationRepository = paginationRepository;
+    }
+
+    public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
+    {
+        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(_conversationId, caller, ct);
+        if (access is null)
+            return Denied(ApplicationErrorCodes.Conversation.NotFound, "Conversation was not found");
+
+        if (access.Participant is null)
+            return Denied(ApplicationErrorCodes.Conversation.AccessDenied, "You do not have access to this conversation");
+
+        return new AuthorizationResult<Context>.Authorized(new Context());
+    }
+
+    public Task<MessagePage> GetPageAsync(MessageCursor? cursor, int limit, UserId callerId, CancellationToken ct)
+        => _paginationRepository.GetConversationPageAsync(_conversationId, cursor, limit, callerId, ct);
+
+    private static AuthorizationResult<Context> Denied(string code, string detail)
+        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
+}

--- a/src/Harmonie.Application/Features/Conversations/PinMessage/PinMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/PinMessage/PinMessageHandler.cs
@@ -1,8 +1,8 @@
 using Harmonie.Application.Common;
-using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Conversations.Pins;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
-using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -14,29 +14,21 @@ public sealed record ConversationPinMessageInput(ConversationId ConversationId, 
 
 public sealed class PinMessageHandler : IAuthenticatedHandler<ConversationPinMessageInput, bool>
 {
-    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
-
     private readonly IConversationRepository _conversationRepository;
-    private readonly IMessageRepository _messageRepository;
-    private readonly IPinnedMessageRepository _pinnedMessageRepository;
-    private readonly IUnitOfWork _unitOfWork;
     private readonly IPinNotifier _pinNotifier;
-    private readonly ILogger<PinMessageHandler> _logger;
+    private readonly ILogger<ConversationPinScope> _scopeLogger;
+    private readonly PinOrchestrator _orchestrator;
 
     public PinMessageHandler(
         IConversationRepository conversationRepository,
-        IMessageRepository messageRepository,
-        IPinnedMessageRepository pinnedMessageRepository,
-        IUnitOfWork unitOfWork,
         IPinNotifier pinNotifier,
-        ILogger<PinMessageHandler> logger)
+        ILogger<ConversationPinScope> scopeLogger,
+        PinOrchestrator orchestrator)
     {
         _conversationRepository = conversationRepository;
-        _messageRepository = messageRepository;
-        _pinnedMessageRepository = pinnedMessageRepository;
-        _unitOfWork = unitOfWork;
         _pinNotifier = pinNotifier;
-        _logger = logger;
+        _scopeLogger = scopeLogger;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<bool>> HandleAsync(
@@ -44,64 +36,14 @@ public sealed class PinMessageHandler : IAuthenticatedHandler<ConversationPinMes
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(
-            request.ConversationId, currentUserId, cancellationToken);
-        if (access is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Conversation.NotFound,
-                "Conversation was not found");
-        }
-        if (access.Participant is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Conversation.AccessDenied,
-                "You do not have access to this conversation");
-        }
+        var scope = new ConversationPinScope(
+            request.ConversationId, _conversationRepository, _pinNotifier, _scopeLogger);
 
-        var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        if (message is null || !message.Scope.Matches(request.ConversationId))
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Pin.MessageNotFound,
-                "Message was not found");
-        }
-
-        var pinnedMessage = PinnedMessage.Create(request.MessageId, currentUserId);
-        if (pinnedMessage.IsFailure || pinnedMessage.Value is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Common.DomainRuleViolation,
-                pinnedMessage.Error ?? "Invalid pin");
-        }
-
-        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
-        await _pinnedMessageRepository.AddAsync(pinnedMessage.Value, cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
-
-        await NotifyPinAddedSafelyAsync(
-            new ConversationPinAddedNotification(
-                request.MessageId,
-                request.ConversationId,
-                access.Conversation.Name,
-                access.Conversation.Type.ToString(),
-                currentUserId,
-                access.CallerUsername ?? string.Empty,
-                access.CallerDisplayName,
-                pinnedMessage.Value.PinnedAtUtc));
-
-        return ApplicationResponse<bool>.Ok(true);
-    }
-
-    private async Task NotifyPinAddedSafelyAsync(
-        ConversationPinAddedNotification notification)
-    {
-        await BestEffortNotificationHelper.TryNotifyAsync(
-            token => _pinNotifier.NotifyMessagePinnedInConversationAsync(notification, token),
-            NotificationTimeout,
-            _logger,
-            "Conversation pin notification failed (best-effort). MessageId={MessageId}, ConversationId={ConversationId}",
-            notification.MessageId,
-            notification.ConversationId);
+        return await _orchestrator.PinAsync(
+            scope,
+            new MessageScope.Conversation(request.ConversationId),
+            request.MessageId,
+            currentUserId,
+            cancellationToken);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/Pins/ConversationPinScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/Pins/ConversationPinScope.cs
@@ -1,0 +1,88 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.Entities.Conversations;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging;
+
+namespace Harmonie.Application.Features.Conversations.Pins;
+
+public sealed class ConversationPinScope : IPinScope<ConversationPinScope.Context>
+{
+    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
+
+    public sealed record Context(
+        ConversationId ConversationId,
+        string? ConversationName,
+        ConversationType ConversationType,
+        string CallerUsername,
+        string? CallerDisplayName) : ScopeContext;
+
+    private readonly ConversationId _conversationId;
+    private readonly IConversationRepository _conversationRepository;
+    private readonly IPinNotifier _pinNotifier;
+    private readonly ILogger<ConversationPinScope> _logger;
+
+    public ConversationPinScope(
+        ConversationId conversationId,
+        IConversationRepository conversationRepository,
+        IPinNotifier pinNotifier,
+        ILogger<ConversationPinScope> logger)
+    {
+        _conversationId = conversationId;
+        _conversationRepository = conversationRepository;
+        _pinNotifier = pinNotifier;
+        _logger = logger;
+    }
+
+    public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
+    {
+        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(_conversationId, caller, ct);
+        if (access is null)
+            return Denied(ApplicationErrorCodes.Conversation.NotFound, "Conversation was not found");
+
+        if (access.Participant is null)
+            return Denied(ApplicationErrorCodes.Conversation.AccessDenied, "You do not have access to this conversation");
+
+        return new AuthorizationResult<Context>.Authorized(new Context(
+            _conversationId, access.Conversation.Name, access.Conversation.Type,
+            access.CallerUsername ?? string.Empty,
+            access.CallerDisplayName));
+    }
+
+    public async Task NotifyPinAddedAsync(
+        Context context, MessageId messageId, UserId userId, DateTime pinnedAtUtc, CancellationToken ct)
+    {
+        var notification = new ConversationPinAddedNotification(
+            messageId, context.ConversationId, context.ConversationName,
+            context.ConversationType.ToString(),
+            userId, context.CallerUsername, context.CallerDisplayName, pinnedAtUtc);
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            token => _pinNotifier.NotifyMessagePinnedInConversationAsync(notification, token),
+            NotificationTimeout, _logger,
+            "Conversation pin notification failed (best-effort). MessageId={MessageId}, ConversationId={ConversationId}",
+            messageId, context.ConversationId);
+    }
+
+    public async Task NotifyPinRemovedAsync(
+        Context context, MessageId messageId, UserId userId, DateTime unpinnedAtUtc, CancellationToken ct)
+    {
+        var notification = new ConversationPinRemovedNotification(
+            messageId, context.ConversationId, context.ConversationName,
+            context.ConversationType.ToString(),
+            userId, context.CallerUsername, context.CallerDisplayName, unpinnedAtUtc);
+
+        await BestEffortNotificationHelper.TryNotifyAsync(
+            token => _pinNotifier.NotifyMessageUnpinnedInConversationAsync(notification, token),
+            NotificationTimeout, _logger,
+            "Conversation unpin notification failed (best-effort). MessageId={MessageId}, ConversationId={ConversationId}",
+            messageId, context.ConversationId);
+    }
+
+    private static AuthorizationResult<Context> Denied(string code, string detail)
+        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
+}

--- a/src/Harmonie.Application/Features/Conversations/Pins/ConversationPinScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/Pins/ConversationPinScope.cs
@@ -40,13 +40,11 @@ public sealed class ConversationPinScope : IPinScope<ConversationPinScope.Contex
 
     public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
     {
-        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(_conversationId, caller, ct);
-        if (access is null)
-            return Denied(ApplicationErrorCodes.Conversation.NotFound, "Conversation was not found");
+        var result = await ConversationScopeAuthorizer.AuthorizeAsync(_conversationRepository, _conversationId, caller, ct);
+        if (result is ConversationAuthResult.Denied denied)
+            return new AuthorizationResult<Context>.Denied(denied.Error);
 
-        if (access.Participant is null)
-            return Denied(ApplicationErrorCodes.Conversation.AccessDenied, "You do not have access to this conversation");
-
+        var access = ((ConversationAuthResult.Authorized)result).Context;
         return new AuthorizationResult<Context>.Authorized(new Context(
             _conversationId, access.Conversation.Name, access.Conversation.Type,
             access.CallerUsername ?? string.Empty,
@@ -83,6 +81,4 @@ public sealed class ConversationPinScope : IPinScope<ConversationPinScope.Contex
             messageId, context.ConversationId);
     }
 
-    private static AuthorizationResult<Context> Denied(string code, string detail)
-        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
 }

--- a/src/Harmonie.Application/Features/Conversations/Pins/ConversationPinnedMessageFetchScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/Pins/ConversationPinnedMessageFetchScope.cs
@@ -1,0 +1,46 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Features.Conversations.Pins;
+
+public sealed class ConversationPinnedMessageFetchScope : IPinnedMessageFetchScope<ConversationPinnedMessageFetchScope.Context>
+{
+    public sealed record Context : ScopeContext;
+
+    private readonly ConversationId _conversationId;
+    private readonly IConversationRepository _conversationRepository;
+    private readonly IPinnedMessageRepository _pinnedMessageRepository;
+
+    public ConversationPinnedMessageFetchScope(
+        ConversationId conversationId,
+        IConversationRepository conversationRepository,
+        IPinnedMessageRepository pinnedMessageRepository)
+    {
+        _conversationId = conversationId;
+        _conversationRepository = conversationRepository;
+        _pinnedMessageRepository = pinnedMessageRepository;
+    }
+
+    public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
+    {
+        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(_conversationId, caller, ct);
+        if (access is null)
+            return Denied(ApplicationErrorCodes.Conversation.NotFound, "Conversation was not found");
+
+        if (access.Participant is null)
+            return Denied(ApplicationErrorCodes.Conversation.AccessDenied, "You do not have access to this conversation");
+
+        return new AuthorizationResult<Context>.Authorized(new Context());
+    }
+
+    public Task<PinnedMessagesPage> GetPinnedPageAsync(
+        UserId callerId, PinnedMessagesCursor? cursor, int limit, CancellationToken ct)
+        => _pinnedMessageRepository.GetPinnedMessagesAsync(_conversationId, callerId, cursor, limit, ct);
+
+    private static AuthorizationResult<Context> Denied(string code, string detail)
+        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
+}

--- a/src/Harmonie.Application/Features/Conversations/Pins/ConversationPinnedMessageFetchScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/Pins/ConversationPinnedMessageFetchScope.cs
@@ -27,12 +27,9 @@ public sealed class ConversationPinnedMessageFetchScope : IPinnedMessageFetchSco
 
     public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
     {
-        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(_conversationId, caller, ct);
-        if (access is null)
-            return Denied(ApplicationErrorCodes.Conversation.NotFound, "Conversation was not found");
-
-        if (access.Participant is null)
-            return Denied(ApplicationErrorCodes.Conversation.AccessDenied, "You do not have access to this conversation");
+        var result = await ConversationScopeAuthorizer.AuthorizeAsync(_conversationRepository, _conversationId, caller, ct);
+        if (result is ConversationAuthResult.Denied denied)
+            return new AuthorizationResult<Context>.Denied(denied.Error);
 
         return new AuthorizationResult<Context>.Authorized(new Context());
     }
@@ -40,7 +37,4 @@ public sealed class ConversationPinnedMessageFetchScope : IPinnedMessageFetchSco
     public Task<PinnedMessagesPage> GetPinnedPageAsync(
         UserId callerId, PinnedMessagesCursor? cursor, int limit, CancellationToken ct)
         => _pinnedMessageRepository.GetPinnedMessagesAsync(_conversationId, callerId, cursor, limit, ct);
-
-    private static AuthorizationResult<Context> Denied(string code, string detail)
-        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
 }

--- a/src/Harmonie.Application/Features/Conversations/Reactions/ConversationReactionScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/Reactions/ConversationReactionScope.cs
@@ -40,13 +40,11 @@ public sealed class ConversationReactionScope : IReactionScope<ConversationReact
 
     public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
     {
-        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(_conversationId, caller, ct);
-        if (access is null)
-            return Denied(ApplicationErrorCodes.Conversation.NotFound, "Conversation was not found");
+        var result = await ConversationScopeAuthorizer.AuthorizeAsync(_conversationRepository, _conversationId, caller, ct);
+        if (result is ConversationAuthResult.Denied denied)
+            return new AuthorizationResult<Context>.Denied(denied.Error);
 
-        if (access.Participant is null)
-            return Denied(ApplicationErrorCodes.Conversation.AccessDenied, "You do not have access to this conversation");
-
+        var access = ((ConversationAuthResult.Authorized)result).Context;
         return new AuthorizationResult<Context>.Authorized(new Context(
             _conversationId, access.Conversation.Name, access.Conversation.Type,
             access.CallerUsername ?? string.Empty,
@@ -82,7 +80,4 @@ public sealed class ConversationReactionScope : IReactionScope<ConversationReact
             "RemoveConversationReaction notification failed (best-effort). MessageId={MessageId}, ConversationId={ConversationId}",
             notification.MessageId, notification.ConversationId);
     }
-
-    private static AuthorizationResult<Context> Denied(string code, string detail)
-        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
 }

--- a/src/Harmonie.Application/Features/Conversations/Reads/ConversationReadScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/Reads/ConversationReadScope.cs
@@ -1,0 +1,53 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Features.Conversations.Reads;
+
+public sealed class ConversationReadScope : IReadScope<ConversationReadScope.Context>
+{
+    public sealed record Context : ScopeContext;
+
+    private readonly ConversationId _conversationId;
+    private readonly IConversationRepository _conversationRepository;
+    private readonly IMessageRepository _messageRepository;
+    private readonly IConversationReadStateRepository _conversationReadStateRepository;
+
+    public ConversationReadScope(
+        ConversationId conversationId,
+        IConversationRepository conversationRepository,
+        IMessageRepository messageRepository,
+        IConversationReadStateRepository conversationReadStateRepository)
+    {
+        _conversationId = conversationId;
+        _conversationRepository = conversationRepository;
+        _messageRepository = messageRepository;
+        _conversationReadStateRepository = conversationReadStateRepository;
+    }
+
+    public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
+    {
+        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(_conversationId, caller, ct);
+        if (access is null)
+            return Denied(ApplicationErrorCodes.Conversation.NotFound, "Conversation was not found");
+
+        if (access.Participant is null)
+            return Denied(ApplicationErrorCodes.Conversation.AccessDenied, "You do not have access to this conversation");
+
+        return new AuthorizationResult<Context>.Authorized(new Context());
+    }
+
+    public Task<MessageId?> GetLatestMessageIdAsync(CancellationToken ct)
+        => _messageRepository.GetLatestConversationMessageIdAsync(_conversationId, ct);
+
+    public Task UpsertReadStateAsync(MessageReadState state, CancellationToken ct)
+        => _conversationReadStateRepository.UpsertAsync(state, ct);
+
+    private static AuthorizationResult<Context> Denied(string code, string detail)
+        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
+}

--- a/src/Harmonie.Application/Features/Conversations/Reads/ConversationReadScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/Reads/ConversationReadScope.cs
@@ -32,12 +32,9 @@ public sealed class ConversationReadScope : IReadScope<ConversationReadScope.Con
 
     public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
     {
-        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(_conversationId, caller, ct);
-        if (access is null)
-            return Denied(ApplicationErrorCodes.Conversation.NotFound, "Conversation was not found");
-
-        if (access.Participant is null)
-            return Denied(ApplicationErrorCodes.Conversation.AccessDenied, "You do not have access to this conversation");
+        var result = await ConversationScopeAuthorizer.AuthorizeAsync(_conversationRepository, _conversationId, caller, ct);
+        if (result is ConversationAuthResult.Denied denied)
+            return new AuthorizationResult<Context>.Denied(denied.Error);
 
         return new AuthorizationResult<Context>.Authorized(new Context());
     }
@@ -47,7 +44,4 @@ public sealed class ConversationReadScope : IReadScope<ConversationReadScope.Con
 
     public Task UpsertReadStateAsync(MessageReadState state, CancellationToken ct)
         => _conversationReadStateRepository.UpsertAsync(state, ct);
-
-    private static AuthorizationResult<Context> Denied(string code, string detail)
-        => new AuthorizationResult<Context>.Denied(new ApplicationError(code, detail));
 }

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageHandler.cs
@@ -59,10 +59,10 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
             cancellationToken);
 
         if (!result.Success)
-            return ApplicationResponse<SendMessageResponse>.Fail(result.Error!);
+            return ApplicationResponse<SendMessageResponse>.Fail(result.Error);
 
         return ApplicationResponse<SendMessageResponse>.Ok(new SendMessageResponse(
-            result.Data!.MessageId,
+            result.Data.MessageId,
             request.ConversationId.Value,
             result.Data.AuthorUserId,
             result.Data.Content,

--- a/src/Harmonie.Application/Features/Conversations/UnpinMessage/UnpinMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/UnpinMessage/UnpinMessageHandler.cs
@@ -1,5 +1,6 @@
 using Harmonie.Application.Common;
-using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Conversations.Pins;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
@@ -13,29 +14,21 @@ public sealed record ConversationUnpinMessageInput(ConversationId ConversationId
 
 public sealed class UnpinMessageHandler : IAuthenticatedHandler<ConversationUnpinMessageInput, bool>
 {
-    private static readonly TimeSpan NotificationTimeout = TimeSpan.FromSeconds(5);
-
     private readonly IConversationRepository _conversationRepository;
-    private readonly IMessageRepository _messageRepository;
-    private readonly IPinnedMessageRepository _pinnedMessageRepository;
-    private readonly IUnitOfWork _unitOfWork;
     private readonly IPinNotifier _pinNotifier;
-    private readonly ILogger<UnpinMessageHandler> _logger;
+    private readonly ILogger<ConversationPinScope> _scopeLogger;
+    private readonly PinOrchestrator _orchestrator;
 
     public UnpinMessageHandler(
         IConversationRepository conversationRepository,
-        IMessageRepository messageRepository,
-        IPinnedMessageRepository pinnedMessageRepository,
-        IUnitOfWork unitOfWork,
         IPinNotifier pinNotifier,
-        ILogger<UnpinMessageHandler> logger)
+        ILogger<ConversationPinScope> scopeLogger,
+        PinOrchestrator orchestrator)
     {
         _conversationRepository = conversationRepository;
-        _messageRepository = messageRepository;
-        _pinnedMessageRepository = pinnedMessageRepository;
-        _unitOfWork = unitOfWork;
         _pinNotifier = pinNotifier;
-        _logger = logger;
+        _scopeLogger = scopeLogger;
+        _orchestrator = orchestrator;
     }
 
     public async Task<ApplicationResponse<bool>> HandleAsync(
@@ -43,56 +36,14 @@ public sealed class UnpinMessageHandler : IAuthenticatedHandler<ConversationUnpi
         UserId currentUserId,
         CancellationToken cancellationToken = default)
     {
-        var access = await _conversationRepository.GetByIdWithParticipantCheckAsync(
-            request.ConversationId, currentUserId, cancellationToken);
-        if (access is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Conversation.NotFound,
-                "Conversation was not found");
-        }
-        if (access.Participant is null)
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Conversation.AccessDenied,
-                "You do not have access to this conversation");
-        }
+        var scope = new ConversationPinScope(
+            request.ConversationId, _conversationRepository, _pinNotifier, _scopeLogger);
 
-        var message = await _messageRepository.GetByIdAsync(request.MessageId, cancellationToken);
-        if (message is null || !message.Scope.Matches(request.ConversationId))
-        {
-            return ApplicationResponse<bool>.Fail(
-                ApplicationErrorCodes.Pin.MessageNotFound,
-                "Message was not found");
-        }
-
-        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
-        await _pinnedMessageRepository.RemoveAsync(request.MessageId, cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
-
-        await NotifyPinRemovedSafelyAsync(
-            new ConversationPinRemovedNotification(
-                request.MessageId,
-                request.ConversationId,
-                access.Conversation.Name,
-                access.Conversation.Type.ToString(),
-                currentUserId,
-                access.CallerUsername ?? string.Empty,
-                access.CallerDisplayName,
-                DateTime.UtcNow));
-
-        return ApplicationResponse<bool>.Ok(true);
-    }
-
-    private async Task NotifyPinRemovedSafelyAsync(
-        ConversationPinRemovedNotification notification)
-    {
-        await BestEffortNotificationHelper.TryNotifyAsync(
-            token => _pinNotifier.NotifyMessageUnpinnedInConversationAsync(notification, token),
-            NotificationTimeout,
-            _logger,
-            "Conversation unpin notification failed (best-effort). MessageId={MessageId}, ConversationId={ConversationId}",
-            notification.MessageId,
-            notification.ConversationId);
+        return await _orchestrator.UnpinAsync(
+            scope,
+            new MessageScope.Conversation(request.ConversationId),
+            request.MessageId,
+            currentUserId,
+            cancellationToken);
     }
 }

--- a/tests/Harmonie.Application.Tests/Channels/AcknowledgeChannelReadHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Channels/AcknowledgeChannelReadHandlerTests.cs
@@ -1,6 +1,8 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Channels.AcknowledgeRead;
+using Harmonie.Application.Features.Channels.Reads;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
@@ -23,6 +25,7 @@ public sealed class AcknowledgeChannelReadHandlerTests
     private readonly Mock<IChannelReadStateRepository> _channelReadStateRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly ReadOrchestrator _orchestrator;
     private readonly AcknowledgeReadHandler _handler;
 
     public AcknowledgeChannelReadHandlerTests()
@@ -35,11 +38,13 @@ public sealed class AcknowledgeChannelReadHandlerTests
 
         _transactionMock = _unitOfWorkMock.SetupTransactionMock();
 
+        _orchestrator = new ReadOrchestrator(_messageRepositoryMock.Object, _unitOfWorkMock.Object);
+
         _handler = new AcknowledgeReadHandler(
             _guildChannelRepositoryMock.Object,
             _messageRepositoryMock.Object,
             _channelReadStateRepositoryMock.Object,
-            _unitOfWorkMock.Object);
+            _orchestrator);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Conversations/AcknowledgeConversationReadHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/AcknowledgeConversationReadHandlerTests.cs
@@ -1,6 +1,8 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Conversations.AcknowledgeRead;
+using Harmonie.Application.Features.Conversations.Reads;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
@@ -21,6 +23,7 @@ public sealed class AcknowledgeConversationReadHandlerTests
     private readonly Mock<IConversationReadStateRepository> _conversationReadStateRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly ReadOrchestrator _orchestrator;
     private readonly AcknowledgeReadHandler _handler;
 
     public AcknowledgeConversationReadHandlerTests()
@@ -33,11 +36,13 @@ public sealed class AcknowledgeConversationReadHandlerTests
 
         _transactionMock = _unitOfWorkMock.SetupTransactionMock();
 
+        _orchestrator = new ReadOrchestrator(_messageRepositoryMock.Object, _unitOfWorkMock.Object);
+
         _handler = new AcknowledgeReadHandler(
             _conversationRepositoryMock.Object,
             _messageRepositoryMock.Object,
             _conversationReadStateRepositoryMock.Object,
-            _unitOfWorkMock.Object);
+            _orchestrator);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/GetChannelPinnedMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetChannelPinnedMessagesHandlerTests.cs
@@ -1,6 +1,8 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Channels.GetPinnedMessages;
+using Harmonie.Application.Features.Channels.Pins;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Tests.Common;
@@ -19,16 +21,19 @@ public sealed class GetChannelPinnedMessagesHandlerTests
 {
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IPinnedMessageRepository> _pinnedMessageRepositoryMock;
+    private readonly PinnedMessageFetchOrchestrator _orchestrator;
     private readonly GetPinnedMessagesHandler _handler;
 
     public GetChannelPinnedMessagesHandlerTests()
     {
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
         _pinnedMessageRepositoryMock = new Mock<IPinnedMessageRepository>();
+        _orchestrator = new PinnedMessageFetchOrchestrator();
 
         _handler = new GetPinnedMessagesHandler(
             _guildChannelRepositoryMock.Object,
-            _pinnedMessageRepositoryMock.Object);
+            _pinnedMessageRepositoryMock.Object,
+            _orchestrator);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/GetConversationMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetConversationMessagesHandlerTests.cs
@@ -19,16 +19,19 @@ public sealed class GetConversationMessagesHandlerTests
 {
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IMessagePaginationRepository> _directMessageRepositoryMock;
+    private readonly MessageFetchOrchestrator _orchestrator;
     private readonly GetMessagesHandler _handler;
 
     public GetConversationMessagesHandlerTests()
     {
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _directMessageRepositoryMock = new Mock<IMessagePaginationRepository>();
+        _orchestrator = new MessageFetchOrchestrator();
 
         _handler = new GetMessagesHandler(
             _conversationRepositoryMock.Object,
-            _directMessageRepositoryMock.Object);
+            _directMessageRepositoryMock.Object,
+            _orchestrator);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/GetConversationPinnedMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetConversationPinnedMessagesHandlerTests.cs
@@ -1,6 +1,8 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Conversations.GetPinnedMessages;
+using Harmonie.Application.Features.Conversations.Pins;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Tests.Common;
@@ -18,16 +20,19 @@ public sealed class GetConversationPinnedMessagesHandlerTests
 {
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IPinnedMessageRepository> _pinnedMessageRepositoryMock;
+    private readonly PinnedMessageFetchOrchestrator _orchestrator;
     private readonly GetPinnedMessagesHandler _handler;
 
     public GetConversationPinnedMessagesHandlerTests()
     {
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _pinnedMessageRepositoryMock = new Mock<IPinnedMessageRepository>();
+        _orchestrator = new PinnedMessageFetchOrchestrator();
 
         _handler = new GetPinnedMessagesHandler(
             _conversationRepositoryMock.Object,
-            _pinnedMessageRepositoryMock.Object);
+            _pinnedMessageRepositoryMock.Object,
+            _orchestrator);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/GetMessagesHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/GetMessagesHandlerTests.cs
@@ -21,16 +21,19 @@ public sealed class GetMessagesHandlerTests
 {
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
     private readonly Mock<IMessagePaginationRepository> _channelMessageRepositoryMock;
+    private readonly MessageFetchOrchestrator _orchestrator;
     private readonly GetMessagesHandler _handler;
 
     public GetMessagesHandlerTests()
     {
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
         _channelMessageRepositoryMock = new Mock<IMessagePaginationRepository>();
+        _orchestrator = new MessageFetchOrchestrator();
 
         _handler = new GetMessagesHandler(
             _guildChannelRepositoryMock.Object,
-            _channelMessageRepositoryMock.Object);
+            _channelMessageRepositoryMock.Object,
+            _orchestrator);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/MessageFetchOrchestratorTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/MessageFetchOrchestratorTests.cs
@@ -1,0 +1,127 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Messages;
+
+public sealed class MessageFetchOrchestratorTests
+{
+    public sealed record OrchestratorTestContext : ScopeContext;
+
+    private readonly MessageFetchOrchestrator _orchestrator;
+
+    public MessageFetchOrchestratorTests()
+    {
+        _orchestrator = new MessageFetchOrchestrator();
+    }
+
+    private static MessageScope ChannelScope() => new MessageScope.Channel(GuildChannelId.New());
+    private static UserId AnyUser() => UserId.New();
+
+    private static Mock<IMessagePageScope<OrchestratorTestContext>> CreateAuthorizedScope(MessagePage? page = null)
+    {
+        var mock = new Mock<IMessagePageScope<OrchestratorTestContext>>();
+        mock.Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<OrchestratorTestContext>.Authorized(
+                new OrchestratorTestContext()));
+        mock.Setup(x => x.GetPageAsync(It.IsAny<MessageCursor?>(), It.IsAny<int>(), It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(page ?? CreateEmptyPage());
+        return mock;
+    }
+
+    private static MessagePage CreateEmptyPage() => new(
+        Items: Array.Empty<Message>(),
+        NextCursor: null,
+        ReactionsByMessageId: new Dictionary<Guid, IReadOnlyList<MessageReactionSummary>>(),
+        AttachmentsByMessageId: new Dictionary<Guid, IReadOnlyList<MessageAttachment>>());
+
+    // ── Cursor validation ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task FetchAsync_WhenCursorInvalid_ShouldReturnValidationFailed()
+    {
+        var scope = CreateAuthorizedScope();
+
+        var result = await _orchestrator.FetchAsync(
+            scope.Object, "not-a-valid-cursor", null, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
+    }
+
+    // ── Authorization ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FetchAsync_WhenAuthorizationDenied_ShouldReturnAuthError()
+    {
+        var scopeMock = new Mock<IMessagePageScope<OrchestratorTestContext>>();
+        scopeMock.Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<OrchestratorTestContext>.Denied(
+                new ApplicationError("AUTH_DENIED", "Not allowed")));
+
+        var result = await _orchestrator.FetchAsync(
+            scopeMock.Object, null, null, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be("AUTH_DENIED");
+    }
+
+    // ── Successful fetch ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FetchAsync_WhenSuccessful_ShouldReturnMappedItems()
+    {
+        var scope = CreateAuthorizedScope();
+
+        var result = await _orchestrator.FetchAsync(
+            scope.Object, null, 10, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        result.Data!.Items.Should().BeEmpty();
+        result.Data.NextCursor.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FetchAsync_ShouldClampLimit()
+    {
+        var scopeMock = CreateAuthorizedScope();
+
+        await _orchestrator.FetchAsync(
+            scopeMock.Object, null, null, AnyUser(), TestContext.Current.CancellationToken);
+
+        // Default limit is 50, so GetPageAsync should be called with limit=50
+        scopeMock.Verify(
+            x => x.GetPageAsync(null, 50, It.IsAny<UserId>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task FetchAsync_ShouldEncodeNextCursor()
+    {
+        var channelId = GuildChannelId.New();
+        var message = ApplicationTestBuilders.CreateChannelMessage(channelId, UserId.New(), "hello");
+        var cursor = new MessageCursor(DateTime.UtcNow, message.Id);
+        var page = new MessagePage(
+            Items: [message],
+            NextCursor: cursor,
+            ReactionsByMessageId: new Dictionary<Guid, IReadOnlyList<MessageReactionSummary>>(),
+            AttachmentsByMessageId: new Dictionary<Guid, IReadOnlyList<MessageAttachment>>());
+
+        var scopeMock = CreateAuthorizedScope(page);
+
+        var result = await _orchestrator.FetchAsync(
+            scopeMock.Object, null, null, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        result.Data!.Items.Should().HaveCount(1);
+        result.Data.NextCursor.Should().NotBeNull();
+    }
+}

--- a/tests/Harmonie.Application.Tests/Messages/PinChannelMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/PinChannelMessageHandlerTests.cs
@@ -1,6 +1,8 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Channels.PinMessage;
+using Harmonie.Application.Features.Channels.Pins;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
@@ -29,6 +31,7 @@ public sealed class PinChannelMessageHandlerTests
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IPinNotifier> _pinNotifierMock;
+    private readonly PinOrchestrator _orchestrator;
     private readonly PinMessageHandler _handler;
 
     public PinChannelMessageHandlerTests()
@@ -46,13 +49,16 @@ public sealed class PinChannelMessageHandlerTests
             .Setup(x => x.NotifyMessagePinnedInChannelAsync(It.IsAny<ChannelPinAddedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        _handler = new PinMessageHandler(
-            _guildChannelRepositoryMock.Object,
+        _orchestrator = new PinOrchestrator(
             _messageRepositoryMock.Object,
             _pinnedMessageRepositoryMock.Object,
-            _unitOfWorkMock.Object,
+            _unitOfWorkMock.Object);
+
+        _handler = new PinMessageHandler(
+            _guildChannelRepositoryMock.Object,
             _pinNotifierMock.Object,
-            NullLogger<PinMessageHandler>.Instance);
+            NullLogger<ChannelPinScope>.Instance,
+            _orchestrator);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/PinConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/PinConversationMessageHandlerTests.cs
@@ -1,6 +1,8 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Conversations.PinMessage;
+using Harmonie.Application.Features.Conversations.Pins;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
@@ -27,6 +29,7 @@ public sealed class PinConversationMessageHandlerTests
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IPinNotifier> _pinNotifierMock;
+    private readonly PinOrchestrator _orchestrator;
     private readonly PinMessageHandler _handler;
 
     public PinConversationMessageHandlerTests()
@@ -44,13 +47,16 @@ public sealed class PinConversationMessageHandlerTests
             .Setup(x => x.NotifyMessagePinnedInConversationAsync(It.IsAny<ConversationPinAddedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        _handler = new PinMessageHandler(
-            _conversationRepositoryMock.Object,
+        _orchestrator = new PinOrchestrator(
             _messageRepositoryMock.Object,
             _pinnedMessageRepositoryMock.Object,
-            _unitOfWorkMock.Object,
+            _unitOfWorkMock.Object);
+
+        _handler = new PinMessageHandler(
+            _conversationRepositoryMock.Object,
             _pinNotifierMock.Object,
-            NullLogger<PinMessageHandler>.Instance);
+            NullLogger<ConversationPinScope>.Instance,
+            _orchestrator);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/PinOrchestratorTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/PinOrchestratorTests.cs
@@ -1,0 +1,208 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.Pins;
+using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Guilds;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Messages;
+
+public sealed class PinOrchestratorTests
+{
+    public sealed record OrchestratorTestContext : ScopeContext;
+
+    private readonly Mock<IMessageRepository> _messageRepositoryMock;
+    private readonly Mock<IPinnedMessageRepository> _pinnedMessageRepositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly PinOrchestrator _orchestrator;
+
+    private static readonly OrchestratorTestContext Ctx = new();
+
+    public PinOrchestratorTests()
+    {
+        _messageRepositoryMock = new Mock<IMessageRepository>();
+        _pinnedMessageRepositoryMock = new Mock<IPinnedMessageRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _transactionMock = _unitOfWorkMock.SetupTransactionMock();
+
+        _orchestrator = new PinOrchestrator(
+            _messageRepositoryMock.Object,
+            _pinnedMessageRepositoryMock.Object,
+            _unitOfWorkMock.Object);
+    }
+
+    private static MessageScope ChannelScope() => new MessageScope.Channel(GuildChannelId.New());
+    private static MessageId AnyMessageId() => MessageId.New();
+    private static UserId AnyUser() => UserId.New();
+
+    private static Mock<IPinScope<OrchestratorTestContext>> CreateAuthorizedScope()
+    {
+        var mock = new Mock<IPinScope<OrchestratorTestContext>>();
+        mock.Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<OrchestratorTestContext>.Authorized(Ctx));
+        mock.Setup(x => x.NotifyPinAddedAsync(
+            Ctx, It.IsAny<MessageId>(), It.IsAny<UserId>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        mock.Setup(x => x.NotifyPinRemovedAsync(
+            Ctx, It.IsAny<MessageId>(), It.IsAny<UserId>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        return mock;
+    }
+
+    private void SetupMessageExists(MessageId messageId, MessageScope scope)
+    {
+        var message = scope is MessageScope.Channel c
+            ? ApplicationTestBuilders.CreateChannelMessage(c.ChannelId, AnyUser())
+            : ApplicationTestBuilders.CreateConversationMessage(
+                ((MessageScope.Conversation)scope).ConversationId, AnyUser());
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+    }
+
+    // ── PinAsync ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PinAsync_WhenAuthorizationDenied_ShouldReturnAuthError()
+    {
+        var scopeMock = new Mock<IPinScope<OrchestratorTestContext>>();
+        scopeMock.Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<OrchestratorTestContext>.Denied(
+                new ApplicationError("AUTH_DENIED", "Not allowed")));
+
+        var result = await _orchestrator.PinAsync(
+            scopeMock.Object, ChannelScope(), AnyMessageId(), AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be("AUTH_DENIED");
+    }
+
+    [Fact]
+    public async Task PinAsync_WhenMessageNotFound_ShouldReturnPinMessageNotFound()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Message?)null);
+
+        var result = await _orchestrator.PinAsync(
+            scope.Object, ChannelScope(), messageId, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Pin.MessageNotFound);
+    }
+
+    [Fact]
+    public async Task PinAsync_WhenSuccessful_ShouldPersistCommitAndNotify()
+    {
+        var scopeMock = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var messageScope = ChannelScope();
+        SetupMessageExists(messageId, messageScope);
+
+        var callOrder = new List<string>();
+        _pinnedMessageRepositoryMock
+            .Setup(x => x.AddAsync(It.IsAny<PinnedMessage>(), It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("add"))
+            .Returns(Task.CompletedTask);
+        _transactionMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("commit"))
+            .Returns(Task.CompletedTask);
+        scopeMock
+            .Setup(x => x.NotifyPinAddedAsync(
+                Ctx, messageId, It.IsAny<UserId>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("notify"))
+            .Returns(Task.CompletedTask);
+
+        var result = await _orchestrator.PinAsync(
+            scopeMock.Object, messageScope, messageId, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        _pinnedMessageRepositoryMock.Verify(x => x.AddAsync(It.IsAny<PinnedMessage>(), It.IsAny<CancellationToken>()), Times.Once);
+        _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+        scopeMock.Verify(
+            x => x.NotifyPinAddedAsync(Ctx, messageId, It.IsAny<UserId>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        callOrder.Should().Equal("add", "commit", "notify");
+    }
+
+    // ── UnpinAsync ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UnpinAsync_WhenAuthorizationDenied_ShouldReturnAuthError()
+    {
+        var scopeMock = new Mock<IPinScope<OrchestratorTestContext>>();
+        scopeMock.Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<OrchestratorTestContext>.Denied(
+                new ApplicationError("AUTH_DENIED", "Not allowed")));
+
+        var result = await _orchestrator.UnpinAsync(
+            scopeMock.Object, ChannelScope(), AnyMessageId(), AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be("AUTH_DENIED");
+    }
+
+    [Fact]
+    public async Task UnpinAsync_WhenMessageNotFound_ShouldReturnPinMessageNotFound()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Message?)null);
+
+        var result = await _orchestrator.UnpinAsync(
+            scope.Object, ChannelScope(), messageId, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Pin.MessageNotFound);
+    }
+
+    [Fact]
+    public async Task UnpinAsync_WhenSuccessful_ShouldRemoveCommitAndNotify()
+    {
+        var scopeMock = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var messageScope = ChannelScope();
+        SetupMessageExists(messageId, messageScope);
+
+        var callOrder = new List<string>();
+        _pinnedMessageRepositoryMock
+            .Setup(x => x.RemoveAsync(messageId, It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("remove"))
+            .Returns(Task.CompletedTask);
+        _transactionMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("commit"))
+            .Returns(Task.CompletedTask);
+        scopeMock
+            .Setup(x => x.NotifyPinRemovedAsync(
+                Ctx, messageId, It.IsAny<UserId>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("notify"))
+            .Returns(Task.CompletedTask);
+
+        var result = await _orchestrator.UnpinAsync(
+            scopeMock.Object, messageScope, messageId, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        _pinnedMessageRepositoryMock.Verify(x => x.RemoveAsync(messageId, It.IsAny<CancellationToken>()), Times.Once);
+        _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+        scopeMock.Verify(
+            x => x.NotifyPinRemovedAsync(Ctx, messageId, It.IsAny<UserId>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        callOrder.Should().Equal("remove", "commit", "notify");
+    }
+}

--- a/tests/Harmonie.Application.Tests/Messages/PinnedMessageFetchOrchestratorTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/PinnedMessageFetchOrchestratorTests.cs
@@ -1,0 +1,119 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Messages;
+
+public sealed class PinnedMessageFetchOrchestratorTests
+{
+    public sealed record OrchestratorTestContext : ScopeContext;
+
+    private readonly PinnedMessageFetchOrchestrator _orchestrator;
+
+    public PinnedMessageFetchOrchestratorTests()
+    {
+        _orchestrator = new PinnedMessageFetchOrchestrator();
+    }
+
+    private static UserId AnyUser() => UserId.New();
+
+    private static Mock<IPinnedMessageFetchScope<OrchestratorTestContext>> CreateAuthorizedScope(
+        PinnedMessagesPage? page = null)
+    {
+        var mock = new Mock<IPinnedMessageFetchScope<OrchestratorTestContext>>();
+        mock.Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<OrchestratorTestContext>.Authorized(
+                new OrchestratorTestContext()));
+        mock.Setup(x => x.GetPinnedPageAsync(
+                It.IsAny<UserId>(), It.IsAny<PinnedMessagesCursor?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(page ?? new PinnedMessagesPage(
+                Items: Array.Empty<PinnedMessageSummary>(),
+                NextCursor: null,
+                AttachmentsByMessageId: new Dictionary<MessageId, IReadOnlyList<MessageAttachment>>()));
+        return mock;
+    }
+
+    // ── Cursor validation ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task FetchAsync_WhenCursorInvalid_ShouldReturnValidationFailed()
+    {
+        var scope = CreateAuthorizedScope();
+
+        var result = await _orchestrator.FetchAsync(
+            scope.Object, "not-a-valid-cursor", null, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
+    }
+
+    // ── Authorization ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FetchAsync_WhenAuthorizationDenied_ShouldReturnAuthError()
+    {
+        var scopeMock = new Mock<IPinnedMessageFetchScope<OrchestratorTestContext>>();
+        scopeMock.Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<OrchestratorTestContext>.Denied(
+                new ApplicationError("AUTH_DENIED", "Not allowed")));
+
+        var result = await _orchestrator.FetchAsync(
+            scopeMock.Object, null, null, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be("AUTH_DENIED");
+    }
+
+    // ── Successful fetch ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FetchAsync_WhenSuccessful_ShouldReturnMappedItems()
+    {
+        var scope = CreateAuthorizedScope();
+
+        var result = await _orchestrator.FetchAsync(
+            scope.Object, null, 10, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        result.Data!.Items.Should().BeEmpty();
+        result.Data.NextCursor.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FetchAsync_ShouldClampLimit()
+    {
+        var scopeMock = CreateAuthorizedScope();
+
+        await _orchestrator.FetchAsync(
+            scopeMock.Object, null, null, AnyUser(), TestContext.Current.CancellationToken);
+
+        scopeMock.Verify(
+            x => x.GetPinnedPageAsync(It.IsAny<UserId>(), null, 50, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task FetchAsync_ShouldEncodeNextCursor()
+    {
+        var cursor = new PinnedMessagesCursor(DateTime.UtcNow, Guid.NewGuid());
+        var page = new PinnedMessagesPage(
+            Items: Array.Empty<PinnedMessageSummary>(),
+            NextCursor: cursor,
+            AttachmentsByMessageId: new Dictionary<MessageId, IReadOnlyList<MessageAttachment>>());
+
+        var scopeMock = CreateAuthorizedScope(page);
+
+        var result = await _orchestrator.FetchAsync(
+            scopeMock.Object, null, null, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        result.Data!.NextCursor.Should().NotBeNull();
+    }
+}

--- a/tests/Harmonie.Application.Tests/Messages/ReadOrchestratorTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/ReadOrchestratorTests.cs
@@ -1,0 +1,158 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.Entities.Messages;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Messages;
+
+public sealed class ReadOrchestratorTests
+{
+    public sealed record OrchestratorTestContext : ScopeContext;
+
+    private readonly Mock<IMessageRepository> _messageRepositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly ReadOrchestrator _orchestrator;
+
+    private static readonly OrchestratorTestContext Ctx = new();
+
+    public ReadOrchestratorTests()
+    {
+        _messageRepositoryMock = new Mock<IMessageRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _transactionMock = _unitOfWorkMock.SetupTransactionMock();
+
+        _orchestrator = new ReadOrchestrator(
+            _messageRepositoryMock.Object,
+            _unitOfWorkMock.Object);
+    }
+
+    private static MessageScope ChannelScope() => new MessageScope.Channel(GuildChannelId.New());
+    private static MessageId AnyMessageId() => MessageId.New();
+    private static UserId AnyUser() => UserId.New();
+
+    private static Mock<IReadScope<OrchestratorTestContext>> CreateAuthorizedScope(
+        MessageId? latestMessageId = null)
+    {
+        var mock = new Mock<IReadScope<OrchestratorTestContext>>();
+        mock.Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<OrchestratorTestContext>.Authorized(Ctx));
+        mock.Setup(x => x.GetLatestMessageIdAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latestMessageId);
+        mock.Setup(x => x.UpsertReadStateAsync(It.IsAny<MessageReadState>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        return mock;
+    }
+
+    // ── Authorization ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AcknowledgeAsync_WhenAuthorizationDenied_ShouldReturnAuthError()
+    {
+        var scopeMock = new Mock<IReadScope<OrchestratorTestContext>>();
+        scopeMock.Setup(x => x.AuthorizeAsync(It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthorizationResult<OrchestratorTestContext>.Denied(
+                new ApplicationError("AUTH_DENIED", "Not allowed")));
+
+        var result = await _orchestrator.AcknowledgeAsync(
+            scopeMock.Object, ChannelScope(), AnyMessageId(), AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be("AUTH_DENIED");
+    }
+
+    // ── Specific message provided ───────────────────────────────────────
+
+    [Fact]
+    public async Task AcknowledgeAsync_WhenSpecificMessageNotFound_ShouldReturnMessageNotFound()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Message?)null);
+
+        var result = await _orchestrator.AcknowledgeAsync(
+            scope.Object, ChannelScope(), messageId, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
+    }
+
+    [Fact]
+    public async Task AcknowledgeAsync_WhenSpecificMessageWrongScope_ShouldReturnMessageNotFound()
+    {
+        var scope = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var wrongScope = new MessageScope.Channel(GuildChannelId.New());
+        var message = ApplicationTestBuilders.CreateChannelMessage(
+            ((MessageScope.Channel)wrongScope).ChannelId, AnyUser());
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        var result = await _orchestrator.AcknowledgeAsync(
+            scope.Object, ChannelScope(), messageId, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
+    }
+
+    [Fact]
+    public async Task AcknowledgeAsync_WhenSpecificMessageValid_ShouldUpsertAndCommit()
+    {
+        var scopeMock = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var messageScope = ChannelScope();
+        var message = ApplicationTestBuilders.CreateChannelMessage(
+            ((MessageScope.Channel)messageScope).ChannelId, AnyUser());
+        _messageRepositoryMock
+            .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(message);
+
+        var result = await _orchestrator.AcknowledgeAsync(
+            scopeMock.Object, messageScope, messageId, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        scopeMock.Verify(x => x.UpsertReadStateAsync(It.IsAny<MessageReadState>(), It.IsAny<CancellationToken>()), Times.Once);
+        _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── No specific message → fallback to latest ────────────────────────
+
+    [Fact]
+    public async Task AcknowledgeAsync_WhenNoLatestMessage_ShouldReturnOkEarly()
+    {
+        var scope = CreateAuthorizedScope(latestMessageId: null);
+
+        var result = await _orchestrator.AcknowledgeAsync(
+            scope.Object, ChannelScope(), null, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        scope.Verify(x => x.UpsertReadStateAsync(It.IsAny<MessageReadState>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AcknowledgeAsync_WhenFallsBackToLatest_ShouldUpsertAndCommit()
+    {
+        var latestId = AnyMessageId();
+        var scopeMock = CreateAuthorizedScope(latestMessageId: latestId);
+
+        var result = await _orchestrator.AcknowledgeAsync(
+            scopeMock.Object, ChannelScope(), null, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        scopeMock.Verify(x => x.GetLatestMessageIdAsync(It.IsAny<CancellationToken>()), Times.Once);
+        scopeMock.Verify(x => x.UpsertReadStateAsync(It.IsAny<MessageReadState>(), It.IsAny<CancellationToken>()), Times.Once);
+        _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/Harmonie.Application.Tests/Messages/UnpinChannelMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/UnpinChannelMessageHandlerTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.Pins;
 using Harmonie.Application.Features.Channels.UnpinMessage;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
@@ -29,6 +31,7 @@ public sealed class UnpinChannelMessageHandlerTests
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IPinNotifier> _pinNotifierMock;
+    private readonly PinOrchestrator _orchestrator;
     private readonly UnpinMessageHandler _handler;
 
     public UnpinChannelMessageHandlerTests()
@@ -46,13 +49,16 @@ public sealed class UnpinChannelMessageHandlerTests
             .Setup(x => x.NotifyMessageUnpinnedInChannelAsync(It.IsAny<ChannelPinRemovedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        _handler = new UnpinMessageHandler(
-            _guildChannelRepositoryMock.Object,
+        _orchestrator = new PinOrchestrator(
             _messageRepositoryMock.Object,
             _pinnedMessageRepositoryMock.Object,
-            _unitOfWorkMock.Object,
+            _unitOfWorkMock.Object);
+
+        _handler = new UnpinMessageHandler(
+            _guildChannelRepositoryMock.Object,
             _pinNotifierMock.Object,
-            NullLogger<UnpinMessageHandler>.Instance);
+            NullLogger<ChannelPinScope>.Instance,
+            _orchestrator);
     }
 
     [Fact]

--- a/tests/Harmonie.Application.Tests/Messages/UnpinConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/UnpinConversationMessageHandlerTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Conversations.Pins;
 using Harmonie.Application.Features.Conversations.UnpinMessage;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
@@ -27,6 +29,7 @@ public sealed class UnpinConversationMessageHandlerTests
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IPinNotifier> _pinNotifierMock;
+    private readonly PinOrchestrator _orchestrator;
     private readonly UnpinMessageHandler _handler;
 
     public UnpinConversationMessageHandlerTests()
@@ -44,13 +47,16 @@ public sealed class UnpinConversationMessageHandlerTests
             .Setup(x => x.NotifyMessageUnpinnedInConversationAsync(It.IsAny<ConversationPinRemovedNotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        _handler = new UnpinMessageHandler(
-            _conversationRepositoryMock.Object,
+        _orchestrator = new PinOrchestrator(
             _messageRepositoryMock.Object,
             _pinnedMessageRepositoryMock.Object,
-            _unitOfWorkMock.Object,
+            _unitOfWorkMock.Object);
+
+        _handler = new UnpinMessageHandler(
+            _conversationRepositoryMock.Object,
             _pinNotifierMock.Object,
-            NullLogger<UnpinMessageHandler>.Instance);
+            NullLogger<ConversationPinScope>.Instance,
+            _orchestrator);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Consolidates 10 handlers (5 features × 2 contexts) across 4 orchestrators:

### Pin / Unpin
- `IPinScope<TContext>` — authorization + notifications
- `PinOrchestrator` — PinAsync / UnpinAsync
- 4 handlers → thin wrappers

### AcknowledgeRead
- `IReadScope<TContext>` — authorization + latest message fetch + read state upsert
- `ReadOrchestrator` — message resolution + read state creation + persist
- 2 handlers → thin wrappers

### GetMessages
- `IMessagePageScope<TContext>` — authorization + page fetch
- `MessageFetchOrchestrator` — cursor parsing + 17-line item mapping + response assembly
- 2 handlers → thin wrappers

### GetPinnedMessages
- `IPinnedMessageFetchScope<TContext>` — authorization + pinned page fetch
- `PinnedMessageFetchOrchestrator` — cursor parsing + item mapping + response assembly
- 2 handlers → thin wrappers

### Bonus
- Moved duplicated `GetMessagesItemResponse` and `GetPinnedMessagesItemResponse` to `Common.Messages` (eliminated channel/conversation copy-paste)

Closes #382