### PR TITLE
feat: add @mentions support in messages (#392)

### DIFF
--- a/src/Harmonie.API/RealTime/Channels/SignalRTextChannelNotifier.cs
+++ b/src/Harmonie.API/RealTime/Channels/SignalRTextChannelNotifier.cs
@@ -32,6 +32,7 @@ public sealed class SignalRTextChannelNotifier : ITextChannelNotifier
             Content: notification.Content,
             Attachments: notification.Attachments,
             ReplyTo: notification.ReplyTo,
+            MentionedUserIds: notification.MentionedUserIds,
             CreatedAtUtc: notification.CreatedAtUtc);
 
         await _hubContext.Clients
@@ -74,6 +75,7 @@ public sealed class SignalRTextChannelNotifier : ITextChannelNotifier
             GuildId: notification.GuildId.Value,
             GuildName: notification.GuildName,
             Content: notification.Content,
+            MentionedUserIds: notification.MentionedUserIds,
             UpdatedAtUtc: notification.UpdatedAtUtc);
 
         await _hubContext.Clients
@@ -112,6 +114,7 @@ public sealed record MessageCreatedEvent(
     string? Content,
     IReadOnlyList<MessageAttachmentDto> Attachments,
     ReplyPreviewDto? ReplyTo,
+    IReadOnlyList<Guid> MentionedUserIds,
     DateTime CreatedAtUtc);
 
 public sealed record MessageUpdatedEvent(
@@ -121,6 +124,7 @@ public sealed record MessageUpdatedEvent(
     Guid GuildId,
     string GuildName,
     string? Content,
+    IReadOnlyList<Guid> MentionedUserIds,
     DateTime UpdatedAtUtc);
 
 public sealed record MessageDeletedEvent(

--- a/src/Harmonie.API/RealTime/Conversations/SignalRConversationMessageNotifier.cs
+++ b/src/Harmonie.API/RealTime/Conversations/SignalRConversationMessageNotifier.cs
@@ -32,6 +32,7 @@ public sealed class SignalRConversationMessageNotifier : IConversationMessageNot
             Content: notification.Content,
             Attachments: notification.Attachments,
             ReplyTo: notification.ReplyTo,
+            MentionedUserIds: notification.MentionedUserIds,
             CreatedAtUtc: notification.CreatedAtUtc);
 
         await _hubContext.Clients
@@ -73,6 +74,7 @@ public sealed class SignalRConversationMessageNotifier : IConversationMessageNot
             ConversationName: notification.ConversationName,
             ConversationType: notification.ConversationType,
             Content: notification.Content,
+            MentionedUserIds: notification.MentionedUserIds,
             UpdatedAtUtc: notification.UpdatedAtUtc);
 
         await _hubContext.Clients
@@ -109,6 +111,7 @@ public sealed record ConversationMessageCreatedEvent(
     string? Content,
     IReadOnlyList<MessageAttachmentDto> Attachments,
     ReplyPreviewDto? ReplyTo,
+    IReadOnlyList<Guid> MentionedUserIds,
     DateTime CreatedAtUtc);
 
 public sealed record ConversationMessageUpdatedEvent(
@@ -117,6 +120,7 @@ public sealed record ConversationMessageUpdatedEvent(
     string? ConversationName,
     string ConversationType,
     string? Content,
+    IReadOnlyList<Guid> MentionedUserIds,
     DateTime UpdatedAtUtc);
 
 public sealed record ConversationMessageDeletedEvent(

--- a/src/Harmonie.Application/Common/ApplicationErrorCodes.cs
+++ b/src/Harmonie.Application/Common/ApplicationErrorCodes.cs
@@ -73,6 +73,8 @@ public static class ApplicationErrorCodes
         public const string AttachmentNotFound = "MESSAGE_ATTACHMENT_NOT_FOUND";
         public const string EditForbidden = "MESSAGE_EDIT_FORBIDDEN";
         public const string DeleteForbidden = "MESSAGE_DELETE_FORBIDDEN";
+        public const string MentionedUserNotFound = "MESSAGE_MENTIONED_USER_NOT_FOUND";
+        public const string MentionedUserNotMember = "MESSAGE_MENTIONED_USER_NOT_MEMBER";
     }
 
     public static class Reaction

--- a/src/Harmonie.Application/Common/EndpointExtensions.cs
+++ b/src/Harmonie.Application/Common/EndpointExtensions.cs
@@ -344,6 +344,8 @@ public static class EndpointExtensions
             ApplicationErrorCodes.Invite.Expired => HttpStatusCode.Gone,
             ApplicationErrorCodes.Invite.Exhausted => HttpStatusCode.Gone,
             ApplicationErrorCodes.Invite.RevokeForbidden => HttpStatusCode.Forbidden,
+            ApplicationErrorCodes.Message.MentionedUserNotFound => HttpStatusCode.NotFound,
+            ApplicationErrorCodes.Message.MentionedUserNotMember => HttpStatusCode.Forbidden,
             _ => HttpStatusCode.InternalServerError
         };
 }

--- a/src/Harmonie.Application/Common/Messages/GetMessagesItemResponse.cs
+++ b/src/Harmonie.Application/Common/Messages/GetMessagesItemResponse.cs
@@ -15,5 +15,6 @@ public sealed record GetMessagesItemResponse(
     IReadOnlyList<LinkPreviewDto>? LinkPreviews,
     bool IsPinned,
     ReplyPreviewDto? ReplyTo,
+    IReadOnlyList<Guid> MentionedUserIds,
     DateTime CreatedAtUtc,
     DateTime? UpdatedAtUtc);

--- a/src/Harmonie.Application/Common/Messages/IMessageEditDeleteScope.cs
+++ b/src/Harmonie.Application/Common/Messages/IMessageEditDeleteScope.cs
@@ -40,6 +40,7 @@ public interface IMessageEditDeleteScope<TContext> where TContext : ScopeContext
         TContext context,
         MessageId messageId,
         string? content,
+        IReadOnlyList<Guid> mentionedUserIds,
         DateTime updatedAtUtc,
         CancellationToken ct);
 

--- a/src/Harmonie.Application/Common/Messages/IMessageEditDeleteScope.cs
+++ b/src/Harmonie.Application/Common/Messages/IMessageEditDeleteScope.cs
@@ -1,4 +1,5 @@
 using Harmonie.Application.Common;
+using Harmonie.Domain.Common;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -21,6 +22,15 @@ public interface IMessageEditDeleteScope<TContext> where TContext : ScopeContext
     /// Returns true for channel admins, false for conversation contexts.
     /// </summary>
     bool CanDeleteOthersMessages(TContext context);
+
+    /// <summary>
+    /// Validates that all mentioned user IDs are members/participants of the scope.
+    /// Returns a failure on the first invalid mention, or success.
+    /// </summary>
+    Task<Result> ValidateMentionedUsersAsync(
+        IReadOnlyCollection<UserId> userIds,
+        TContext context,
+        CancellationToken ct);
 
     /// <summary>
     /// Notifies scope participants that a message was updated.
@@ -52,6 +62,7 @@ public sealed record MessageEditResult(
     Guid AuthorUserId,
     string? Content,
     IReadOnlyList<MessageAttachmentDto> Attachments,
+    IReadOnlyList<Guid> MentionedUserIds,
     DateTime CreatedAtUtc,
     DateTime? UpdatedAtUtc);
 

--- a/src/Harmonie.Application/Common/Messages/ISendMessageScope.cs
+++ b/src/Harmonie.Application/Common/Messages/ISendMessageScope.cs
@@ -1,4 +1,5 @@
 using Harmonie.Application.Common;
+using Harmonie.Domain.Common;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Users;
 
@@ -45,6 +46,15 @@ public interface ISendMessageScope<TContext> where TContext : ScopeContext
         CancellationToken ct);
 
     /// <summary>
+    /// Validates that all mentioned user IDs exist and are members/participants of the scope.
+    /// Returns a failure on the first invalid mention, or success.
+    /// </summary>
+    Task<Result> ValidateMentionedUsersAsync(
+        IReadOnlyCollection<UserId> userIds,
+        TContext context,
+        CancellationToken ct);
+
+    /// <summary>
     /// Triggers fire-and-forget link preview resolution for the given message.
     /// </summary>
     void ScheduleLinkPreviewResolution(
@@ -76,4 +86,5 @@ public sealed record MessageSendResult(
     string? Content,
     IReadOnlyList<MessageAttachmentDto> Attachments,
     ReplyPreviewDto? ReplyTo,
+    IReadOnlyList<Guid> MentionedUserIds,
     DateTime CreatedAtUtc);

--- a/src/Harmonie.Application/Common/Messages/MentionValidationHelper.cs
+++ b/src/Harmonie.Application/Common/Messages/MentionValidationHelper.cs
@@ -14,9 +14,9 @@ public static class MentionValidationHelper
     /// <summary>
     /// Validates mentioned user IDs: resolves GUIDs to UserIds, checks existence,
     /// verifies membership via the scope, and returns the validated distinct UserId array.
-    /// Returns a failure ApplicationResponse with the appropriate error code on rejection.
+    /// On failure, the error code and message are set.
     /// </summary>
-    public static async Task<ApplicationResponse<UserId[]>> ValidateAsync<TContext>(
+    public static async Task<MentionValidationResult> ValidateAsync<TContext>(
         IReadOnlyList<Guid> rawMentionedUserIds,
         IUserRepository userRepository,
         Func<IReadOnlyCollection<UserId>, TContext, CancellationToken, Task<Result>> validateMembershipAsync,
@@ -37,7 +37,7 @@ public static class MentionValidationHelper
 
         if (missingIds.Count > 0)
         {
-            return ApplicationResponse<UserId[]>.Fail(
+            return MentionValidationResult.Failure(
                 ApplicationErrorCodes.Message.MentionedUserNotFound,
                 $"One or more mentioned users were not found: {string.Join(", ", missingIds)}");
         }
@@ -45,11 +45,37 @@ public static class MentionValidationHelper
         var validateResult = await validateMembershipAsync(userIds, context, ct);
         if (validateResult.IsFailure)
         {
-            return ApplicationResponse<UserId[]>.Fail(
+            return MentionValidationResult.Failure(
                 ApplicationErrorCodes.Message.MentionedUserNotMember,
                 validateResult.Error ?? "One or more mentioned users are not members of this scope");
         }
 
-        return ApplicationResponse<UserId[]>.Ok(userIds);
+        return MentionValidationResult.Success(userIds);
     }
+}
+
+/// <summary>
+/// Internal result for mention validation. Avoids coupling to the HTTP-flavored
+/// <see cref="ApplicationResponse{T}"/> for a pure domain-logic helper.
+/// </summary>
+public sealed record MentionValidationResult
+{
+    public bool IsSuccess { get; }
+    public UserId[]? Value { get; }
+    public string? ErrorCode { get; }
+    public string? ErrorMessage { get; }
+
+    private MentionValidationResult(bool isSuccess, UserId[]? value, string? errorCode, string? errorMessage)
+    {
+        IsSuccess = isSuccess;
+        Value = value;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public static MentionValidationResult Success(UserId[] value)
+        => new(true, value, null, null);
+
+    public static MentionValidationResult Failure(string errorCode, string errorMessage)
+        => new(false, null, errorCode, errorMessage);
 }

--- a/src/Harmonie.Application/Common/Messages/MentionValidationHelper.cs
+++ b/src/Harmonie.Application/Common/Messages/MentionValidationHelper.cs
@@ -1,0 +1,55 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Interfaces.Users;
+using Harmonie.Domain.Common;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Common.Messages;
+
+/// <summary>
+/// Shared mention validation logic used by both <see cref="MessageSendOrchestrator"/>
+/// and <see cref="MessageEditDeleteOrchestrator"/>.
+/// </summary>
+public static class MentionValidationHelper
+{
+    /// <summary>
+    /// Validates mentioned user IDs: resolves GUIDs to UserIds, checks existence,
+    /// verifies membership via the scope, and returns the validated distinct UserId array.
+    /// Returns a failure ApplicationResponse with the appropriate error code on rejection.
+    /// </summary>
+    public static async Task<ApplicationResponse<UserId[]>> ValidateAsync<TContext>(
+        IReadOnlyList<Guid> rawMentionedUserIds,
+        IUserRepository userRepository,
+        Func<IReadOnlyCollection<UserId>, TContext, CancellationToken, Task<Result>> validateMembershipAsync,
+        TContext context,
+        CancellationToken ct)
+    {
+        var distinctIds = rawMentionedUserIds.Distinct().ToArray();
+        var userIds = distinctIds.Select(UserId.From).ToArray();
+
+        var existingUsers = await userRepository.GetManyByIdsAsync(userIds, ct);
+        var existingUserIds = existingUsers.Select(u => u.Id).ToHashSet();
+        var missingIds = new List<Guid>();
+        foreach (var id in userIds)
+        {
+            if (!existingUserIds.Contains(id))
+                missingIds.Add(id.Value);
+        }
+
+        if (missingIds.Count > 0)
+        {
+            return ApplicationResponse<UserId[]>.Fail(
+                ApplicationErrorCodes.Message.MentionedUserNotFound,
+                $"One or more mentioned users were not found: {string.Join(", ", missingIds)}");
+        }
+
+        var validateResult = await validateMembershipAsync(userIds, context, ct);
+        if (validateResult.IsFailure)
+        {
+            return ApplicationResponse<UserId[]>.Fail(
+                ApplicationErrorCodes.Message.MentionedUserNotMember,
+                validateResult.Error ?? "One or more mentioned users are not members of this scope");
+        }
+
+        return ApplicationResponse<UserId[]>.Ok(userIds);
+    }
+}

--- a/src/Harmonie.Application/Common/Messages/MentionValidationHelper.cs
+++ b/src/Harmonie.Application/Common/Messages/MentionValidationHelper.cs
@@ -16,11 +16,10 @@ public static class MentionValidationHelper
     /// verifies membership via the scope, and returns the validated distinct UserId array.
     /// On failure, the error code and message are set.
     /// </summary>
-    public static async Task<MentionValidationResult> ValidateAsync<TContext>(
+    public static async Task<MentionValidationResult> ValidateAsync(
         IReadOnlyList<Guid> rawMentionedUserIds,
         IUserRepository userRepository,
-        Func<IReadOnlyCollection<UserId>, TContext, CancellationToken, Task<Result>> validateMembershipAsync,
-        TContext context,
+        Func<IReadOnlyCollection<UserId>, CancellationToken, Task<Result>> validateMembershipAsync,
         CancellationToken ct)
     {
         var distinctIds = rawMentionedUserIds.Distinct().ToArray();
@@ -42,7 +41,7 @@ public static class MentionValidationHelper
                 $"One or more mentioned users were not found: {string.Join(", ", missingIds)}");
         }
 
-        var validateResult = await validateMembershipAsync(userIds, context, ct);
+        var validateResult = await validateMembershipAsync(userIds, ct);
         if (validateResult.IsFailure)
         {
             return new MentionValidationResult.Failure(

--- a/src/Harmonie.Application/Common/Messages/MentionValidationHelper.cs
+++ b/src/Harmonie.Application/Common/Messages/MentionValidationHelper.cs
@@ -37,7 +37,7 @@ public static class MentionValidationHelper
 
         if (missingIds.Count > 0)
         {
-            return MentionValidationResult.Failure(
+            return new MentionValidationResult.Failure(
                 ApplicationErrorCodes.Message.MentionedUserNotFound,
                 $"One or more mentioned users were not found: {string.Join(", ", missingIds)}");
         }
@@ -45,37 +45,25 @@ public static class MentionValidationHelper
         var validateResult = await validateMembershipAsync(userIds, context, ct);
         if (validateResult.IsFailure)
         {
-            return MentionValidationResult.Failure(
+            return new MentionValidationResult.Failure(
                 ApplicationErrorCodes.Message.MentionedUserNotMember,
                 validateResult.Error ?? "One or more mentioned users are not members of this scope");
         }
 
-        return MentionValidationResult.Success(userIds);
+        return new MentionValidationResult.Success(userIds);
     }
 }
 
 /// <summary>
-/// Internal result for mention validation. Avoids coupling to the HTTP-flavored
-/// <see cref="ApplicationResponse{T}"/> for a pure domain-logic helper.
+/// Discriminated union for mention validation results.
+/// Follows the same pattern as <see cref="AuthorizationResult{TContext}"/>
+/// and <see cref="FetchMessageResult{TContext}"/>.
 /// </summary>
-public sealed record MentionValidationResult
+public abstract record MentionValidationResult
 {
-    public bool IsSuccess { get; }
-    public UserId[]? Value { get; }
-    public string? ErrorCode { get; }
-    public string? ErrorMessage { get; }
+    private MentionValidationResult() { }
 
-    private MentionValidationResult(bool isSuccess, UserId[]? value, string? errorCode, string? errorMessage)
-    {
-        IsSuccess = isSuccess;
-        Value = value;
-        ErrorCode = errorCode;
-        ErrorMessage = errorMessage;
-    }
+    public sealed record Success(UserId[] Value) : MentionValidationResult;
 
-    public static MentionValidationResult Success(UserId[] value)
-        => new(true, value, null, null);
-
-    public static MentionValidationResult Failure(string errorCode, string errorMessage)
-        => new(false, null, errorCode, errorMessage);
+    public sealed record Failure(string ErrorCode, string ErrorMessage) : MentionValidationResult;
 }

--- a/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
@@ -3,6 +3,7 @@ using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Uploads;
@@ -19,17 +20,20 @@ public sealed class MessageEditDeleteOrchestrator
 {
     private readonly IMessageRepository _messageRepository;
     private readonly IMessageAttachmentRepository _messageAttachmentRepository;
+    private readonly IUserRepository _userRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly UploadedFileCleanupService _uploadedFileCleanupService;
 
     public MessageEditDeleteOrchestrator(
         IMessageRepository messageRepository,
         IMessageAttachmentRepository messageAttachmentRepository,
+        IUserRepository userRepository,
         IUnitOfWork unitOfWork,
         UploadedFileCleanupService uploadedFileCleanupService)
     {
         _messageRepository = messageRepository;
         _messageAttachmentRepository = messageAttachmentRepository;
+        _userRepository = userRepository;
         _unitOfWork = unitOfWork;
         _uploadedFileCleanupService = uploadedFileCleanupService;
     }
@@ -39,6 +43,7 @@ public sealed class MessageEditDeleteOrchestrator
         MessageScope messageScope,
         MessageId messageId,
         string rawContent,
+        IReadOnlyList<Guid>? mentionedUserIds,
         UserId callerId,
         CancellationToken ct)
         where TContext : ScopeContext
@@ -91,9 +96,41 @@ public sealed class MessageEditDeleteOrchestrator
                 "Message edit succeeded but updated timestamp is missing");
         }
 
+        // ── Mention validation ──────────────────────────────────────────
+        IReadOnlyList<Guid>? validatedMentionIds = null;
+        if (mentionedUserIds is { Count: > 0 })
+        {
+            var distinctMentionIds = mentionedUserIds.Distinct().ToArray();
+            var userIds = distinctMentionIds.Select(UserId.From).ToArray();
+
+            // Verify all users exist
+            var existingUsers = await _userRepository.GetManyByIdsAsync(userIds.ToArray(), ct);
+            var existingUserIds = existingUsers.Select(u => u.Id).ToHashSet();
+            var missingIds = userIds.Where(id => !existingUserIds.Contains(id)).ToArray();
+            if (missingIds.Length > 0)
+            {
+                return ApplicationResponse<MessageEditResult>.Fail(
+                    ApplicationErrorCodes.Message.MentionedUserNotFound,
+                    $"One or more mentioned users were not found: {string.Join(", ", missingIds.Select(id => id.Value))}");
+            }
+
+            // Verify membership via scope
+            var validateResult = await scope.ValidateMentionedUsersAsync(userIds.ToArray(), context, ct);
+            if (validateResult.IsFailure)
+            {
+                return ApplicationResponse<MessageEditResult>.Fail(
+                    ApplicationErrorCodes.Message.MentionedUserNotMember,
+                    validateResult.Error ?? "One or more mentioned users are not members of this scope");
+            }
+
+            validatedMentionIds = distinctMentionIds;
+        }
+
         // ── Persist ─────────────────────────────────────────────────────
         await using var transaction = await _unitOfWork.BeginAsync(ct);
         await _messageRepository.UpdateAsync(message, ct);
+        if (validatedMentionIds is not null)
+            await _messageRepository.ReplaceMentionsAsync(message.Id, validatedMentionIds.Select(UserId.From).ToArray(), ct);
         await transaction.CommitAsync(ct);
 
         // ── Notify ──────────────────────────────────────────────────────
@@ -107,12 +144,26 @@ public sealed class MessageEditDeleteOrchestrator
         // ── Attachments for response ────────────────────────────────────
         var attachments = await _messageAttachmentRepository.GetByMessageIdAsync(messageId, ct);
 
+        // ── Retrieve mentions for response ──────────────────────────────
+        IReadOnlyList<Guid> mentionIdsResponse;
+        if (validatedMentionIds is not null)
+        {
+            mentionIdsResponse = validatedMentionIds;
+        }
+        else
+        {
+            var mentionsDict = await _messageRepository.GetMentionedUserIdsByMessageIdAsync(
+                [message.Id.Value], ct);
+            mentionIdsResponse = mentionsDict.TryGetValue(message.Id.Value, out var ids) ? ids : Array.Empty<Guid>();
+        }
+
         // ── Result ──────────────────────────────────────────────────────
         return ApplicationResponse<MessageEditResult>.Ok(new MessageEditResult(
             MessageId: message.Id.Value,
             AuthorUserId: message.AuthorUserId.Value,
             Content: message.Content?.Value,
             Attachments: attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
+            MentionedUserIds: mentionIdsResponse.ToArray(),
             CreatedAtUtc: message.CreatedAtUtc,
             UpdatedAtUtc: updatedAtUtc));
     }

--- a/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
@@ -38,6 +38,7 @@ public sealed class MessageEditDeleteOrchestrator
         _uploadedFileCleanupService = uploadedFileCleanupService;
     }
 
+    /// <inheritdoc cref="MessageSendOrchestrator.SendAsync{TContext}"/>
     public async Task<ApplicationResponse<MessageEditResult>> EditAsync<TContext>(
         IMessageEditDeleteScope<TContext> scope,
         MessageScope messageScope,

--- a/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
@@ -97,58 +97,56 @@ public sealed class MessageEditDeleteOrchestrator
         }
 
         // ── Mention validation ──────────────────────────────────────────
-        IReadOnlyList<Guid>? validatedMentionIds = null;
-        if (mentionedUserIds is { Count: > 0 })
+        // null = don't touch mentions (field absent, backward compat)
+        // []   = clear all mentions
+        // ids  = validate and replace
+        IReadOnlyList<Guid>? resolvedMentionIds = null;
+        bool shouldUpdateMentions = false;
+        if (mentionedUserIds is not null)
         {
-            var distinctMentionIds = mentionedUserIds.Distinct().ToArray();
-            var userIds = distinctMentionIds.Select(UserId.From).ToArray();
-
-            // Verify all users exist
-            var existingUsers = await _userRepository.GetManyByIdsAsync(userIds.ToArray(), ct);
-            var existingUserIds = existingUsers.Select(u => u.Id).ToHashSet();
-            var missingIds = userIds.Where(id => !existingUserIds.Contains(id)).ToArray();
-            if (missingIds.Length > 0)
+            shouldUpdateMentions = true;
+            if (mentionedUserIds.Count > 0)
             {
-                return ApplicationResponse<MessageEditResult>.Fail(
-                    ApplicationErrorCodes.Message.MentionedUserNotFound,
-                    $"One or more mentioned users were not found: {string.Join(", ", missingIds.Select(id => id.Value))}");
-            }
+                var distinctMentionIds = mentionedUserIds.Distinct().ToArray();
+                var userIds = distinctMentionIds.Select(UserId.From).ToArray();
 
-            // Verify membership via scope
-            var validateResult = await scope.ValidateMentionedUsersAsync(userIds.ToArray(), context, ct);
-            if (validateResult.IsFailure)
-            {
-                return ApplicationResponse<MessageEditResult>.Fail(
-                    ApplicationErrorCodes.Message.MentionedUserNotMember,
-                    validateResult.Error ?? "One or more mentioned users are not members of this scope");
-            }
+                var existingUsers = await _userRepository.GetManyByIdsAsync(userIds.ToArray(), ct);
+                var existingUserIds = existingUsers.Select(u => u.Id).ToHashSet();
+                var missingIds = userIds.Where(id => !existingUserIds.Contains(id)).ToArray();
+                if (missingIds.Length > 0)
+                {
+                    return ApplicationResponse<MessageEditResult>.Fail(
+                        ApplicationErrorCodes.Message.MentionedUserNotFound,
+                        $"One or more mentioned users were not found: {string.Join(", ", missingIds.Select(id => id.Value))}");
+                }
 
-            validatedMentionIds = distinctMentionIds;
+                var validateResult = await scope.ValidateMentionedUsersAsync(userIds.ToArray(), context, ct);
+                if (validateResult.IsFailure)
+                {
+                    return ApplicationResponse<MessageEditResult>.Fail(
+                        ApplicationErrorCodes.Message.MentionedUserNotMember,
+                        validateResult.Error ?? "One or more mentioned users are not members of this scope");
+                }
+
+                resolvedMentionIds = distinctMentionIds;
+            }
+            // else: empty list → resolvedMentionIds stays null, but shouldUpdateMentions=true clears the table
         }
 
         // ── Persist ─────────────────────────────────────────────────────
         await using var transaction = await _unitOfWork.BeginAsync(ct);
         await _messageRepository.UpdateAsync(message, ct);
-        if (validatedMentionIds is not null)
-            await _messageRepository.ReplaceMentionsAsync(message.Id, validatedMentionIds.Select(UserId.From).ToArray(), ct);
+        if (shouldUpdateMentions)
+            await _messageRepository.ReplaceMentionsAsync(message.Id, resolvedMentionIds?.Select(UserId.From).ToArray() ?? Array.Empty<UserId>(), ct);
         await transaction.CommitAsync(ct);
 
-        // ── Notify ──────────────────────────────────────────────────────
-        await scope.NotifyMessageUpdatedAsync(
-            context,
-            message.Id,
-            message.Content?.Value,
-            updatedAtUtc.Value,
-            ct);
-
-        // ── Attachments for response ────────────────────────────────────
+        // ── Attachments + mentions for response & notification ──────────
         var attachments = await _messageAttachmentRepository.GetByMessageIdAsync(messageId, ct);
 
-        // ── Retrieve mentions for response ──────────────────────────────
         IReadOnlyList<Guid> mentionIdsResponse;
-        if (validatedMentionIds is not null)
+        if (shouldUpdateMentions)
         {
-            mentionIdsResponse = validatedMentionIds;
+            mentionIdsResponse = resolvedMentionIds ?? Array.Empty<Guid>();
         }
         else
         {
@@ -156,6 +154,15 @@ public sealed class MessageEditDeleteOrchestrator
                 [message.Id.Value], ct);
             mentionIdsResponse = mentionsDict.TryGetValue(message.Id.Value, out var ids) ? ids : Array.Empty<Guid>();
         }
+
+        // ── Notify ──────────────────────────────────────────────────────
+        await scope.NotifyMessageUpdatedAsync(
+            context,
+            message.Id,
+            message.Content?.Value,
+            mentionIdsResponse,
+            updatedAtUtc.Value,
+            ct);
 
         // ── Result ──────────────────────────────────────────────────────
         return ApplicationResponse<MessageEditResult>.Ok(new MessageEditResult(

--- a/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
@@ -114,10 +114,10 @@ public sealed class MessageEditDeleteOrchestrator
                     context,
                     ct);
 
-                if (!validated.Success)
-                    return ApplicationResponse<MessageEditResult>.Fail(validated.Error!);
+                if (!validated.IsSuccess)
+                    return ApplicationResponse<MessageEditResult>.Fail(validated.ErrorCode!, validated.ErrorMessage!);
 
-                resolvedMentionIds = validated.Data!.Select(id => id.Value).ToArray();
+                resolvedMentionIds = validated.Value!.Select(id => id.Value).ToArray();
             }
             // else: empty list → shouldUpdateMentions=true clears the table
         }

--- a/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
@@ -103,7 +103,7 @@ public sealed class MessageEditDeleteOrchestrator
         bool mentionsTouched = false;
         if (mentionedUserIds is not null)
         {
-            UserId[] validatedIds;
+            var validatedIds = Array.Empty<UserId>();
             if (mentionedUserIds.Count > 0)
             {
                 var validated = await MentionValidationHelper.ValidateAsync(
@@ -117,10 +117,6 @@ public sealed class MessageEditDeleteOrchestrator
                     return ApplicationResponse<MessageEditResult>.Fail(editFailure.ErrorCode, editFailure.ErrorMessage);
 
                 validatedIds = ((MentionValidationResult.Success)validated).Value;
-            }
-            else
-            {
-                validatedIds = Array.Empty<UserId>();
             }
 
             var replaceResult = message.ReplaceMentions(validatedIds);

--- a/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
@@ -38,7 +38,10 @@ public sealed class MessageEditDeleteOrchestrator
         _uploadedFileCleanupService = uploadedFileCleanupService;
     }
 
-    /// <inheritdoc cref="MessageSendOrchestrator.SendAsync{TContext}"/>
+    /// <remarks>
+    /// Mention membership is validated before the transaction opens (same race window
+    /// as <see cref="MessageSendOrchestrator.SendAsync{TContext}"/>).
+    /// </remarks>
     public async Task<ApplicationResponse<MessageEditResult>> EditAsync<TContext>(
         IMessageEditDeleteScope<TContext> scope,
         MessageScope messageScope,

--- a/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
@@ -100,11 +100,10 @@ public sealed class MessageEditDeleteOrchestrator
         // null = don't touch mentions (field absent, backward compat)
         // []   = clear all mentions
         // ids  = validate and replace
-        IReadOnlyList<Guid>? resolvedMentionIds = null;
-        bool shouldUpdateMentions = false;
+        bool mentionsTouched = false;
         if (mentionedUserIds is not null)
         {
-            shouldUpdateMentions = true;
+            UserId[] validatedIds;
             if (mentionedUserIds.Count > 0)
             {
                 var validated = await MentionValidationHelper.ValidateAsync(
@@ -117,32 +116,38 @@ public sealed class MessageEditDeleteOrchestrator
                 if (validated is MentionValidationResult.Failure editFailure)
                     return ApplicationResponse<MessageEditResult>.Fail(editFailure.ErrorCode, editFailure.ErrorMessage);
 
-                resolvedMentionIds = ((MentionValidationResult.Success)validated).Value.Select(id => id.Value).ToArray();
+                validatedIds = ((MentionValidationResult.Success)validated).Value;
             }
-            // else: empty list → shouldUpdateMentions=true clears the table
+            else
+            {
+                validatedIds = Array.Empty<UserId>();
+            }
+
+            var replaceResult = message.ReplaceMentions(validatedIds);
+            if (replaceResult.IsFailure)
+            {
+                return ApplicationResponse<MessageEditResult>.Fail(
+                    ApplicationErrorCodes.Common.DomainRuleViolation,
+                    replaceResult.Error ?? "Unable to replace message mentions");
+            }
+
+            mentionsTouched = true;
         }
 
         // ── Persist ─────────────────────────────────────────────────────
         await using var transaction = await _unitOfWork.BeginAsync(ct);
         await _messageRepository.UpdateAsync(message, ct);
-        if (shouldUpdateMentions)
-            await _messageRepository.ReplaceMentionsAsync(message.Id, resolvedMentionIds?.Select(UserId.From).ToArray() ?? Array.Empty<UserId>(), ct);
+        if (mentionsTouched)
+            await _messageRepository.ReplaceMentionsAsync(message.Id, message.MentionedUserIds, ct);
         await transaction.CommitAsync(ct);
 
-        // ── Attachments + mentions for response & notification ──────────
+        // ── Attachments for response ────────────────────────────────────
         var attachments = await _messageAttachmentRepository.GetByMessageIdAsync(messageId, ct);
 
-        IReadOnlyList<Guid> mentionIdsResponse;
-        if (shouldUpdateMentions)
-        {
-            mentionIdsResponse = resolvedMentionIds ?? Array.Empty<Guid>();
-        }
-        else
-        {
-            var mentionsDict = await _messageRepository.GetMentionedUserIdsByMessageIdAsync(
-                [message.Id.Value], ct);
-            mentionIdsResponse = mentionsDict.TryGetValue(message.Id.Value, out var ids) ? ids : Array.Empty<Guid>();
-        }
+        // ── Resolve mention IDs for response & notification ─────────────
+        // If mentions were touched, the entity is already up-to-date.
+        // If not, GetByIdAsync already hydrated them during the initial fetch.
+        var mentionIdsResponse = message.MentionedUserIds.Select(id => id.Value).ToArray();
 
         // ── Notify ──────────────────────────────────────────────────────
         await scope.NotifyMessageUpdatedAsync(
@@ -159,7 +164,7 @@ public sealed class MessageEditDeleteOrchestrator
             AuthorUserId: message.AuthorUserId.Value,
             Content: message.Content?.Value,
             Attachments: attachments.Select(MessageAttachmentDto.FromDomain).ToArray(),
-            MentionedUserIds: mentionIdsResponse.ToArray(),
+            MentionedUserIds: mentionIdsResponse,
             CreatedAtUtc: message.CreatedAtUtc,
             UpdatedAtUtc: updatedAtUtc));
     }

--- a/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
@@ -110,8 +110,7 @@ public sealed class MessageEditDeleteOrchestrator
                 var validated = await MentionValidationHelper.ValidateAsync(
                     mentionedUserIds,
                     _userRepository,
-                    (ids, ctx, t) => scope.ValidateMentionedUsersAsync(ids, ctx, t),
-                    context,
+                    (ids, ct2) => scope.ValidateMentionedUsersAsync(ids, context, ct2),
                     ct);
 
                 if (validated is MentionValidationResult.Failure editFailure)

--- a/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
@@ -107,30 +107,19 @@ public sealed class MessageEditDeleteOrchestrator
             shouldUpdateMentions = true;
             if (mentionedUserIds.Count > 0)
             {
-                var distinctMentionIds = mentionedUserIds.Distinct().ToArray();
-                var userIds = distinctMentionIds.Select(UserId.From).ToArray();
+                var validated = await MentionValidationHelper.ValidateAsync(
+                    mentionedUserIds,
+                    _userRepository,
+                    (ids, ctx, t) => scope.ValidateMentionedUsersAsync(ids, ctx, t),
+                    context,
+                    ct);
 
-                var existingUsers = await _userRepository.GetManyByIdsAsync(userIds.ToArray(), ct);
-                var existingUserIds = existingUsers.Select(u => u.Id).ToHashSet();
-                var missingIds = userIds.Where(id => !existingUserIds.Contains(id)).ToArray();
-                if (missingIds.Length > 0)
-                {
-                    return ApplicationResponse<MessageEditResult>.Fail(
-                        ApplicationErrorCodes.Message.MentionedUserNotFound,
-                        $"One or more mentioned users were not found: {string.Join(", ", missingIds.Select(id => id.Value))}");
-                }
+                if (!validated.Success)
+                    return ApplicationResponse<MessageEditResult>.Fail(validated.Error!);
 
-                var validateResult = await scope.ValidateMentionedUsersAsync(userIds.ToArray(), context, ct);
-                if (validateResult.IsFailure)
-                {
-                    return ApplicationResponse<MessageEditResult>.Fail(
-                        ApplicationErrorCodes.Message.MentionedUserNotMember,
-                        validateResult.Error ?? "One or more mentioned users are not members of this scope");
-                }
-
-                resolvedMentionIds = distinctMentionIds;
+                resolvedMentionIds = validated.Data!.Select(id => id.Value).ToArray();
             }
-            // else: empty list → resolvedMentionIds stays null, but shouldUpdateMentions=true clears the table
+            // else: empty list → shouldUpdateMentions=true clears the table
         }
 
         // ── Persist ─────────────────────────────────────────────────────

--- a/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageEditDeleteOrchestrator.cs
@@ -114,10 +114,10 @@ public sealed class MessageEditDeleteOrchestrator
                     context,
                     ct);
 
-                if (!validated.IsSuccess)
-                    return ApplicationResponse<MessageEditResult>.Fail(validated.ErrorCode!, validated.ErrorMessage!);
+                if (validated is MentionValidationResult.Failure editFailure)
+                    return ApplicationResponse<MessageEditResult>.Fail(editFailure.ErrorCode, editFailure.ErrorMessage);
 
-                resolvedMentionIds = validated.Value!.Select(id => id.Value).ToArray();
+                resolvedMentionIds = ((MentionValidationResult.Success)validated).Value.Select(id => id.Value).ToArray();
             }
             // else: empty list → shouldUpdateMentions=true clears the table
         }

--- a/src/Harmonie.Application/Common/Messages/MessageFetchOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageFetchOrchestrator.cs
@@ -76,6 +76,9 @@ public sealed class MessageFetchOrchestrator
                 {
                     page.ReplyPreviewsByTargetMessageId?.TryGetValue(x.ReplyToMessageId.Value, out replyTo);
                 }
+                IReadOnlyList<Guid>? mentionedIds = null;
+                page.MentionedUserIdsByMessageId?.TryGetValue(x.Id.Value, out mentionedIds);
+                var mentionedUserIds = mentionedIds ?? Array.Empty<Guid>();
                 return new GetMessagesItemResponse(
                     MessageId: x.Id.Value,
                     AuthorUserId: x.AuthorUserId.Value,
@@ -88,6 +91,7 @@ public sealed class MessageFetchOrchestrator
                     LinkPreviews: previews?.ToArray(),
                     IsPinned: isPinned,
                     ReplyTo: replyTo,
+                    MentionedUserIds: mentionedUserIds?.ToArray() ?? Array.Empty<Guid>(),
                     CreatedAtUtc: x.CreatedAtUtc,
                     UpdatedAtUtc: x.UpdatedAtUtc);
             })

--- a/src/Harmonie.Application/Common/Messages/MessageFetchOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageFetchOrchestrator.cs
@@ -78,7 +78,6 @@ public sealed class MessageFetchOrchestrator
                 }
                 IReadOnlyList<Guid>? mentionedIds = null;
                 page.MentionedUserIdsByMessageId?.TryGetValue(x.Id.Value, out mentionedIds);
-                var mentionedUserIds = mentionedIds ?? Array.Empty<Guid>();
                 return new GetMessagesItemResponse(
                     MessageId: x.Id.Value,
                     AuthorUserId: x.AuthorUserId.Value,
@@ -91,7 +90,7 @@ public sealed class MessageFetchOrchestrator
                     LinkPreviews: previews?.ToArray(),
                     IsPinned: isPinned,
                     ReplyTo: replyTo,
-                    MentionedUserIds: mentionedUserIds?.ToArray() ?? Array.Empty<Guid>(),
+                    MentionedUserIds: mentionedIds?.ToArray() ?? Array.Empty<Guid>(),
                     CreatedAtUtc: x.CreatedAtUtc,
                     UpdatedAtUtc: x.UpdatedAtUtc);
             })

--- a/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
@@ -38,6 +38,13 @@ public sealed class MessageSendOrchestrator
         _unitOfWork = unitOfWork;
     }
 
+    /// <remarks>
+    /// Mention membership is validated before the transaction opens.
+    /// There is a theoretical race window: if a user is removed from the guild/conversation
+    /// between validation and commit, a mention to a non-member may be persisted.
+    /// This is accepted as the window is narrow and the impact is non-blocking
+    /// (the mention is still a valid FK reference).
+    /// </remarks>
     public async Task<ApplicationResponse<MessageSendResult>> SendAsync<TContext>(
         ISendMessageScope<TContext> scope,
         MessageScope messageScope,

--- a/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
@@ -2,7 +2,9 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Services;
+using Harmonie.Domain.Common;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -19,17 +21,20 @@ public sealed class MessageSendOrchestrator
     private readonly IMessageRepository _messageRepository;
     private readonly IMessageAttachmentRepository _messageAttachmentRepository;
     private readonly MessageAttachmentResolver _attachmentResolver;
+    private readonly IUserRepository _userRepository;
     private readonly IUnitOfWork _unitOfWork;
 
     public MessageSendOrchestrator(
         IMessageRepository messageRepository,
         IMessageAttachmentRepository messageAttachmentRepository,
         MessageAttachmentResolver attachmentResolver,
+        IUserRepository userRepository,
         IUnitOfWork unitOfWork)
     {
         _messageRepository = messageRepository;
         _messageAttachmentRepository = messageAttachmentRepository;
         _attachmentResolver = attachmentResolver;
+        _userRepository = userRepository;
         _unitOfWork = unitOfWork;
     }
 
@@ -39,6 +44,7 @@ public sealed class MessageSendOrchestrator
         string? rawContent,
         IReadOnlyList<Guid>? attachmentFileIds,
         Guid? replyToMessageId,
+        IReadOnlyList<Guid>? mentionedUserIds,
         UserId callerId,
         CancellationToken ct)
         where TContext : ScopeContext
@@ -107,12 +113,43 @@ public sealed class MessageSendOrchestrator
                 "Message must have content or at least one attachment");
         }
 
+        // ── Mention validation ──────────────────────────────────────────
+        IReadOnlyCollection<UserId>? mentionUserIds = null;
+        if (mentionedUserIds is { Count: > 0 })
+        {
+            var distinctMentionIds = mentionedUserIds.Distinct().ToArray();
+            var userIds = distinctMentionIds.Select(UserId.From).ToArray();
+
+            // Verify all users exist
+            var existingUsers = await _userRepository.GetManyByIdsAsync(userIds.ToArray(), ct);
+            var existingUserIds = existingUsers.Select(u => u.Id).ToHashSet();
+            var missingIds = userIds.Where(id => !existingUserIds.Contains(id)).ToArray();
+            if (missingIds.Length > 0)
+            {
+                return ApplicationResponse<MessageSendResult>.Fail(
+                    ApplicationErrorCodes.Message.MentionedUserNotFound,
+                    $"One or more mentioned users were not found: {string.Join(", ", missingIds.Select(id => id.Value))}");
+            }
+
+            // Verify membership via scope
+            var validateResult = await scope.ValidateMentionedUsersAsync(userIds.ToArray(), context, ct);
+            if (validateResult.IsFailure)
+            {
+                return ApplicationResponse<MessageSendResult>.Fail(
+                    ApplicationErrorCodes.Message.MentionedUserNotMember,
+                    validateResult.Error ?? "One or more mentioned users are not members of this scope");
+            }
+
+            mentionUserIds = userIds;
+        }
+
         // ── Domain message creation ─────────────────────────────────────
         var messageResult = Message.Create(
             messageScope,
             callerId,
             content,
-            replyToTargetId);
+            replyToTargetId,
+            mentionUserIds);
         if (messageResult.IsFailure || messageResult.Value is null)
         {
             return ApplicationResponse<MessageSendResult>.Fail(
@@ -146,6 +183,8 @@ public sealed class MessageSendOrchestrator
         await _messageRepository.AddAsync(messageResult.Value, ct);
         if (attachments.Count > 0)
             await _messageAttachmentRepository.AddRangeAsync(attachments, ct);
+        if (mentionUserIds is { Count: > 0 })
+            await _messageRepository.AddMentionsAsync(messageResult.Value.Id, mentionUserIds, ct);
         await scope.ApplyInTransactionSideEffectsAsync(context, ct);
         await transaction.CommitAsync(ct);
 
@@ -182,6 +221,9 @@ public sealed class MessageSendOrchestrator
             scope.ScheduleLinkPreviewResolution(context, messageResult.Value, urls, ct);
         }
 
+        // ── Mention DTO mapping ────────────────────────────────────────
+        var mentionDtos = mentionUserIds?.Select(id => id.Value).ToArray() ?? Array.Empty<Guid>();
+
         // ── Result ──────────────────────────────────────────────────────
         return ApplicationResponse<MessageSendResult>.Ok(new MessageSendResult(
             MessageId: messageResult.Value.Id.Value,
@@ -189,6 +231,7 @@ public sealed class MessageSendOrchestrator
             Content: messageResult.Value.Content?.Value,
             Attachments: attachmentDtos,
             ReplyTo: replyTo,
+            MentionedUserIds: mentionDtos,
             CreatedAtUtc: messageResult.Value.CreatedAtUtc));
     }
 }

--- a/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
@@ -124,10 +124,10 @@ public sealed class MessageSendOrchestrator
                 context,
                 ct);
 
-            if (!validated.Success)
-                return ApplicationResponse<MessageSendResult>.Fail(validated.Error!);
+            if (!validated.IsSuccess)
+                return ApplicationResponse<MessageSendResult>.Fail(validated.ErrorCode!, validated.ErrorMessage!);
 
-            mentionUserIds = validated.Data!;
+            mentionUserIds = validated.Value!;
         }
 
         // ── Domain message creation ─────────────────────────────────────

--- a/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
@@ -127,8 +127,7 @@ public sealed class MessageSendOrchestrator
             var validated = await MentionValidationHelper.ValidateAsync(
                 mentionedUserIds,
                 _userRepository,
-                (ids, ctx, t) => scope.ValidateMentionedUsersAsync(ids, ctx, t),
-                context,
+                (ids, ct2) => scope.ValidateMentionedUsersAsync(ids, context, ct2),
                 ct);
 
             if (validated is MentionValidationResult.Failure failure)

--- a/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
@@ -124,10 +124,10 @@ public sealed class MessageSendOrchestrator
                 context,
                 ct);
 
-            if (!validated.IsSuccess)
-                return ApplicationResponse<MessageSendResult>.Fail(validated.ErrorCode!, validated.ErrorMessage!);
+            if (validated is MentionValidationResult.Failure failure)
+                return ApplicationResponse<MessageSendResult>.Fail(failure.ErrorCode, failure.ErrorMessage);
 
-            mentionUserIds = validated.Value!;
+            mentionUserIds = ((MentionValidationResult.Success)validated).Value;
         }
 
         // ── Domain message creation ─────────────────────────────────────

--- a/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
@@ -114,33 +114,20 @@ public sealed class MessageSendOrchestrator
         }
 
         // ── Mention validation ──────────────────────────────────────────
-        IReadOnlyCollection<UserId>? mentionUserIds = null;
+        UserId[]? mentionUserIds = null;
         if (mentionedUserIds is { Count: > 0 })
         {
-            var distinctMentionIds = mentionedUserIds.Distinct().ToArray();
-            var userIds = distinctMentionIds.Select(UserId.From).ToArray();
+            var validated = await MentionValidationHelper.ValidateAsync(
+                mentionedUserIds,
+                _userRepository,
+                (ids, ctx, t) => scope.ValidateMentionedUsersAsync(ids, ctx, t),
+                context,
+                ct);
 
-            // Verify all users exist
-            var existingUsers = await _userRepository.GetManyByIdsAsync(userIds.ToArray(), ct);
-            var existingUserIds = existingUsers.Select(u => u.Id).ToHashSet();
-            var missingIds = userIds.Where(id => !existingUserIds.Contains(id)).ToArray();
-            if (missingIds.Length > 0)
-            {
-                return ApplicationResponse<MessageSendResult>.Fail(
-                    ApplicationErrorCodes.Message.MentionedUserNotFound,
-                    $"One or more mentioned users were not found: {string.Join(", ", missingIds.Select(id => id.Value))}");
-            }
+            if (!validated.Success)
+                return ApplicationResponse<MessageSendResult>.Fail(validated.Error!);
 
-            // Verify membership via scope
-            var validateResult = await scope.ValidateMentionedUsersAsync(userIds.ToArray(), context, ct);
-            if (validateResult.IsFailure)
-            {
-                return ApplicationResponse<MessageSendResult>.Fail(
-                    ApplicationErrorCodes.Message.MentionedUserNotMember,
-                    validateResult.Error ?? "One or more mentioned users are not members of this scope");
-            }
-
-            mentionUserIds = userIds;
+            mentionUserIds = validated.Data!;
         }
 
         // ── Domain message creation ─────────────────────────────────────
@@ -183,7 +170,7 @@ public sealed class MessageSendOrchestrator
         await _messageRepository.AddAsync(messageResult.Value, ct);
         if (attachments.Count > 0)
             await _messageAttachmentRepository.AddRangeAsync(attachments, ct);
-        if (mentionUserIds is { Count: > 0 })
+        if (mentionUserIds is { Length: > 0 })
             await _messageRepository.AddMentionsAsync(messageResult.Value.Id, mentionUserIds, ct);
         await scope.ApplyInTransactionSideEffectsAsync(context, ct);
         await transaction.CommitAsync(ct);

--- a/src/Harmonie.Application/Features/Channels/DeleteMessage/DeleteMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/DeleteMessage/DeleteMessageHandler.cs
@@ -2,6 +2,7 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Channels.Messages;
 using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -14,17 +15,20 @@ public sealed record DeleteChannelMessageInput(GuildChannelId ChannelId, Message
 public sealed class DeleteMessageHandler : IAuthenticatedHandler<DeleteChannelMessageInput, bool>
 {
     private readonly IGuildChannelRepository _guildChannelRepository;
+    private readonly IGuildMemberRepository _guildMemberRepository;
     private readonly ITextChannelNotifier _textChannelNotifier;
     private readonly ILogger<ChannelMessageEditDeleteScope> _scopeLogger;
     private readonly MessageEditDeleteOrchestrator _orchestrator;
 
     public DeleteMessageHandler(
         IGuildChannelRepository guildChannelRepository,
+        IGuildMemberRepository guildMemberRepository,
         ITextChannelNotifier textChannelNotifier,
         ILogger<ChannelMessageEditDeleteScope> scopeLogger,
         MessageEditDeleteOrchestrator orchestrator)
     {
         _guildChannelRepository = guildChannelRepository;
+        _guildMemberRepository = guildMemberRepository;
         _textChannelNotifier = textChannelNotifier;
         _scopeLogger = scopeLogger;
         _orchestrator = orchestrator;
@@ -38,6 +42,7 @@ public sealed class DeleteMessageHandler : IAuthenticatedHandler<DeleteChannelMe
         var scope = new ChannelMessageEditDeleteScope(
             request.ChannelId,
             _guildChannelRepository,
+            _guildMemberRepository,
             _textChannelNotifier,
             _scopeLogger);
 

--- a/src/Harmonie.Application/Features/Channels/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
@@ -2,6 +2,7 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Channels.Messages;
 using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Uploads;
@@ -15,17 +16,20 @@ public sealed record DeleteChannelMessageAttachmentInput(GuildChannelId ChannelI
 public sealed class DeleteMessageAttachmentHandler : IAuthenticatedHandler<DeleteChannelMessageAttachmentInput, bool>
 {
     private readonly IGuildChannelRepository _guildChannelRepository;
+    private readonly IGuildMemberRepository _guildMemberRepository;
     private readonly ITextChannelNotifier _textChannelNotifier;
     private readonly ILogger<ChannelMessageEditDeleteScope> _scopeLogger;
     private readonly MessageEditDeleteOrchestrator _orchestrator;
 
     public DeleteMessageAttachmentHandler(
         IGuildChannelRepository guildChannelRepository,
+        IGuildMemberRepository guildMemberRepository,
         ITextChannelNotifier textChannelNotifier,
         ILogger<ChannelMessageEditDeleteScope> scopeLogger,
         MessageEditDeleteOrchestrator orchestrator)
     {
         _guildChannelRepository = guildChannelRepository;
+        _guildMemberRepository = guildMemberRepository;
         _textChannelNotifier = textChannelNotifier;
         _scopeLogger = scopeLogger;
         _orchestrator = orchestrator;
@@ -39,6 +43,7 @@ public sealed class DeleteMessageAttachmentHandler : IAuthenticatedHandler<Delet
         var scope = new ChannelMessageEditDeleteScope(
             request.ChannelId,
             _guildChannelRepository,
+            _guildMemberRepository,
             _textChannelNotifier,
             _scopeLogger);
 

--- a/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageEndpoint.cs
@@ -49,7 +49,7 @@ public static class EditMessageEndpoint
 
         var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
-        var response = await handler.HandleAsync(new EditChannelMessageInput(channelId, messageId, request.Content), callerId, cancellationToken);
+        var response = await handler.HandleAsync(new EditChannelMessageInput(channelId, messageId, request.Content, request.MentionedUserIds), callerId, cancellationToken);
         return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageEndpoint.cs
@@ -31,7 +31,9 @@ public static class EditMessageEndpoint
                 ApplicationErrorCodes.Channel.NotText,
                 ApplicationErrorCodes.Channel.AccessDenied,
                 ApplicationErrorCodes.Message.NotFound,
-                ApplicationErrorCodes.Message.EditForbidden);
+                ApplicationErrorCodes.Message.EditForbidden,
+                ApplicationErrorCodes.Message.MentionedUserNotFound,
+                ApplicationErrorCodes.Message.MentionedUserNotMember);
     }
 
     private static async Task<IResult> HandleAsync(

--- a/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageEndpoint.cs
@@ -18,7 +18,7 @@ public static class EditMessageEndpoint
             .WithTags("Channels")
             .RequireAuthorization()
             .WithSummary("Edit a message")
-            .WithDescription("Updates the content of a message. Only the message author can edit their own messages.")
+            .WithDescription("Updates the content of a message. Only the message author can edit their own messages. Omit `mentionedUserIds` to leave mentions unchanged; pass an empty array to clear all mentions; pass IDs to replace the mention set.")
             .Produces<EditMessageResponse>(StatusCodes.Status200OK)
             .ProducesErrors(
                 ApplicationErrorCodes.Common.ValidationFailed,

--- a/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageHandler.cs
@@ -2,6 +2,7 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Channels.Messages;
 using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
@@ -9,22 +10,25 @@ using Microsoft.Extensions.Logging;
 
 namespace Harmonie.Application.Features.Channels.EditMessage;
 
-public sealed record EditChannelMessageInput(GuildChannelId ChannelId, MessageId MessageId, string Content);
+public sealed record EditChannelMessageInput(GuildChannelId ChannelId, MessageId MessageId, string Content, IReadOnlyList<Guid>? MentionedUserIds = null);
 
 public sealed class EditMessageHandler : IAuthenticatedHandler<EditChannelMessageInput, EditMessageResponse>
 {
     private readonly IGuildChannelRepository _guildChannelRepository;
+    private readonly IGuildMemberRepository _guildMemberRepository;
     private readonly ITextChannelNotifier _textChannelNotifier;
     private readonly ILogger<ChannelMessageEditDeleteScope> _scopeLogger;
     private readonly MessageEditDeleteOrchestrator _orchestrator;
 
     public EditMessageHandler(
         IGuildChannelRepository guildChannelRepository,
+        IGuildMemberRepository guildMemberRepository,
         ITextChannelNotifier textChannelNotifier,
         ILogger<ChannelMessageEditDeleteScope> scopeLogger,
         MessageEditDeleteOrchestrator orchestrator)
     {
         _guildChannelRepository = guildChannelRepository;
+        _guildMemberRepository = guildMemberRepository;
         _textChannelNotifier = textChannelNotifier;
         _scopeLogger = scopeLogger;
         _orchestrator = orchestrator;
@@ -38,6 +42,7 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditChannelMessag
         var scope = new ChannelMessageEditDeleteScope(
             request.ChannelId,
             _guildChannelRepository,
+            _guildMemberRepository,
             _textChannelNotifier,
             _scopeLogger);
 
@@ -46,6 +51,7 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditChannelMessag
             new MessageScope.Channel(request.ChannelId),
             request.MessageId,
             request.Content,
+            request.MentionedUserIds,
             currentUserId,
             cancellationToken);
 
@@ -58,6 +64,7 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditChannelMessag
             AuthorUserId: result.Data.AuthorUserId,
             Content: result.Data.Content,
             Attachments: result.Data.Attachments,
+            MentionedUserIds: result.Data.MentionedUserIds,
             CreatedAtUtc: result.Data.CreatedAtUtc,
             UpdatedAtUtc: result.Data.UpdatedAtUtc));
     }

--- a/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageRequest.cs
+++ b/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageRequest.cs
@@ -1,3 +1,3 @@
 namespace Harmonie.Application.Features.Channels.EditMessage;
 
-public sealed record EditMessageRequest(string Content);
+public sealed record EditMessageRequest(string Content, IReadOnlyList<Guid>? MentionedUserIds = null);

--- a/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageResponse.cs
+++ b/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageResponse.cs
@@ -9,5 +9,6 @@ public sealed record EditMessageResponse(
     Guid AuthorUserId,
     string? Content,
     IReadOnlyList<MessageAttachmentDto> Attachments,
+    IReadOnlyList<Guid> MentionedUserIds,
     DateTime CreatedAtUtc,
     DateTime? UpdatedAtUtc);

--- a/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageValidator.cs
+++ b/src/Harmonie.Application/Features/Channels/EditMessage/EditMessageValidator.cs
@@ -9,5 +9,20 @@ public sealed class EditMessageValidator : AbstractValidator<EditMessageRequest>
         RuleFor(x => x.Content)
             .NotEmpty()
             .WithMessage("Message content is required");
+
+        RuleForEach(x => x.MentionedUserIds)
+            .NotEqual(Guid.Empty)
+            .WithMessage("Mentioned user IDs must be valid non-empty GUIDs")
+            .When(x => x.MentionedUserIds is not null);
+
+        RuleFor(x => x.MentionedUserIds)
+            .Must(ids => ids is null || ids.Distinct().Count() == ids.Count)
+            .WithMessage("Mentioned user IDs must be unique")
+            .When(x => x.MentionedUserIds is not null);
+
+        RuleFor(x => x.MentionedUserIds)
+            .Must(ids => ids is null || ids.Count <= 50)
+            .WithMessage("A message can mention at most 50 users")
+            .When(x => x.MentionedUserIds is not null);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/Messages/ChannelMessageEditDeleteScope.cs
+++ b/src/Harmonie.Application/Features/Channels/Messages/ChannelMessageEditDeleteScope.cs
@@ -73,7 +73,7 @@ public sealed class ChannelMessageEditDeleteScope : IMessageEditDeleteScope<Chan
         if (userIds.Count == 0)
             return Result.Success();
 
-        var memberSet = await _guildMemberRepository.GetMembersInAsync(context.GuildId, userIds.ToArray(), ct);
+        var memberSet = await _guildMemberRepository.GetMembersInAsync(context.GuildId, userIds, ct);
         var nonMembers = userIds.Where(id => !memberSet.Contains(id)).ToArray();
         if (nonMembers.Length > 0)
         {

--- a/src/Harmonie.Application/Features/Channels/Messages/ChannelMessageEditDeleteScope.cs
+++ b/src/Harmonie.Application/Features/Channels/Messages/ChannelMessageEditDeleteScope.cs
@@ -70,13 +70,14 @@ public sealed class ChannelMessageEditDeleteScope : IMessageEditDeleteScope<Chan
         Context context,
         CancellationToken ct)
     {
-        foreach (var userId in userIds)
+        if (userIds.Count == 0)
+            return Result.Success();
+
+        var memberSet = await _guildMemberRepository.GetMembersInAsync(context.GuildId, userIds.ToArray(), ct);
+        var nonMembers = userIds.Where(id => !memberSet.Contains(id)).ToArray();
+        if (nonMembers.Length > 0)
         {
-            var isMember = await _guildMemberRepository.IsMemberAsync(context.GuildId, userId, ct);
-            if (!isMember)
-            {
-                return Result.Failure($"User {userId.Value} is not a member of guild {context.GuildId.Value}");
-            }
+            return Result.Failure($"Users not members of guild {context.GuildId.Value}: {string.Join(", ", nonMembers.Select(id => id.Value))}");
         }
 
         return Result.Success();
@@ -86,6 +87,7 @@ public sealed class ChannelMessageEditDeleteScope : IMessageEditDeleteScope<Chan
         Context context,
         MessageId messageId,
         string? content,
+        IReadOnlyList<Guid> mentionedUserIds,
         DateTime updatedAtUtc,
         CancellationToken ct)
     {
@@ -96,6 +98,7 @@ public sealed class ChannelMessageEditDeleteScope : IMessageEditDeleteScope<Chan
             context.GuildId,
             context.GuildName,
             content,
+            mentionedUserIds,
             updatedAtUtc);
 
         await BestEffortNotificationHelper.TryNotifyAsync(

--- a/src/Harmonie.Application/Features/Channels/Messages/ChannelMessageEditDeleteScope.cs
+++ b/src/Harmonie.Application/Features/Channels/Messages/ChannelMessageEditDeleteScope.cs
@@ -1,6 +1,8 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Interfaces.Guilds;
+using Harmonie.Domain.Common;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Guilds;
@@ -26,17 +28,20 @@ public sealed class ChannelMessageEditDeleteScope : IMessageEditDeleteScope<Chan
 
     private readonly GuildChannelId _channelId;
     private readonly IGuildChannelRepository _guildChannelRepository;
+    private readonly IGuildMemberRepository _guildMemberRepository;
     private readonly ITextChannelNotifier _textChannelNotifier;
     private readonly ILogger<ChannelMessageEditDeleteScope> _logger;
 
     public ChannelMessageEditDeleteScope(
         GuildChannelId channelId,
         IGuildChannelRepository guildChannelRepository,
+        IGuildMemberRepository guildMemberRepository,
         ITextChannelNotifier textChannelNotifier,
         ILogger<ChannelMessageEditDeleteScope> logger)
     {
         _channelId = channelId;
         _guildChannelRepository = guildChannelRepository;
+        _guildMemberRepository = guildMemberRepository;
         _textChannelNotifier = textChannelNotifier;
         _logger = logger;
     }
@@ -59,6 +64,23 @@ public sealed class ChannelMessageEditDeleteScope : IMessageEditDeleteScope<Chan
     // In channels, admins can delete any message, not just their own.
     public bool CanDeleteOthersMessages(Context context)
         => context.CallerRole == GuildRole.Admin;
+
+    public async Task<Result> ValidateMentionedUsersAsync(
+        IReadOnlyCollection<UserId> userIds,
+        Context context,
+        CancellationToken ct)
+    {
+        foreach (var userId in userIds)
+        {
+            var isMember = await _guildMemberRepository.IsMemberAsync(context.GuildId, userId, ct);
+            if (!isMember)
+            {
+                return Result.Failure($"User {userId.Value} is not a member of guild {context.GuildId.Value}");
+            }
+        }
+
+        return Result.Success();
+    }
 
     public async Task NotifyMessageUpdatedAsync(
         Context context,

--- a/src/Harmonie.Application/Features/Channels/SendMessage/ChannelSendMessageScope.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/ChannelSendMessageScope.cs
@@ -1,7 +1,9 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Services;
+using Harmonie.Domain.Common;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.Enums;
 using Harmonie.Domain.ValueObjects.Channels;
@@ -28,6 +30,7 @@ public sealed class ChannelSendMessageScope : ISendMessageScope<ChannelSendMessa
 
     private readonly GuildChannelId _channelId;
     private readonly IGuildChannelRepository _guildChannelRepository;
+    private readonly IGuildMemberRepository _guildMemberRepository;
     private readonly ITextChannelNotifier _textChannelNotifier;
     private readonly LinkPreviewResolutionService _linkPreviewService;
     private readonly ILogger<ChannelSendMessageScope> _logger;
@@ -35,12 +38,14 @@ public sealed class ChannelSendMessageScope : ISendMessageScope<ChannelSendMessa
     public ChannelSendMessageScope(
         GuildChannelId channelId,
         IGuildChannelRepository guildChannelRepository,
+        IGuildMemberRepository guildMemberRepository,
         ITextChannelNotifier textChannelNotifier,
         LinkPreviewResolutionService linkPreviewService,
         ILogger<ChannelSendMessageScope> logger)
     {
         _channelId = channelId;
         _guildChannelRepository = guildChannelRepository;
+        _guildMemberRepository = guildMemberRepository;
         _textChannelNotifier = textChannelNotifier;
         _linkPreviewService = linkPreviewService;
         _logger = logger;
@@ -64,6 +69,23 @@ public sealed class ChannelSendMessageScope : ISendMessageScope<ChannelSendMessa
 
     public Task ApplyInTransactionSideEffectsAsync(Context context, CancellationToken ct)
         => Task.CompletedTask;
+
+    public async Task<Result> ValidateMentionedUsersAsync(
+        IReadOnlyCollection<UserId> userIds,
+        Context context,
+        CancellationToken ct)
+    {
+        foreach (var userId in userIds)
+        {
+            var isMember = await _guildMemberRepository.IsMemberAsync(context.GuildId, userId, ct);
+            if (!isMember)
+            {
+                return Result.Failure($"User {userId.Value} is not a member of guild {context.GuildId.Value}");
+            }
+        }
+
+        return Result.Success();
+    }
 
     public async Task NotifyMessageCreatedAsync(
         Context context,

--- a/src/Harmonie.Application/Features/Channels/SendMessage/ChannelSendMessageScope.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/ChannelSendMessageScope.cs
@@ -75,13 +75,14 @@ public sealed class ChannelSendMessageScope : ISendMessageScope<ChannelSendMessa
         Context context,
         CancellationToken ct)
     {
-        foreach (var userId in userIds)
+        if (userIds.Count == 0)
+            return Result.Success();
+
+        var memberSet = await _guildMemberRepository.GetMembersInAsync(context.GuildId, userIds.ToArray(), ct);
+        var nonMembers = userIds.Where(id => !memberSet.Contains(id)).ToArray();
+        if (nonMembers.Length > 0)
         {
-            var isMember = await _guildMemberRepository.IsMemberAsync(context.GuildId, userId, ct);
-            if (!isMember)
-            {
-                return Result.Failure($"User {userId.Value} is not a member of guild {context.GuildId.Value}");
-            }
+            return Result.Failure($"Users not members of guild {context.GuildId.Value}: {string.Join(", ", nonMembers.Select(id => id.Value))}");
         }
 
         return Result.Success();
@@ -106,6 +107,7 @@ public sealed class ChannelSendMessageScope : ISendMessageScope<ChannelSendMessa
             message.Content?.Value,
             attachments,
             replyTo,
+            message.MentionedUserIds.Select(id => id.Value).ToArray(),
             message.CreatedAtUtc);
 
         await BestEffortNotificationHelper.TryNotifyAsync(

--- a/src/Harmonie.Application/Features/Channels/SendMessage/ChannelSendMessageScope.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/ChannelSendMessageScope.cs
@@ -78,7 +78,7 @@ public sealed class ChannelSendMessageScope : ISendMessageScope<ChannelSendMessa
         if (userIds.Count == 0)
             return Result.Success();
 
-        var memberSet = await _guildMemberRepository.GetMembersInAsync(context.GuildId, userIds.ToArray(), ct);
+        var memberSet = await _guildMemberRepository.GetMembersInAsync(context.GuildId, userIds, ct);
         var nonMembers = userIds.Where(id => !memberSet.Contains(id)).ToArray();
         if (nonMembers.Length > 0)
         {

--- a/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageEndpoint.cs
@@ -47,7 +47,7 @@ public static class SendMessageEndpoint
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
-        var response = await handler.HandleAsync(new SendChannelMessageInput(channelId, request.Content, request.AttachmentFileIds, request.ReplyToMessageId), currentUserId, cancellationToken);
+        var response = await handler.HandleAsync(new SendChannelMessageInput(channelId, request.Content, request.AttachmentFileIds, request.ReplyToMessageId, request.MentionedUserIds), currentUserId, cancellationToken);
         return response.ToCreatedHttpResult(data => $"/api/channels/{data.ChannelId}/messages/{data.MessageId}", httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageEndpoint.cs
@@ -30,7 +30,9 @@ public static class SendMessageEndpoint
                 ApplicationErrorCodes.Guild.AccessDenied,
                 ApplicationErrorCodes.Channel.NotFound,
                 ApplicationErrorCodes.Channel.NotText,
-                ApplicationErrorCodes.Channel.AccessDenied);
+                ApplicationErrorCodes.Channel.AccessDenied,
+                ApplicationErrorCodes.Message.MentionedUserNotFound,
+                ApplicationErrorCodes.Message.MentionedUserNotMember);
     }
 
     private static async Task<IResult> HandleAsync(

--- a/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageEndpoint.cs
@@ -18,7 +18,7 @@ public static class SendMessageEndpoint
             .RequireAuthorization()
             .RequireRateLimiting("message-post")
             .WithSummary("Send a message")
-            .WithDescription("Posts a message in a text channel. Optional `attachmentFileIds` values must reference files previously uploaded with attachment purpose.")
+            .WithDescription("Posts a message in a text channel. Optional `attachmentFileIds` values must reference files previously uploaded with attachment purpose. `mentionedUserIds` can be omitted or empty for no mentions; mentioned users must be guild members.")
             .Produces<SendMessageResponse>(StatusCodes.Status201Created)
             .Produces(StatusCodes.Status429TooManyRequests)
             .ProducesErrors(

--- a/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageHandler.cs
@@ -1,6 +1,7 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Channels;
+using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Services;
 using Harmonie.Domain.ValueObjects.Channels;
 using Harmonie.Domain.ValueObjects.Messages;
@@ -9,11 +10,12 @@ using Microsoft.Extensions.Logging;
 
 namespace Harmonie.Application.Features.Channels.SendMessage;
 
-public sealed record SendChannelMessageInput(GuildChannelId ChannelId, string? Content, IReadOnlyList<Guid>? AttachmentFileIds = null, Guid? ReplyToMessageId = null);
+public sealed record SendChannelMessageInput(GuildChannelId ChannelId, string? Content, IReadOnlyList<Guid>? AttachmentFileIds = null, Guid? ReplyToMessageId = null, IReadOnlyList<Guid>? MentionedUserIds = null);
 
 public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessageInput, SendMessageResponse>
 {
     private readonly IGuildChannelRepository _guildChannelRepository;
+    private readonly IGuildMemberRepository _guildMemberRepository;
     private readonly ITextChannelNotifier _textChannelNotifier;
     private readonly LinkPreviewResolutionService _linkPreviewService;
     private readonly ILogger<ChannelSendMessageScope> _scopeLogger;
@@ -21,12 +23,14 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessag
 
     public SendMessageHandler(
         IGuildChannelRepository guildChannelRepository,
+        IGuildMemberRepository guildMemberRepository,
         ITextChannelNotifier textChannelNotifier,
         LinkPreviewResolutionService linkPreviewService,
         ILogger<ChannelSendMessageScope> scopeLogger,
         MessageSendOrchestrator orchestrator)
     {
         _guildChannelRepository = guildChannelRepository;
+        _guildMemberRepository = guildMemberRepository;
         _textChannelNotifier = textChannelNotifier;
         _linkPreviewService = linkPreviewService;
         _scopeLogger = scopeLogger;
@@ -41,6 +45,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessag
         var scope = new ChannelSendMessageScope(
             request.ChannelId,
             _guildChannelRepository,
+            _guildMemberRepository,
             _textChannelNotifier,
             _linkPreviewService,
             _scopeLogger);
@@ -51,6 +56,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessag
             request.Content,
             request.AttachmentFileIds,
             request.ReplyToMessageId,
+            request.MentionedUserIds,
             currentUserId,
             cancellationToken);
 
@@ -64,6 +70,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendChannelMessag
             result.Data.Content,
             result.Data.Attachments,
             result.Data.ReplyTo,
+            result.Data.MentionedUserIds,
             result.Data.CreatedAtUtc));
     }
 }

--- a/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageRequest.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageRequest.cs
@@ -3,4 +3,5 @@ namespace Harmonie.Application.Features.Channels.SendMessage;
 public sealed record SendMessageRequest(
     string? Content,
     IReadOnlyList<Guid>? AttachmentFileIds = null,
-    Guid? ReplyToMessageId = null);
+    Guid? ReplyToMessageId = null,
+    IReadOnlyList<Guid>? MentionedUserIds = null);

--- a/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageResponse.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageResponse.cs
@@ -10,4 +10,5 @@ public sealed record SendMessageResponse(
     string? Content,
     IReadOnlyList<MessageAttachmentDto> Attachments,
     ReplyPreviewDto? ReplyTo,
+    IReadOnlyList<Guid> MentionedUserIds,
     DateTime CreatedAtUtc);

--- a/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageValidator.cs
+++ b/src/Harmonie.Application/Features/Channels/SendMessage/SendMessageValidator.cs
@@ -20,5 +20,20 @@ public sealed class SendMessageValidator : AbstractValidator<SendMessageRequest>
             .Must(ids => ids is null || ids.Distinct().Count() == ids.Count)
             .WithMessage("Attachment file IDs must be unique")
             .When(x => x.AttachmentFileIds is not null);
+
+        RuleForEach(x => x.MentionedUserIds)
+            .NotEqual(Guid.Empty)
+            .WithMessage("Mentioned user IDs must be valid non-empty GUIDs")
+            .When(x => x.MentionedUserIds is not null);
+
+        RuleFor(x => x.MentionedUserIds)
+            .Must(ids => ids is null || ids.Distinct().Count() == ids.Count)
+            .WithMessage("Mentioned user IDs must be unique")
+            .When(x => x.MentionedUserIds is not null);
+
+        RuleFor(x => x.MentionedUserIds)
+            .Must(ids => ids is null || ids.Count <= 50)
+            .WithMessage("A message can mention at most 50 users")
+            .When(x => x.MentionedUserIds is not null);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/DeleteMessage/DeleteMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteMessage/DeleteMessageHandler.cs
@@ -14,17 +14,20 @@ public sealed record DeleteConversationMessageInput(ConversationId ConversationI
 public sealed class DeleteMessageHandler : IAuthenticatedHandler<DeleteConversationMessageInput, bool>
 {
     private readonly IConversationRepository _conversationRepository;
+    private readonly IConversationParticipantRepository _participantRepository;
     private readonly IConversationMessageNotifier _conversationMessageNotifier;
     private readonly ILogger<ConversationMessageEditDeleteScope> _scopeLogger;
     private readonly MessageEditDeleteOrchestrator _orchestrator;
 
     public DeleteMessageHandler(
         IConversationRepository conversationRepository,
+        IConversationParticipantRepository participantRepository,
         IConversationMessageNotifier conversationMessageNotifier,
         ILogger<ConversationMessageEditDeleteScope> scopeLogger,
         MessageEditDeleteOrchestrator orchestrator)
     {
         _conversationRepository = conversationRepository;
+        _participantRepository = participantRepository;
         _conversationMessageNotifier = conversationMessageNotifier;
         _scopeLogger = scopeLogger;
         _orchestrator = orchestrator;
@@ -38,6 +41,7 @@ public sealed class DeleteMessageHandler : IAuthenticatedHandler<DeleteConversat
         var scope = new ConversationMessageEditDeleteScope(
             request.ConversationId,
             _conversationRepository,
+            _participantRepository,
             _conversationMessageNotifier,
             _scopeLogger);
 

--- a/src/Harmonie.Application/Features/Conversations/DeleteMessage/DeleteMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteMessage/DeleteMessageHandler.cs
@@ -14,20 +14,17 @@ public sealed record DeleteConversationMessageInput(ConversationId ConversationI
 public sealed class DeleteMessageHandler : IAuthenticatedHandler<DeleteConversationMessageInput, bool>
 {
     private readonly IConversationRepository _conversationRepository;
-    private readonly IConversationParticipantRepository _participantRepository;
     private readonly IConversationMessageNotifier _conversationMessageNotifier;
     private readonly ILogger<ConversationMessageEditDeleteScope> _scopeLogger;
     private readonly MessageEditDeleteOrchestrator _orchestrator;
 
     public DeleteMessageHandler(
         IConversationRepository conversationRepository,
-        IConversationParticipantRepository participantRepository,
         IConversationMessageNotifier conversationMessageNotifier,
         ILogger<ConversationMessageEditDeleteScope> scopeLogger,
         MessageEditDeleteOrchestrator orchestrator)
     {
         _conversationRepository = conversationRepository;
-        _participantRepository = participantRepository;
         _conversationMessageNotifier = conversationMessageNotifier;
         _scopeLogger = scopeLogger;
         _orchestrator = orchestrator;
@@ -41,7 +38,6 @@ public sealed class DeleteMessageHandler : IAuthenticatedHandler<DeleteConversat
         var scope = new ConversationMessageEditDeleteScope(
             request.ConversationId,
             _conversationRepository,
-            _participantRepository,
             _conversationMessageNotifier,
             _scopeLogger);
 

--- a/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
@@ -15,17 +15,20 @@ public sealed record DeleteConversationMessageAttachmentInput(ConversationId Con
 public sealed class DeleteMessageAttachmentHandler : IAuthenticatedHandler<DeleteConversationMessageAttachmentInput, bool>
 {
     private readonly IConversationRepository _conversationRepository;
+    private readonly IConversationParticipantRepository _participantRepository;
     private readonly IConversationMessageNotifier _conversationMessageNotifier;
     private readonly ILogger<ConversationMessageEditDeleteScope> _scopeLogger;
     private readonly MessageEditDeleteOrchestrator _orchestrator;
 
     public DeleteMessageAttachmentHandler(
         IConversationRepository conversationRepository,
+        IConversationParticipantRepository participantRepository,
         IConversationMessageNotifier conversationMessageNotifier,
         ILogger<ConversationMessageEditDeleteScope> scopeLogger,
         MessageEditDeleteOrchestrator orchestrator)
     {
         _conversationRepository = conversationRepository;
+        _participantRepository = participantRepository;
         _conversationMessageNotifier = conversationMessageNotifier;
         _scopeLogger = scopeLogger;
         _orchestrator = orchestrator;
@@ -39,6 +42,7 @@ public sealed class DeleteMessageAttachmentHandler : IAuthenticatedHandler<Delet
         var scope = new ConversationMessageEditDeleteScope(
             request.ConversationId,
             _conversationRepository,
+            _participantRepository,
             _conversationMessageNotifier,
             _scopeLogger);
 

--- a/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/DeleteMessageAttachment/DeleteMessageAttachmentHandler.cs
@@ -15,20 +15,17 @@ public sealed record DeleteConversationMessageAttachmentInput(ConversationId Con
 public sealed class DeleteMessageAttachmentHandler : IAuthenticatedHandler<DeleteConversationMessageAttachmentInput, bool>
 {
     private readonly IConversationRepository _conversationRepository;
-    private readonly IConversationParticipantRepository _participantRepository;
     private readonly IConversationMessageNotifier _conversationMessageNotifier;
     private readonly ILogger<ConversationMessageEditDeleteScope> _scopeLogger;
     private readonly MessageEditDeleteOrchestrator _orchestrator;
 
     public DeleteMessageAttachmentHandler(
         IConversationRepository conversationRepository,
-        IConversationParticipantRepository participantRepository,
         IConversationMessageNotifier conversationMessageNotifier,
         ILogger<ConversationMessageEditDeleteScope> scopeLogger,
         MessageEditDeleteOrchestrator orchestrator)
     {
         _conversationRepository = conversationRepository;
-        _participantRepository = participantRepository;
         _conversationMessageNotifier = conversationMessageNotifier;
         _scopeLogger = scopeLogger;
         _orchestrator = orchestrator;
@@ -42,7 +39,6 @@ public sealed class DeleteMessageAttachmentHandler : IAuthenticatedHandler<Delet
         var scope = new ConversationMessageEditDeleteScope(
             request.ConversationId,
             _conversationRepository,
-            _participantRepository,
             _conversationMessageNotifier,
             _scopeLogger);
 

--- a/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageEndpoint.cs
@@ -47,7 +47,7 @@ public static class EditMessageEndpoint
 
         var callerId = httpContext.GetRequiredAuthenticatedUserId();
 
-        var response = await handler.HandleAsync(new EditConversationMessageInput(conversationId, messageId, request.Content), callerId, cancellationToken);
+        var response = await handler.HandleAsync(new EditConversationMessageInput(conversationId, messageId, request.Content, request.MentionedUserIds), callerId, cancellationToken);
         return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageEndpoint.cs
@@ -29,7 +29,9 @@ public static class EditMessageEndpoint
                 ApplicationErrorCodes.Conversation.NotFound,
                 ApplicationErrorCodes.Conversation.AccessDenied,
                 ApplicationErrorCodes.Message.NotFound,
-                ApplicationErrorCodes.Message.EditForbidden);
+                ApplicationErrorCodes.Message.EditForbidden,
+                ApplicationErrorCodes.Message.MentionedUserNotFound,
+                ApplicationErrorCodes.Message.MentionedUserNotMember);
     }
 
     private static async Task<IResult> HandleAsync(

--- a/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageEndpoint.cs
@@ -18,7 +18,7 @@ public static class EditMessageEndpoint
             .WithTags("Conversations")
             .RequireAuthorization()
             .WithSummary("Edit a conversation message")
-            .WithDescription("Updates the content of a conversation message. Only the message author can edit their own messages.")
+            .WithDescription("Updates the content of a conversation message. Only the message author can edit their own messages. Omit `mentionedUserIds` to leave mentions unchanged; pass an empty array to clear all mentions; pass IDs to replace the mention set.")
             .Produces<EditMessageResponse>(StatusCodes.Status200OK)
             .ProducesErrors(
                 ApplicationErrorCodes.Common.ValidationFailed,

--- a/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageHandler.cs
@@ -9,22 +9,25 @@ using Microsoft.Extensions.Logging;
 
 namespace Harmonie.Application.Features.Conversations.EditMessage;
 
-public sealed record EditConversationMessageInput(ConversationId ConversationId, MessageId MessageId, string Content);
+public sealed record EditConversationMessageInput(ConversationId ConversationId, MessageId MessageId, string Content, IReadOnlyList<Guid>? MentionedUserIds = null);
 
 public sealed class EditMessageHandler : IAuthenticatedHandler<EditConversationMessageInput, EditMessageResponse>
 {
     private readonly IConversationRepository _conversationRepository;
+    private readonly IConversationParticipantRepository _participantRepository;
     private readonly IConversationMessageNotifier _conversationMessageNotifier;
     private readonly ILogger<ConversationMessageEditDeleteScope> _scopeLogger;
     private readonly MessageEditDeleteOrchestrator _orchestrator;
 
     public EditMessageHandler(
         IConversationRepository conversationRepository,
+        IConversationParticipantRepository participantRepository,
         IConversationMessageNotifier conversationMessageNotifier,
         ILogger<ConversationMessageEditDeleteScope> scopeLogger,
         MessageEditDeleteOrchestrator orchestrator)
     {
         _conversationRepository = conversationRepository;
+        _participantRepository = participantRepository;
         _conversationMessageNotifier = conversationMessageNotifier;
         _scopeLogger = scopeLogger;
         _orchestrator = orchestrator;
@@ -38,6 +41,7 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditConversationM
         var scope = new ConversationMessageEditDeleteScope(
             request.ConversationId,
             _conversationRepository,
+            _participantRepository,
             _conversationMessageNotifier,
             _scopeLogger);
 
@@ -46,6 +50,7 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditConversationM
             new MessageScope.Conversation(request.ConversationId),
             request.MessageId,
             request.Content,
+            request.MentionedUserIds,
             currentUserId,
             cancellationToken);
 
@@ -58,6 +63,7 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditConversationM
             AuthorUserId: result.Data.AuthorUserId,
             Content: result.Data.Content,
             Attachments: result.Data.Attachments,
+            MentionedUserIds: result.Data.MentionedUserIds,
             CreatedAtUtc: result.Data.CreatedAtUtc,
             UpdatedAtUtc: result.Data.UpdatedAtUtc));
     }

--- a/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageHandler.cs
@@ -14,20 +14,17 @@ public sealed record EditConversationMessageInput(ConversationId ConversationId,
 public sealed class EditMessageHandler : IAuthenticatedHandler<EditConversationMessageInput, EditMessageResponse>
 {
     private readonly IConversationRepository _conversationRepository;
-    private readonly IConversationParticipantRepository _participantRepository;
     private readonly IConversationMessageNotifier _conversationMessageNotifier;
     private readonly ILogger<ConversationMessageEditDeleteScope> _scopeLogger;
     private readonly MessageEditDeleteOrchestrator _orchestrator;
 
     public EditMessageHandler(
         IConversationRepository conversationRepository,
-        IConversationParticipantRepository participantRepository,
         IConversationMessageNotifier conversationMessageNotifier,
         ILogger<ConversationMessageEditDeleteScope> scopeLogger,
         MessageEditDeleteOrchestrator orchestrator)
     {
         _conversationRepository = conversationRepository;
-        _participantRepository = participantRepository;
         _conversationMessageNotifier = conversationMessageNotifier;
         _scopeLogger = scopeLogger;
         _orchestrator = orchestrator;
@@ -41,7 +38,6 @@ public sealed class EditMessageHandler : IAuthenticatedHandler<EditConversationM
         var scope = new ConversationMessageEditDeleteScope(
             request.ConversationId,
             _conversationRepository,
-            _participantRepository,
             _conversationMessageNotifier,
             _scopeLogger);
 

--- a/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageRequest.cs
+++ b/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageRequest.cs
@@ -1,3 +1,3 @@
 namespace Harmonie.Application.Features.Conversations.EditMessage;
 
-public sealed record EditMessageRequest(string Content);
+public sealed record EditMessageRequest(string Content, IReadOnlyList<Guid>? MentionedUserIds = null);

--- a/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageResponse.cs
+++ b/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageResponse.cs
@@ -9,5 +9,6 @@ public sealed record EditMessageResponse(
     Guid AuthorUserId,
     string? Content,
     IReadOnlyList<MessageAttachmentDto> Attachments,
+    IReadOnlyList<Guid> MentionedUserIds,
     DateTime CreatedAtUtc,
     DateTime? UpdatedAtUtc);

--- a/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageValidator.cs
+++ b/src/Harmonie.Application/Features/Conversations/EditMessage/EditMessageValidator.cs
@@ -9,5 +9,20 @@ public sealed class EditMessageValidator : AbstractValidator<EditMessageRequest>
         RuleFor(x => x.Content)
             .NotEmpty()
             .WithMessage("Message content is required");
+
+        RuleForEach(x => x.MentionedUserIds)
+            .NotEqual(Guid.Empty)
+            .WithMessage("Mentioned user IDs must be valid non-empty GUIDs")
+            .When(x => x.MentionedUserIds is not null);
+
+        RuleFor(x => x.MentionedUserIds)
+            .Must(ids => ids is null || ids.Distinct().Count() == ids.Count)
+            .WithMessage("Mentioned user IDs must be unique")
+            .When(x => x.MentionedUserIds is not null);
+
+        RuleFor(x => x.MentionedUserIds)
+            .Must(ids => ids is null || ids.Count <= 50)
+            .WithMessage("A message can mention at most 50 users")
+            .When(x => x.MentionedUserIds is not null);
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/Messages/ConversationMessageEditDeleteScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/Messages/ConversationMessageEditDeleteScope.cs
@@ -81,6 +81,7 @@ public sealed class ConversationMessageEditDeleteScope : IMessageEditDeleteScope
         Context context,
         MessageId messageId,
         string? content,
+        IReadOnlyList<Guid> mentionedUserIds,
         DateTime updatedAtUtc,
         CancellationToken ct)
     {
@@ -90,6 +91,7 @@ public sealed class ConversationMessageEditDeleteScope : IMessageEditDeleteScope
             context.ConversationName,
             context.ConversationType.ToString(),
             content,
+            mentionedUserIds,
             updatedAtUtc);
 
         await BestEffortNotificationHelper.TryNotifyAsync(

--- a/src/Harmonie.Application/Features/Conversations/Messages/ConversationMessageEditDeleteScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/Messages/ConversationMessageEditDeleteScope.cs
@@ -64,6 +64,9 @@ public sealed class ConversationMessageEditDeleteScope : IMessageEditDeleteScope
         Context context,
         CancellationToken ct)
     {
+        if (userIds.Count == 0)
+            return Result.Success();
+
         var participants = await _participantRepository.GetByConversationIdAsync(context.ConversationId, ct);
         var participantIds = participants.Select(p => p.UserId).ToHashSet();
         foreach (var userId in userIds)

--- a/src/Harmonie.Application/Features/Conversations/Messages/ConversationMessageEditDeleteScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/Messages/ConversationMessageEditDeleteScope.cs
@@ -1,6 +1,7 @@
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Conversations;
+using Harmonie.Domain.Common;
 using Harmonie.Domain.Entities.Conversations;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
@@ -23,17 +24,20 @@ public sealed class ConversationMessageEditDeleteScope : IMessageEditDeleteScope
 
     private readonly ConversationId _conversationId;
     private readonly IConversationRepository _conversationRepository;
+    private readonly IConversationParticipantRepository _participantRepository;
     private readonly IConversationMessageNotifier _conversationMessageNotifier;
     private readonly ILogger<ConversationMessageEditDeleteScope> _logger;
 
     public ConversationMessageEditDeleteScope(
         ConversationId conversationId,
         IConversationRepository conversationRepository,
+        IConversationParticipantRepository participantRepository,
         IConversationMessageNotifier conversationMessageNotifier,
         ILogger<ConversationMessageEditDeleteScope> logger)
     {
         _conversationId = conversationId;
         _conversationRepository = conversationRepository;
+        _participantRepository = participantRepository;
         _conversationMessageNotifier = conversationMessageNotifier;
         _logger = logger;
     }
@@ -54,6 +58,24 @@ public sealed class ConversationMessageEditDeleteScope : IMessageEditDeleteScope
     // Conversations have no admin role; only the author can delete their own messages.
     public bool CanDeleteOthersMessages(Context context)
         => false;
+
+    public async Task<Result> ValidateMentionedUsersAsync(
+        IReadOnlyCollection<UserId> userIds,
+        Context context,
+        CancellationToken ct)
+    {
+        var participants = await _participantRepository.GetByConversationIdAsync(context.ConversationId, ct);
+        var participantIds = participants.Select(p => p.UserId).ToHashSet();
+        foreach (var userId in userIds)
+        {
+            if (!participantIds.Contains(userId))
+            {
+                return Result.Failure($"User {userId.Value} is not a participant of conversation {context.ConversationId.Value}");
+            }
+        }
+
+        return Result.Success();
+    }
 
     public async Task NotifyMessageUpdatedAsync(
         Context context,

--- a/src/Harmonie.Application/Features/Conversations/Messages/ConversationMessageEditDeleteScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/Messages/ConversationMessageEditDeleteScope.cs
@@ -20,64 +20,68 @@ public sealed class ConversationMessageEditDeleteScope : IMessageEditDeleteScope
     public sealed record Context(
         ConversationId ConversationId,
         string? ConversationName,
-        ConversationType ConversationType) : ScopeContext;
+        ConversationType ConversationType,
+        IReadOnlyList<ConversationParticipant> AllParticipants) : ScopeContext;
 
     private readonly ConversationId _conversationId;
     private readonly IConversationRepository _conversationRepository;
-    private readonly IConversationParticipantRepository _participantRepository;
     private readonly IConversationMessageNotifier _conversationMessageNotifier;
     private readonly ILogger<ConversationMessageEditDeleteScope> _logger;
 
     public ConversationMessageEditDeleteScope(
         ConversationId conversationId,
         IConversationRepository conversationRepository,
-        IConversationParticipantRepository participantRepository,
         IConversationMessageNotifier conversationMessageNotifier,
         ILogger<ConversationMessageEditDeleteScope> logger)
     {
         _conversationId = conversationId;
         _conversationRepository = conversationRepository;
-        _participantRepository = participantRepository;
         _conversationMessageNotifier = conversationMessageNotifier;
         _logger = logger;
     }
 
     public async Task<AuthorizationResult<Context>> AuthorizeAsync(UserId caller, CancellationToken ct)
     {
-        var result = await ConversationScopeAuthorizer.AuthorizeAsync(_conversationRepository, _conversationId, caller, ct);
-        if (result is ConversationAuthResult.Denied denied)
-            return new AuthorizationResult<Context>.Denied(denied.Error);
+        var access = await _conversationRepository.GetByIdWithAllParticipantsAsync(_conversationId, caller, ct);
+        if (access is null)
+        {
+            return new AuthorizationResult<Context>.Denied(new ApplicationError(
+                ApplicationErrorCodes.Conversation.NotFound,
+                "Conversation was not found"));
+        }
+        if (access.CallerParticipant is null)
+        {
+            return new AuthorizationResult<Context>.Denied(new ApplicationError(
+                ApplicationErrorCodes.Conversation.AccessDenied,
+                "You do not have access to this conversation"));
+        }
 
-        var access = ((ConversationAuthResult.Authorized)result).Context;
         return new AuthorizationResult<Context>.Authorized(new Context(
             _conversationId,
             access.Conversation.Name,
-            access.Conversation.Type));
+            access.Conversation.Type,
+            access.AllParticipants));
     }
 
     // Conversations have no admin role; only the author can delete their own messages.
     public bool CanDeleteOthersMessages(Context context)
         => false;
 
-    public async Task<Result> ValidateMentionedUsersAsync(
+    public Task<Result> ValidateMentionedUsersAsync(
         IReadOnlyCollection<UserId> userIds,
         Context context,
         CancellationToken ct)
     {
-        if (userIds.Count == 0)
-            return Result.Success();
-
-        var participants = await _participantRepository.GetByConversationIdAsync(context.ConversationId, ct);
-        var participantIds = participants.Select(p => p.UserId).ToHashSet();
+        var participantIds = context.AllParticipants.Select(p => p.UserId).ToHashSet();
         foreach (var userId in userIds)
         {
             if (!participantIds.Contains(userId))
             {
-                return Result.Failure($"User {userId.Value} is not a participant of conversation {context.ConversationId.Value}");
+                return Task.FromResult(Result.Failure($"User {userId.Value} is not a participant of conversation {context.ConversationId.Value}"));
             }
         }
 
-        return Result.Success();
+        return Task.FromResult(Result.Success());
     }
 
     public async Task NotifyMessageUpdatedAsync(

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/ConversationSendMessageScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/ConversationSendMessageScope.cs
@@ -2,6 +2,7 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Services;
+using Harmonie.Domain.Common;
 using Harmonie.Domain.Entities.Conversations;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
@@ -89,6 +90,23 @@ public sealed class ConversationSendMessageScope : ISendMessageScope<Conversatio
             p.Unhide();
 
         await _participantRepository.UpdateRangeAsync(hidden, ct);
+    }
+
+    public Task<Result> ValidateMentionedUsersAsync(
+        IReadOnlyCollection<UserId> userIds,
+        Context context,
+        CancellationToken ct)
+    {
+        var participantIds = context.AllParticipants.Select(p => p.UserId).ToHashSet();
+        foreach (var userId in userIds)
+        {
+            if (!participantIds.Contains(userId))
+            {
+                return Task.FromResult(Result.Failure($"User {userId.Value} is not a participant of conversation {context.ConversationId.Value}"));
+            }
+        }
+
+        return Task.FromResult(Result.Success());
     }
 
     public async Task NotifyMessageCreatedAsync(

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/ConversationSendMessageScope.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/ConversationSendMessageScope.cs
@@ -127,6 +127,7 @@ public sealed class ConversationSendMessageScope : ISendMessageScope<Conversatio
             message.Content?.Value,
             attachments,
             replyTo,
+            message.MentionedUserIds.Select(id => id.Value).ToArray(),
             message.CreatedAtUtc);
 
         await BestEffortNotificationHelper.TryNotifyAsync(

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageEndpoint.cs
@@ -45,7 +45,7 @@ public static class SendMessageEndpoint
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
-        var response = await handler.HandleAsync(new SendConversationMessageInput(conversationId, request.Content, request.AttachmentFileIds, request.ReplyToMessageId), currentUserId, cancellationToken);
+        var response = await handler.HandleAsync(new SendConversationMessageInput(conversationId, request.Content, request.AttachmentFileIds, request.ReplyToMessageId, request.MentionedUserIds), currentUserId, cancellationToken);
         return response.ToCreatedHttpResult(
             data => $"/api/conversations/{data.ConversationId}/messages/{data.MessageId}", httpContext);
     }

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageEndpoint.cs
@@ -28,7 +28,9 @@ public static class SendMessageEndpoint
                 ApplicationErrorCodes.Message.ContentEmpty,
                 ApplicationErrorCodes.Message.ContentTooLong,
                 ApplicationErrorCodes.Conversation.NotFound,
-                ApplicationErrorCodes.Conversation.AccessDenied);
+                ApplicationErrorCodes.Conversation.AccessDenied,
+                ApplicationErrorCodes.Message.MentionedUserNotFound,
+                ApplicationErrorCodes.Message.MentionedUserNotMember);
     }
 
     private static async Task<IResult> HandleAsync(

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageEndpoint.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageEndpoint.cs
@@ -18,7 +18,7 @@ public static class SendMessageEndpoint
             .RequireAuthorization()
             .RequireRateLimiting("message-post")
             .WithSummary("Send a conversation message")
-            .WithDescription("Posts a message in a conversation where the authenticated user is a participant. Optional `attachmentFileIds` values must reference files previously uploaded with attachment purpose.")
+            .WithDescription("Posts a message in a conversation where the authenticated user is a participant. Optional `attachmentFileIds` values must reference files previously uploaded with attachment purpose. `mentionedUserIds` can be omitted or empty for no mentions; mentioned users must be conversation participants.")
             .Produces<SendMessageResponse>(StatusCodes.Status201Created)
             .Produces(StatusCodes.Status429TooManyRequests)
             .ProducesErrors(

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageHandler.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Harmonie.Application.Features.Conversations.SendMessage;
 
-public sealed record SendConversationMessageInput(ConversationId ConversationId, string? Content, IReadOnlyList<Guid>? AttachmentFileIds = null, Guid? ReplyToMessageId = null);
+public sealed record SendConversationMessageInput(ConversationId ConversationId, string? Content, IReadOnlyList<Guid>? AttachmentFileIds = null, Guid? ReplyToMessageId = null, IReadOnlyList<Guid>? MentionedUserIds = null);
 
 public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationMessageInput, SendMessageResponse>
 {
@@ -55,6 +55,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
             request.Content,
             request.AttachmentFileIds,
             request.ReplyToMessageId,
+            request.MentionedUserIds,
             currentUserId,
             cancellationToken);
 
@@ -68,6 +69,7 @@ public sealed class SendMessageHandler : IAuthenticatedHandler<SendConversationM
             result.Data.Content,
             result.Data.Attachments,
             result.Data.ReplyTo,
+            result.Data.MentionedUserIds,
             result.Data.CreatedAtUtc));
     }
 }

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageRequest.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageRequest.cs
@@ -3,4 +3,5 @@ namespace Harmonie.Application.Features.Conversations.SendMessage;
 public sealed record SendMessageRequest(
     string? Content,
     IReadOnlyList<Guid>? AttachmentFileIds = null,
-    Guid? ReplyToMessageId = null);
+    Guid? ReplyToMessageId = null,
+    IReadOnlyList<Guid>? MentionedUserIds = null);

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageResponse.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageResponse.cs
@@ -10,4 +10,5 @@ public sealed record SendMessageResponse(
     string? Content,
     IReadOnlyList<MessageAttachmentDto> Attachments,
     ReplyPreviewDto? ReplyTo,
+    IReadOnlyList<Guid> MentionedUserIds,
     DateTime CreatedAtUtc);

--- a/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageValidator.cs
+++ b/src/Harmonie.Application/Features/Conversations/SendMessage/SendMessageValidator.cs
@@ -20,5 +20,20 @@ public sealed class SendMessageValidator : AbstractValidator<SendMessageRequest>
             .Must(ids => ids is null || ids.Distinct().Count() == ids.Count)
             .WithMessage("Attachment file IDs must be unique")
             .When(x => x.AttachmentFileIds is not null);
+
+        RuleForEach(x => x.MentionedUserIds)
+            .NotEqual(Guid.Empty)
+            .WithMessage("Mentioned user IDs must be valid non-empty GUIDs")
+            .When(x => x.MentionedUserIds is not null);
+
+        RuleFor(x => x.MentionedUserIds)
+            .Must(ids => ids is null || ids.Distinct().Count() == ids.Count)
+            .WithMessage("Mentioned user IDs must be unique")
+            .When(x => x.MentionedUserIds is not null);
+
+        RuleFor(x => x.MentionedUserIds)
+            .Must(ids => ids is null || ids.Count <= 50)
+            .WithMessage("A message can mention at most 50 users")
+            .When(x => x.MentionedUserIds is not null);
     }
 }

--- a/src/Harmonie.Application/Interfaces/Channels/ITextChannelNotifier.cs
+++ b/src/Harmonie.Application/Interfaces/Channels/ITextChannelNotifier.cs
@@ -37,6 +37,7 @@ public sealed record TextChannelMessageCreatedNotification(
     string? Content,
     IReadOnlyList<MessageAttachmentDto> Attachments,
     ReplyPreviewDto? ReplyTo,
+    IReadOnlyList<Guid> MentionedUserIds,
     DateTime CreatedAtUtc);
 
 public sealed record TextChannelMessageUpdatedNotification(
@@ -46,6 +47,7 @@ public sealed record TextChannelMessageUpdatedNotification(
     GuildId GuildId,
     string GuildName,
     string? Content,
+    IReadOnlyList<Guid> MentionedUserIds,
     DateTime UpdatedAtUtc);
 
 public sealed record TextChannelMessageDeletedNotification(

--- a/src/Harmonie.Application/Interfaces/Conversations/IConversationMessageNotifier.cs
+++ b/src/Harmonie.Application/Interfaces/Conversations/IConversationMessageNotifier.cs
@@ -35,6 +35,7 @@ public sealed record ConversationMessageCreatedNotification(
     string? Content,
     IReadOnlyList<MessageAttachmentDto> Attachments,
     ReplyPreviewDto? ReplyTo,
+    IReadOnlyList<Guid> MentionedUserIds,
     DateTime CreatedAtUtc);
 
 public sealed record ConversationMessageUpdatedNotification(
@@ -43,6 +44,7 @@ public sealed record ConversationMessageUpdatedNotification(
     string? ConversationName,
     string ConversationType,
     string? Content,
+    IReadOnlyList<Guid> MentionedUserIds,
     DateTime UpdatedAtUtc);
 
 public sealed record ConversationMessageDeletedNotification(

--- a/src/Harmonie.Application/Interfaces/Guilds/IGuildMemberRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Guilds/IGuildMemberRepository.cs
@@ -13,6 +13,14 @@ public interface IGuildMemberRepository
         UserId userId,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Returns the subset of userIds that are members of the guild.
+    /// </summary>
+    Task<IReadOnlySet<UserId>> GetMembersInAsync(
+        GuildId guildId,
+        IReadOnlyCollection<UserId> userIds,
+        CancellationToken cancellationToken = default);
+
     Task<GuildMemberUserRole?> GetUserWithRoleAsync(
         GuildId guildId,
         UserId userId,

--- a/src/Harmonie.Application/Interfaces/Messages/IMessageRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Messages/IMessageRepository.cs
@@ -56,6 +56,30 @@ public interface IMessageRepository
         UserId authorUserId,
         int days,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Persist mention rows for a message. Must be called inside the same transaction as the message insert.
+    /// </summary>
+    Task AddMentionsAsync(
+        MessageId messageId,
+        IReadOnlyCollection<UserId> mentionedUserIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Replace the mention set for a message atomically (delete all existing, insert new).
+    /// Must be called inside a transaction.
+    /// </summary>
+    Task ReplaceMentionsAsync(
+        MessageId messageId,
+        IReadOnlyCollection<UserId> mentionedUserIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get mentioned user IDs for a set of messages. Returns empty for messages without mentions.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, IReadOnlyList<Guid>>> GetMentionedUserIdsByMessageIdAsync(
+        IReadOnlyCollection<Guid> messageIds,
+        CancellationToken cancellationToken = default);
 }
 
 public sealed record MessageCursor(
@@ -70,6 +94,7 @@ public sealed record MessagePage(
     IReadOnlyDictionary<Guid, IReadOnlyList<LinkPreviewDto>>? LinkPreviewsByMessageId = null,
     IReadOnlySet<Guid>? PinnedMessageIds = null,
     IReadOnlyDictionary<Guid, ReplyPreviewDto>? ReplyPreviewsByTargetMessageId = null,
+    IReadOnlyDictionary<Guid, IReadOnlyList<Guid>>? MentionedUserIdsByMessageId = null,
     MessageReadState? LastReadState = null);
 
 public sealed record SearchGuildMessagesQuery(

--- a/src/Harmonie.Domain/Entities/Messages/Message.cs
+++ b/src/Harmonie.Domain/Entities/Messages/Message.cs
@@ -8,6 +8,8 @@ namespace Harmonie.Domain.Entities.Messages;
 
 public sealed class Message : Entity<MessageId>
 {
+    public const int MaxMentionedUsers = 50;
+
     public MessageScope Scope { get; private set; }
 
     public UserId AuthorUserId { get; private set; }
@@ -18,6 +20,8 @@ public sealed class Message : Entity<MessageId>
 
     public DateTime? DeletedAtUtc { get; private set; }
 
+    public IReadOnlyCollection<UserId> MentionedUserIds { get; private set; }
+
     private Message(
         MessageId id,
         MessageScope scope,
@@ -26,7 +30,8 @@ public sealed class Message : Entity<MessageId>
         MessageContent? content,
         DateTime createdAtUtc,
         DateTime? updatedAtUtc,
-        DateTime? deletedAtUtc)
+        DateTime? deletedAtUtc,
+        IReadOnlyCollection<UserId> mentionedUserIds)
     {
         Id = id;
         Scope = scope;
@@ -36,18 +41,28 @@ public sealed class Message : Entity<MessageId>
         CreatedAtUtc = createdAtUtc;
         UpdatedAtUtc = updatedAtUtc;
         DeletedAtUtc = deletedAtUtc;
+        MentionedUserIds = mentionedUserIds;
     }
 
     public static Result<Message> Create(
         MessageScope scope,
         UserId authorUserId,
         MessageContent? content,
-        MessageId? replyToMessageId = null)
+        MessageId? replyToMessageId = null,
+        IReadOnlyCollection<UserId>? mentionedUserIds = null)
     {
         if (scope is null)
             return Result.Failure<Message>("Message scope is required");
         if (authorUserId is null)
             return Result.Failure<Message>("Author user ID is required");
+
+        var mentions = mentionedUserIds ?? Array.Empty<UserId>();
+
+        if (mentions.Count > MaxMentionedUsers)
+            return Result.Failure<Message>($"A message can mention at most {MaxMentionedUsers} users");
+
+        if (mentions.Distinct().Count() != mentions.Count)
+            return Result.Failure<Message>("Mentioned user IDs must be distinct");
 
         return Result.Success(new Message(
             MessageId.New(),
@@ -57,7 +72,8 @@ public sealed class Message : Entity<MessageId>
             content,
             DateTime.UtcNow,
             updatedAtUtc: null,
-            deletedAtUtc: null));
+            deletedAtUtc: null,
+            mentionedUserIds: mentions.ToArray()));
     }
 
     public Result UpdateContent(MessageContent newContent)
@@ -85,7 +101,8 @@ public sealed class Message : Entity<MessageId>
         MessageContent? content,
         DateTime createdAtUtc,
         DateTime? updatedAtUtc,
-        DateTime? deletedAtUtc)
+        DateTime? deletedAtUtc,
+        IReadOnlyCollection<UserId>? mentionedUserIds = null)
     {
         ArgumentNullException.ThrowIfNull(id);
         ArgumentNullException.ThrowIfNull(scope);
@@ -99,6 +116,7 @@ public sealed class Message : Entity<MessageId>
             content,
             createdAtUtc,
             updatedAtUtc,
-            deletedAtUtc);
+            deletedAtUtc,
+            mentionedUserIds ?? Array.Empty<UserId>());
     }
 }

--- a/src/Harmonie.Domain/Entities/Messages/Message.cs
+++ b/src/Harmonie.Domain/Entities/Messages/Message.cs
@@ -83,6 +83,26 @@ public sealed class Message : Entity<MessageId>
         return Result.Success();
     }
 
+    /// <summary>
+    /// Replaces the mention set and marks the entity as updated.
+    /// Enforces domain invariants: distinct IDs, max count.
+    /// Pass null or empty to clear all mentions.
+    /// </summary>
+    public Result ReplaceMentions(IReadOnlyCollection<UserId>? mentionedUserIds)
+    {
+        var mentions = mentionedUserIds ?? Array.Empty<UserId>();
+
+        if (mentions.Count > MaxMentionedUsers)
+            return Result.Failure($"A message can mention at most {MaxMentionedUsers} users");
+
+        if (new HashSet<UserId>(mentions).Count != mentions.Count)
+            return Result.Failure("Mentioned user IDs must be distinct");
+
+        MentionedUserIds = mentions.ToArray();
+        MarkAsUpdated();
+        return Result.Success();
+    }
+
     public Result Delete()
     {
         if (DeletedAtUtc is not null)

--- a/src/Harmonie.Domain/Entities/Messages/Message.cs
+++ b/src/Harmonie.Domain/Entities/Messages/Message.cs
@@ -61,7 +61,7 @@ public sealed class Message : Entity<MessageId>
         if (mentions.Count > MaxMentionedUsers)
             return Result.Failure<Message>($"A message can mention at most {MaxMentionedUsers} users");
 
-        if (mentions.Distinct().Count() != mentions.Count)
+        if (new HashSet<UserId>(mentions).Count != mentions.Count)
             return Result.Failure<Message>("Mentioned user IDs must be distinct");
 
         return Result.Success(new Message(
@@ -117,6 +117,6 @@ public sealed class Message : Entity<MessageId>
             createdAtUtc,
             updatedAtUtc,
             deletedAtUtc,
-            mentionedUserIds ?? Array.Empty<UserId>());
+            (mentionedUserIds is not null ? mentionedUserIds.ToArray() : Array.Empty<UserId>()));
     }
 }

--- a/src/Harmonie.Domain/Entities/Messages/Message.cs
+++ b/src/Harmonie.Domain/Entities/Messages/Message.cs
@@ -57,12 +57,9 @@ public sealed class Message : Entity<MessageId>
             return Result.Failure<Message>("Author user ID is required");
 
         var mentions = mentionedUserIds ?? Array.Empty<UserId>();
-
-        if (mentions.Count > MaxMentionedUsers)
-            return Result.Failure<Message>($"A message can mention at most {MaxMentionedUsers} users");
-
-        if (new HashSet<UserId>(mentions).Count != mentions.Count)
-            return Result.Failure<Message>("Mentioned user IDs must be distinct");
+        var validationError = ValidateMentions(mentions);
+        if (validationError is not null)
+            return Result.Failure<Message>(validationError);
 
         return Result.Success(new Message(
             MessageId.New(),
@@ -91,16 +88,24 @@ public sealed class Message : Entity<MessageId>
     public Result ReplaceMentions(IReadOnlyCollection<UserId>? mentionedUserIds)
     {
         var mentions = mentionedUserIds ?? Array.Empty<UserId>();
-
-        if (mentions.Count > MaxMentionedUsers)
-            return Result.Failure($"A message can mention at most {MaxMentionedUsers} users");
-
-        if (new HashSet<UserId>(mentions).Count != mentions.Count)
-            return Result.Failure("Mentioned user IDs must be distinct");
+        var validationError = ValidateMentions(mentions);
+        if (validationError is not null)
+            return Result.Failure(validationError);
 
         MentionedUserIds = mentions.ToArray();
         MarkAsUpdated();
         return Result.Success();
+    }
+
+    private static string? ValidateMentions(IReadOnlyCollection<UserId> mentions)
+    {
+        if (mentions.Count > MaxMentionedUsers)
+            return $"A message can mention at most {MaxMentionedUsers} users";
+
+        if (new HashSet<UserId>(mentions).Count != mentions.Count)
+            return "Mentioned user IDs must be distinct";
+
+        return null;
     }
 
     public Result Delete()

--- a/src/Harmonie.Infrastructure/Persistence/Guilds/GuildMemberRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Guilds/GuildMemberRepository.cs
@@ -48,6 +48,36 @@ public sealed class GuildMemberRepository : IGuildMemberRepository
         return await connection.ExecuteScalarAsync<bool>(command);
     }
 
+    public async Task<IReadOnlySet<UserId>> GetMembersInAsync(
+        GuildId guildId,
+        IReadOnlyCollection<UserId> userIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (userIds.Count == 0)
+            return new HashSet<UserId>();
+
+        const string sql = """
+                           SELECT user_id
+                           FROM guild_members
+                           WHERE guild_id = @GuildId
+                             AND user_id = ANY(@UserIds::uuid[])
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new
+            {
+                GuildId = guildId.Value,
+                UserIds = userIds.Select(id => id.Value).ToArray()
+            },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        var rows = await connection.QueryAsync<Guid>(command);
+        return rows.Select(UserId.From).ToHashSet();
+    }
+
     public async Task<GuildMemberUserRole?> GetUserWithRoleAsync(
         GuildId guildId,
         UserId userId,

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessagePaginationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessagePaginationRepository.cs
@@ -160,6 +160,16 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
                        ORDER BY t.created_at_utc DESC, t.id DESC
                        LIMIT @Take)
                    ORDER BY m.id;
+
+                   SELECT mm.message_id, mm.mentioned_user_id
+                   FROM message_mentions mm
+                   WHERE mm.message_id IN (
+                       SELECT id FROM messages
+                       WHERE channel_id = @ChannelId
+                         AND deleted_at_utc IS NULL
+                         {cursorFilter}
+                       ORDER BY created_at_utc DESC, id DESC
+                       LIMIT @Take);
                    """;
 
         var parameters = new DynamicParameters();
@@ -216,6 +226,13 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
                     r.IsDeleted,
                     r.DeletedAtUtc));
 
+        var mentionRows = await multi.ReadAsync<(Guid messageId, Guid mentionedUserId)>();
+        var mentionedUserIdsByMessageId = mentionRows
+            .GroupBy(r => r.messageId)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<Guid>)g.Select(r => r.mentionedUserId).Distinct().ToArray());
+
         var items = pageRows
             .Select(row => MessageRepositoryHelpers.MapToMessage(row))
             .OrderBy(x => x.CreatedAtUtc)
@@ -239,7 +256,7 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
                 readStateRow.ReadAtUtc);
         }
 
-        return new MessagePage(items, nextCursor, reactionsByMessageId, attachmentsByMessageId, linkPreviewsByMessageId, pinnedMessageIds, replyPreviewsByTargetMessageId, lastReadState);
+        return new MessagePage(items, nextCursor, reactionsByMessageId, attachmentsByMessageId, linkPreviewsByMessageId, pinnedMessageIds, replyPreviewsByTargetMessageId, mentionedUserIdsByMessageId, lastReadState);
     }
 
     public async Task<MessagePage> GetConversationPageAsync(
@@ -381,6 +398,16 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
                        ORDER BY t.created_at_utc DESC, t.id DESC
                        LIMIT @Take)
                    ORDER BY m.id;
+
+                   SELECT mm.message_id, mm.mentioned_user_id
+                   FROM message_mentions mm
+                   WHERE mm.message_id IN (
+                       SELECT id FROM messages
+                       WHERE conversation_id = @ConversationId
+                         AND deleted_at_utc IS NULL
+                         {cursorFilter}
+                       ORDER BY created_at_utc DESC, id DESC
+                       LIMIT @Take);
                    """;
 
         var parameters = new DynamicParameters();
@@ -408,6 +435,7 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
         var linkPreviewRows = (await multi.ReadAsync<MessageLinkPreviewRow>()).ToArray();
         var pinnedRows = (await multi.ReadAsync<PinnedMessageIdRow>()).ToArray();
         var replyPreviewRows = (await multi.ReadAsync<ReplyPreviewRow>()).ToArray();
+        var mentionRows = await multi.ReadAsync<(Guid messageId, Guid mentionedUserId)>();
 
         var hasMore = rows.Length > limit;
         var pageRows = hasMore ? rows.Take(limit).ToArray() : rows;
@@ -437,6 +465,12 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
                     r.IsDeleted,
                     r.DeletedAtUtc));
 
+        var mentionedUserIdsByMessageId = mentionRows
+            .GroupBy(r => r.messageId)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<Guid>)g.Select(r => r.mentionedUserId).Distinct().ToArray());
+
         var items = pageRows
             .Select(row => MessageRepositoryHelpers.MapToMessage(row))
             .OrderBy(x => x.CreatedAtUtc)
@@ -460,7 +494,7 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
                 readStateRow.ReadAtUtc);
         }
 
-        return new MessagePage(items, nextCursor, reactionsByMessageId, attachmentsByMessageId, linkPreviewsByMessageId, pinnedMessageIds, replyPreviewsByTargetMessageId, lastReadState);
+        return new MessagePage(items, nextCursor, reactionsByMessageId, attachmentsByMessageId, linkPreviewsByMessageId, pinnedMessageIds, replyPreviewsByTargetMessageId, mentionedUserIdsByMessageId, lastReadState);
     }
 
     private sealed class ReadStateRow

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessagePaginationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessagePaginationRepository.cs
@@ -234,7 +234,13 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
                 g => (IReadOnlyList<Guid>)g.Select(r => r.mentionedUserId).Distinct().ToArray());
 
         var items = pageRows
-            .Select(row => MessageRepositoryHelpers.MapToMessage(row))
+            .Select(row =>
+            {
+                mentionedUserIdsByMessageId.TryGetValue(row.Id, out var mentionIds);
+                return MessageRepositoryHelpers.MapToMessage(
+                    row,
+                    mentionIds?.Select(UserId.From).ToArray());
+            })
             .OrderBy(x => x.CreatedAtUtc)
             .ThenBy(x => x.Id.Value)
             .ToArray();
@@ -472,7 +478,13 @@ internal sealed class MessagePaginationRepository : IMessagePaginationRepository
                 g => (IReadOnlyList<Guid>)g.Select(r => r.mentionedUserId).Distinct().ToArray());
 
         var items = pageRows
-            .Select(row => MessageRepositoryHelpers.MapToMessage(row))
+            .Select(row =>
+            {
+                mentionedUserIdsByMessageId.TryGetValue(row.Id, out var mentionIds);
+                return MessageRepositoryHelpers.MapToMessage(
+                    row,
+                    mentionIds?.Select(UserId.From).ToArray());
+            })
             .OrderBy(x => x.CreatedAtUtc)
             .ThenBy(x => x.Id.Value)
             .ToArray();

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepository.cs
@@ -328,24 +328,28 @@ internal sealed class MessageRepository : IMessageRepository
         IReadOnlyCollection<UserId> mentionedUserIds,
         CancellationToken cancellationToken = default)
     {
-        const string deleteSql = """
-                                 DELETE FROM message_mentions
-                                 WHERE message_id = @MessageId
-                                 """;
+        const string sql = """
+                           WITH deleted AS (
+                               DELETE FROM message_mentions
+                               WHERE message_id = @MessageId
+                           )
+                           INSERT INTO message_mentions (message_id, mentioned_user_id)
+                           SELECT @MessageId, unnest(@UserIds::uuid[])
+                           WHERE array_length(@UserIds::uuid[], 1) > 0
+                           """;
 
         var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
-        var deleteCommand = new CommandDefinition(
-            deleteSql,
-            new { MessageId = messageId.Value },
+        var command = new CommandDefinition(
+            sql,
+            new
+            {
+                MessageId = messageId.Value,
+                UserIds = mentionedUserIds.Select(id => id.Value).ToArray()
+            },
             transaction: _dbSession.Transaction,
             cancellationToken: cancellationToken);
 
-        await connection.ExecuteAsync(deleteCommand);
-
-        if (mentionedUserIds.Count > 0)
-        {
-            await AddMentionsAsync(messageId, mentionedUserIds, cancellationToken);
-        }
+        await connection.ExecuteAsync(command);
     }
 
     public async Task<IReadOnlyDictionary<Guid, IReadOnlyList<Guid>>> GetMentionedUserIdsByMessageIdAsync(

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepository.cs
@@ -290,4 +290,89 @@ internal sealed class MessageRepository : IMessageRepository
         return await connection.ExecuteAsync(command);
     }
 
+    public async Task AddMentionsAsync(
+        MessageId messageId,
+        IReadOnlyCollection<UserId> mentionedUserIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (mentionedUserIds.Count == 0)
+            return;
+
+        const string sql = """
+                           INSERT INTO message_mentions (message_id, mentioned_user_id)
+                           VALUES (@MessageId, @MentionedUserId)
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        foreach (var userId in mentionedUserIds)
+        {
+            var command = new CommandDefinition(
+                sql,
+                new
+                {
+                    MessageId = messageId.Value,
+                    MentionedUserId = userId.Value
+                },
+                transaction: _dbSession.Transaction,
+                cancellationToken: cancellationToken);
+
+            await connection.ExecuteAsync(command);
+        }
+    }
+
+    public async Task ReplaceMentionsAsync(
+        MessageId messageId,
+        IReadOnlyCollection<UserId> mentionedUserIds,
+        CancellationToken cancellationToken = default)
+    {
+        const string deleteSql = """
+                                 DELETE FROM message_mentions
+                                 WHERE message_id = @MessageId
+                                 """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var deleteCommand = new CommandDefinition(
+            deleteSql,
+            new { MessageId = messageId.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        await connection.ExecuteAsync(deleteCommand);
+
+        if (mentionedUserIds.Count > 0)
+        {
+            await AddMentionsAsync(messageId, mentionedUserIds, cancellationToken);
+        }
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, IReadOnlyList<Guid>>> GetMentionedUserIdsByMessageIdAsync(
+        IReadOnlyCollection<Guid> messageIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (messageIds.Count == 0)
+            return new Dictionary<Guid, IReadOnlyList<Guid>>();
+
+        const string sql = """
+                           SELECT message_id, mentioned_user_id
+                           FROM message_mentions
+                           WHERE message_id = ANY(@MessageIds)
+                           ORDER BY message_id
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new { MessageIds = messageIds.ToArray() },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        var rows = await connection.QueryAsync<(Guid messageId, Guid mentionedUserId)>(command);
+
+        return rows
+            .GroupBy(r => r.messageId)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<Guid>)g.Select(r => r.mentionedUserId).Distinct().ToArray());
+    }
+
 }

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepository.cs
@@ -300,24 +300,21 @@ internal sealed class MessageRepository : IMessageRepository
 
         const string sql = """
                            INSERT INTO message_mentions (message_id, mentioned_user_id)
-                           VALUES (@MessageId, @MentionedUserId)
+                           SELECT @MessageId, unnest(@UserIds::uuid[])
                            """;
 
         var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
-        foreach (var userId in mentionedUserIds)
-        {
-            var command = new CommandDefinition(
-                sql,
-                new
-                {
-                    MessageId = messageId.Value,
-                    MentionedUserId = userId.Value
-                },
-                transaction: _dbSession.Transaction,
-                cancellationToken: cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new
+            {
+                MessageId = messageId.Value,
+                UserIds = mentionedUserIds.Select(id => id.Value).ToArray()
+            },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
 
-            await connection.ExecuteAsync(command);
-        }
+        await connection.ExecuteAsync(command);
     }
 
     public async Task ReplaceMentionsAsync(

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepository.cs
@@ -333,6 +333,12 @@ internal sealed class MessageRepository : IMessageRepository
         await connection.ExecuteAsync(command);
     }
 
+    /// <remarks>
+    /// The CTE <c>WITH deleted AS (DELETE ...)</c> is always executed by PostgreSQL
+    /// even when <c>deleted</c> is not referenced in the main query (CTEs act as
+    /// optimization fences). The DELETE runs unconditionally; the INSERT is guarded
+    /// by <c>array_length</c> to skip when the array is empty.
+    /// </remarks>
     public async Task ReplaceMentionsAsync(
         MessageId messageId,
         IReadOnlyCollection<UserId> mentionedUserIds,

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepository.cs
@@ -290,6 +290,12 @@ internal sealed class MessageRepository : IMessageRepository
         return await connection.ExecuteAsync(command);
     }
 
+    /// <summary>
+    /// Persist mention rows for a message. The <paramref name="mentionedUserIds"/> collection
+    /// must contain distinct IDs; duplicates will cause a unique-constraint violation on the
+    /// composite PK (message_id, mentioned_user_id). Callers must ensure distinctness.
+    /// Must be called inside the same transaction as the message insert.
+    /// </summary>
     public async Task AddMentionsAsync(
         MessageId messageId,
         IReadOnlyCollection<UserId> mentionedUserIds,

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepository.cs
@@ -94,7 +94,11 @@ internal sealed class MessageRepository : IMessageRepository
                                   deleted_at_utc AS "DeletedAtUtc"
                            FROM messages
                            WHERE id = @MessageId
-                             AND deleted_at_utc IS NULL
+                             AND deleted_at_utc IS NULL;
+
+                           SELECT mentioned_user_id
+                           FROM message_mentions
+                           WHERE message_id = @MessageId;
                            """;
 
         var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
@@ -104,11 +108,17 @@ internal sealed class MessageRepository : IMessageRepository
             transaction: _dbSession.Transaction,
             cancellationToken: cancellationToken);
 
-        var row = await connection.QuerySingleOrDefaultAsync<MessageRow>(command);
+        using var multi = await connection.QueryMultipleAsync(command);
+        var row = await multi.ReadSingleOrDefaultAsync<MessageRow>();
         if (row is null)
             return null;
 
-        return MessageRepositoryHelpers.MapToMessage(row);
+        var mentionRows = (await multi.ReadAsync<Guid>()).ToArray();
+        var mentionUserIds = mentionRows.Length > 0
+            ? mentionRows.Select(UserId.From).ToArray()
+            : Array.Empty<UserId>();
+
+        return MessageRepositoryHelpers.MapToMessage(row, mentionUserIds);
     }
 
     public async Task UpdateAsync(

--- a/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepositoryHelpers.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Messages/MessageRepositoryHelpers.cs
@@ -43,7 +43,7 @@ internal static class MessageRepositoryHelpers
                     .ToArray());
     }
 
-    internal static Message MapToMessage(MessageRow row)
+    internal static Message MapToMessage(MessageRow row, IReadOnlyCollection<UserId>? mentionedUserIds = null)
     {
         MessageContent? messageContent = null;
         if (row.Content is not null)
@@ -68,7 +68,8 @@ internal static class MessageRepositoryHelpers
             messageContent,
             row.CreatedAtUtc,
             row.UpdatedAtUtc,
-            row.DeletedAtUtc);
+            row.DeletedAtUtc,
+            mentionedUserIds);
     }
 
     internal static MessageScope MapToScope(Guid? channelId, Guid? conversationId)

--- a/tests/Harmonie.API.IntegrationTests/MessageMentionsIntegrationTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/MessageMentionsIntegrationTests.cs
@@ -33,7 +33,7 @@ public sealed class MessageMentionsIntegrationTests : IClassFixture<HarmonieWebA
         var owner = await AuthTestHelper.RegisterAsync(_client);
         var member = await AuthTestHelper.RegisterAsync(_client);
 
-        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, "Mention Guild");
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, $"Mention{Guid.NewGuid():N}"[..16]);
         await GuildTestHelper.InviteMemberAsync(_client, guildId, owner.AccessToken, member.AccessToken);
 
         var (channelId, _) = await GetTextChannelAsync(_client, guildId, owner.AccessToken);
@@ -49,10 +49,27 @@ public sealed class MessageMentionsIntegrationTests : IClassFixture<HarmonieWebA
     }
 
     [Fact]
+    public async Task SendChannelMessage_SelfMention_ShouldSucceed()
+    {
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, $"Self{Guid.NewGuid():N}"[..16]);
+        var (channelId, _) = await GetTextChannelAsync(_client, guildId, owner.AccessToken);
+
+        var request = new { content = "noting myself", mentionedUserIds = new[] { owner.UserId } };
+        var response = await _client.SendAuthorizedPostAsync(
+            $"/api/channels/{channelId}/messages", request, owner.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var payload = await response.Content.ReadFromJsonAsync<ChannelSend.SendMessageResponse>(TestContext.Current.CancellationToken);
+        payload.Should().NotBeNull();
+        payload!.MentionedUserIds.Should().ContainSingle().Which.Should().Be(owner.UserId);
+    }
+
+    [Fact]
     public async Task SendChannelMessage_WithNonExistentMentionedUser_ShouldReturn404()
     {
         var owner = await AuthTestHelper.RegisterAsync(_client);
-        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, "Ghost Guild");
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, $"Ghost{Guid.NewGuid():N}"[..16]);
         var (channelId, _) = await GetTextChannelAsync(_client, guildId, owner.AccessToken);
 
         var request = new { content = "Hello @ghost", mentionedUserIds = new[] { Guid.NewGuid() } };
@@ -71,7 +88,7 @@ public sealed class MessageMentionsIntegrationTests : IClassFixture<HarmonieWebA
         var owner = await AuthTestHelper.RegisterAsync(_client);
         var outsider = await AuthTestHelper.RegisterAsync(_client);
 
-        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, "Exclusive Guild");
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, $"Excl{Guid.NewGuid():N}"[..16]);
         var (channelId, _) = await GetTextChannelAsync(_client, guildId, owner.AccessToken);
 
         var request = new { content = "Hello @outsider", mentionedUserIds = new[] { outsider.UserId } };
@@ -88,7 +105,7 @@ public sealed class MessageMentionsIntegrationTests : IClassFixture<HarmonieWebA
     public async Task SendChannelMessage_WithMoreThan50Mentions_ShouldReturn400()
     {
         var owner = await AuthTestHelper.RegisterAsync(_client);
-        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, "Mass Guild");
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, $"Mass{Guid.NewGuid():N}"[..16]);
         var (channelId, _) = await GetTextChannelAsync(_client, guildId, owner.AccessToken);
 
         var ids = Enumerable.Range(0, Message.MaxMentionedUsers + 1).Select(_ => Guid.NewGuid()).ToArray();
@@ -103,7 +120,7 @@ public sealed class MessageMentionsIntegrationTests : IClassFixture<HarmonieWebA
     public async Task SendChannelMessage_WithDuplicateMentions_ShouldReturn400()
     {
         var owner = await AuthTestHelper.RegisterAsync(_client);
-        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, "Dup Guild");
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, $"Dup{Guid.NewGuid():N}"[..16]);
         var (channelId, _) = await GetTextChannelAsync(_client, guildId, owner.AccessToken);
 
         var id = Guid.NewGuid();
@@ -120,7 +137,7 @@ public sealed class MessageMentionsIntegrationTests : IClassFixture<HarmonieWebA
         var owner = await AuthTestHelper.RegisterAsync(_client);
         var member = await AuthTestHelper.RegisterAsync(_client);
 
-        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, "Edit Mention Guild");
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, $"EditM{Guid.NewGuid():N}"[..16]);
         await GuildTestHelper.InviteMemberAsync(_client, guildId, owner.AccessToken, member.AccessToken);
 
         var (channelId, _) = await GetTextChannelAsync(_client, guildId, owner.AccessToken);
@@ -142,7 +159,7 @@ public sealed class MessageMentionsIntegrationTests : IClassFixture<HarmonieWebA
         var owner = await AuthTestHelper.RegisterAsync(_client);
         var member = await AuthTestHelper.RegisterAsync(_client);
 
-        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, "Clear Mention Guild");
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, $"Clear{Guid.NewGuid():N}"[..16]);
         await GuildTestHelper.InviteMemberAsync(_client, guildId, owner.AccessToken, member.AccessToken);
 
         var (channelId, _) = await GetTextChannelAsync(_client, guildId, owner.AccessToken);
@@ -216,7 +233,7 @@ public sealed class MessageMentionsIntegrationTests : IClassFixture<HarmonieWebA
         var owner = await AuthTestHelper.RegisterAsync(_client);
         var member = await AuthTestHelper.RegisterAsync(_client);
 
-        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, "Get Mention Guild");
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, $"GetM{Guid.NewGuid():N}"[..16]);
         await GuildTestHelper.InviteMemberAsync(_client, guildId, owner.AccessToken, member.AccessToken);
 
         var (channelId, _) = await GetTextChannelAsync(_client, guildId, owner.AccessToken);

--- a/tests/Harmonie.API.IntegrationTests/MessageMentionsIntegrationTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/MessageMentionsIntegrationTests.cs
@@ -1,0 +1,254 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Harmonie.API.IntegrationTests.Common;
+using Harmonie.Application.Common;
+using Harmonie.Application.Common.Messages;
+using Harmonie.Application.Features.Channels.EditMessage;
+using Harmonie.Application.Features.Channels.GetMessages;
+using Harmonie.Application.Features.Guilds.GetGuildChannels;
+using Harmonie.Domain.Entities.Messages;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+using ChannelSend = Harmonie.Application.Features.Channels.SendMessage;
+using ConversationSend = Harmonie.Application.Features.Conversations.SendMessage;
+
+namespace Harmonie.API.IntegrationTests;
+
+public sealed class MessageMentionsIntegrationTests : IClassFixture<HarmonieWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public MessageMentionsIntegrationTests(HarmonieWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    // ═════════════════════════════════════════════════════════════════════
+    //  Channel mentions
+
+    [Fact]
+    public async Task SendChannelMessage_WithValidMention_ShouldReturn200WithMentionedUserIds()
+    {
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var member = await AuthTestHelper.RegisterAsync(_client);
+
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, "Mention Guild");
+        await GuildTestHelper.InviteMemberAsync(_client, guildId, owner.AccessToken, member.AccessToken);
+
+        var (channelId, _) = await GetTextChannelAsync(_client, guildId, owner.AccessToken);
+
+        var request = new { content = "Hello @member", mentionedUserIds = new[] { member.UserId } };
+        var response = await _client.SendAuthorizedPostAsync(
+            $"/api/channels/{channelId}/messages", request, owner.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var payload = await response.Content.ReadFromJsonAsync<ChannelSend.SendMessageResponse>(TestContext.Current.CancellationToken);
+        payload.Should().NotBeNull();
+        payload!.MentionedUserIds.Should().ContainSingle().Which.Should().Be(member.UserId);
+    }
+
+    [Fact]
+    public async Task SendChannelMessage_WithNonExistentMentionedUser_ShouldReturn404()
+    {
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, "Ghost Guild");
+        var (channelId, _) = await GetTextChannelAsync(_client, guildId, owner.AccessToken);
+
+        var request = new { content = "Hello @ghost", mentionedUserIds = new[] { Guid.NewGuid() } };
+        var response = await _client.SendAuthorizedPostAsync(
+            $"/api/channels/{channelId}/messages", request, owner.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Message.MentionedUserNotFound);
+    }
+
+    [Fact]
+    public async Task SendChannelMessage_WithNonMemberMention_ShouldReturn403()
+    {
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var outsider = await AuthTestHelper.RegisterAsync(_client);
+
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, "Exclusive Guild");
+        var (channelId, _) = await GetTextChannelAsync(_client, guildId, owner.AccessToken);
+
+        var request = new { content = "Hello @outsider", mentionedUserIds = new[] { outsider.UserId } };
+        var response = await _client.SendAuthorizedPostAsync(
+            $"/api/channels/{channelId}/messages", request, owner.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Message.MentionedUserNotMember);
+    }
+
+    [Fact]
+    public async Task SendChannelMessage_WithMoreThan50Mentions_ShouldReturn400()
+    {
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, "Mass Guild");
+        var (channelId, _) = await GetTextChannelAsync(_client, guildId, owner.AccessToken);
+
+        var ids = Enumerable.Range(0, Message.MaxMentionedUsers + 1).Select(_ => Guid.NewGuid()).ToArray();
+        var request = new { content = "mass mention", mentionedUserIds = ids };
+        var response = await _client.SendAuthorizedPostAsync(
+            $"/api/channels/{channelId}/messages", request, owner.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task SendChannelMessage_WithDuplicateMentions_ShouldReturn400()
+    {
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, "Dup Guild");
+        var (channelId, _) = await GetTextChannelAsync(_client, guildId, owner.AccessToken);
+
+        var id = Guid.NewGuid();
+        var request = new { content = "double mention", mentionedUserIds = new[] { id, id } };
+        var response = await _client.SendAuthorizedPostAsync(
+            $"/api/channels/{channelId}/messages", request, owner.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task EditChannelMessage_ReplaceMentions_ShouldReturn200WithNewMentions()
+    {
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var member = await AuthTestHelper.RegisterAsync(_client);
+
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, "Edit Mention Guild");
+        await GuildTestHelper.InviteMemberAsync(_client, guildId, owner.AccessToken, member.AccessToken);
+
+        var (channelId, _) = await GetTextChannelAsync(_client, guildId, owner.AccessToken);
+        var messageId = await ChannelTestHelper.SendMessageAndGetIdAsync(_client, channelId, "original", owner.AccessToken);
+
+        var editRequest = new { content = "edited with mention", mentionedUserIds = new[] { member.UserId } };
+        var response = await _client.SendAuthorizedPatchAsync(
+            $"/api/channels/{channelId}/messages/{messageId}", editRequest, owner.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<EditMessageResponse>(TestContext.Current.CancellationToken);
+        payload.Should().NotBeNull();
+        payload!.MentionedUserIds.Should().ContainSingle().Which.Should().Be(member.UserId);
+    }
+
+    [Fact]
+    public async Task EditChannelMessage_ClearMentions_ShouldReturn200WithEmptyMentions()
+    {
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var member = await AuthTestHelper.RegisterAsync(_client);
+
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, "Clear Mention Guild");
+        await GuildTestHelper.InviteMemberAsync(_client, guildId, owner.AccessToken, member.AccessToken);
+
+        var (channelId, _) = await GetTextChannelAsync(_client, guildId, owner.AccessToken);
+
+        // First send with a mention
+        var sendRequest = new { content = "with mention", mentionedUserIds = new[] { member.UserId } };
+        var sendResponse = await _client.SendAuthorizedPostAsync(
+            $"/api/channels/{channelId}/messages", sendRequest, owner.AccessToken);
+        sendResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var sendPayload = await sendResponse.Content.ReadFromJsonAsync<ChannelSend.SendMessageResponse>(TestContext.Current.CancellationToken);
+        sendPayload.Should().NotBeNull();
+        sendPayload!.MentionedUserIds.Should().NotBeEmpty();
+
+        // Then clear mentions via edit
+        var editRequest = new { content = "mentions cleared", mentionedUserIds = Array.Empty<Guid>() };
+        var editResponse = await _client.SendAuthorizedPatchAsync(
+            $"/api/channels/{channelId}/messages/{sendPayload.MessageId}", editRequest, owner.AccessToken);
+
+        editResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var editPayload = await editResponse.Content.ReadFromJsonAsync<EditMessageResponse>(TestContext.Current.CancellationToken);
+        editPayload.Should().NotBeNull();
+        editPayload!.MentionedUserIds.Should().BeEmpty();
+    }
+
+    // ═════════════════════════════════════════════════════════════════════
+    //  Conversation mentions
+
+    [Fact]
+    public async Task SendConversationMessage_WithValidMention_ShouldReturn201WithMentionedUserIds()
+    {
+        var userA = await AuthTestHelper.RegisterAsync(_client);
+        var userB = await AuthTestHelper.RegisterAsync(_client);
+
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, userA.AccessToken, userB.UserId);
+
+        var request = new { content = "Hello @userB", mentionedUserIds = new[] { userB.UserId } };
+        var response = await _client.SendAuthorizedPostAsync(
+            $"/api/conversations/{conversationId}/messages", request, userA.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var payload = await response.Content.ReadFromJsonAsync<ConversationSend.SendMessageResponse>(TestContext.Current.CancellationToken);
+        payload.Should().NotBeNull();
+        payload!.MentionedUserIds.Should().ContainSingle().Which.Should().Be(userB.UserId);
+    }
+
+    [Fact]
+    public async Task SendConversationMessage_WithNonParticipantMention_ShouldReturn403()
+    {
+        var userA = await AuthTestHelper.RegisterAsync(_client);
+        var userB = await AuthTestHelper.RegisterAsync(_client);
+        var outsider = await AuthTestHelper.RegisterAsync(_client);
+
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, userA.AccessToken, userB.UserId);
+
+        var request = new { content = "Hello @outsider", mentionedUserIds = new[] { outsider.UserId } };
+        var response = await _client.SendAuthorizedPostAsync(
+            $"/api/conversations/{conversationId}/messages", request, userA.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Message.MentionedUserNotMember);
+    }
+
+    // ═════════════════════════════════════════════════════════════════════
+    //  GET returns mentions
+
+    [Fact]
+    public async Task GetChannelMessages_WithMentions_ShouldHydrateMentionedUserIds()
+    {
+        var owner = await AuthTestHelper.RegisterAsync(_client);
+        var member = await AuthTestHelper.RegisterAsync(_client);
+
+        var guildId = await GuildTestHelper.CreateGuildAndGetIdAsync(_client, owner.AccessToken, "Get Mention Guild");
+        await GuildTestHelper.InviteMemberAsync(_client, guildId, owner.AccessToken, member.AccessToken);
+
+        var (channelId, _) = await GetTextChannelAsync(_client, guildId, owner.AccessToken);
+
+        var sendRequest = new { content = "Hello @member", mentionedUserIds = new[] { member.UserId } };
+        var sendResponse = await _client.SendAuthorizedPostAsync(
+            $"/api/channels/{channelId}/messages", sendRequest, owner.AccessToken);
+        sendResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var getResponse = await _client.SendAuthorizedGetAsync(
+            $"/api/channels/{channelId}/messages", owner.AccessToken);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var getPayload = await getResponse.Content.ReadFromJsonAsync<GetMessagesResponse>(TestContext.Current.CancellationToken);
+        getPayload.Should().NotBeNull();
+        getPayload!.Items.Should().ContainSingle(i => i.MentionedUserIds.Contains(member.UserId));
+    }
+
+    // ═════════════════════════════════════════════════════════════════════
+    //  Helpers
+
+    private static async Task<(Guid ChannelId, string ChannelName)> GetTextChannelAsync(
+        HttpClient client, Guid guildId, string accessToken)
+    {
+        var response = await client.SendAuthorizedGetAsync(
+            $"/api/guilds/{guildId}/channels", accessToken);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<GetGuildChannelsResponse>(TestContext.Current.CancellationToken);
+        payload.Should().NotBeNull();
+
+        var textChannel = payload!.Channels.First(c => c.Type == "Text");
+        return (textChannel.ChannelId, textChannel.Name);
+    }
+}

--- a/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageAttachmentHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageAttachmentHandlerTests.cs
@@ -8,6 +8,7 @@ using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Uploads;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
@@ -28,6 +29,8 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
     private readonly Mock<IObjectStorageService> _objectStorageServiceMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly Mock<IUserRepository> _userRepositoryMock;
+    private readonly Mock<IConversationParticipantRepository> _participantRepositoryMock;
     private readonly MessageEditDeleteOrchestrator _orchestrator;
     private readonly DeleteMessageAttachmentHandler _handler;
 
@@ -38,6 +41,8 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
         _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
         _uploadedFileRepositoryMock = new Mock<IUploadedFileRepository>();
         _objectStorageServiceMock = new Mock<IObjectStorageService>();
+        _userRepositoryMock = new Mock<IUserRepository>();
+        _participantRepositoryMock = new Mock<IConversationParticipantRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
 
@@ -51,11 +56,13 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
         _orchestrator = new MessageEditDeleteOrchestrator(
             _conversationMessageRepositoryMock.Object,
             _messageAttachmentRepositoryMock.Object,
+            _userRepositoryMock.Object,
             _unitOfWorkMock.Object,
             uploadedFileCleanupService);
 
         _handler = new DeleteMessageAttachmentHandler(
             _conversationRepositoryMock.Object,
+            _participantRepositoryMock.Object,
             new Mock<IConversationMessageNotifier>().Object,
             NullLogger<ConversationMessageEditDeleteScope>.Instance,
             _orchestrator);

--- a/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageAttachmentHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageAttachmentHandlerTests.cs
@@ -10,6 +10,7 @@ using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.Entities.Conversations;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Uploads;
@@ -30,7 +31,6 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IUserRepository> _userRepositoryMock;
-    private readonly Mock<IConversationParticipantRepository> _participantRepositoryMock;
     private readonly MessageEditDeleteOrchestrator _orchestrator;
     private readonly DeleteMessageAttachmentHandler _handler;
 
@@ -42,7 +42,6 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
         _uploadedFileRepositoryMock = new Mock<IUploadedFileRepository>();
         _objectStorageServiceMock = new Mock<IObjectStorageService>();
         _userRepositoryMock = new Mock<IUserRepository>();
-        _participantRepositoryMock = new Mock<IConversationParticipantRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
 
@@ -62,7 +61,6 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
 
         _handler = new DeleteMessageAttachmentHandler(
             _conversationRepositoryMock.Object,
-            _participantRepositoryMock.Object,
             new Mock<IConversationMessageNotifier>().Object,
             NullLogger<ConversationMessageEditDeleteScope>.Instance,
             _orchestrator);
@@ -77,8 +75,8 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
         var callerId = UserId.New();
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversationId, It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((ConversationAccess?)null);
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversationId, It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConversationAccessWithAllParticipants?)null);
 
         var response = await _handler.HandleAsync(new DeleteConversationMessageAttachmentInput(conversationId, messageId, attachmentId), callerId, TestContext.Current.CancellationToken);
 
@@ -96,8 +94,8 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
         var conversation = ApplicationTestBuilders.CreateConversation(participantOne, participantTwo);
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: null));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: null, AllParticipants: Array.Empty<ConversationParticipant>(), CallerUsername: null, CallerDisplayName: null));
 
         var response = await _handler.HandleAsync(
             new DeleteConversationMessageAttachmentInput(conversation.Id, MessageId.New(), UploadedFileId.New()),
@@ -119,8 +117,8 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
         var message = ApplicationTestBuilders.CreateConversationMessage(conversation.Id, participantTwo, content: "hello");
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne), AllParticipants: Array.Empty<ConversationParticipant>(), CallerUsername: null, CallerDisplayName: null));
 
         _conversationMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))
@@ -143,8 +141,8 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
         var missingAttachmentId = UploadedFileId.New();
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne), AllParticipants: Array.Empty<ConversationParticipant>(), CallerUsername: null, CallerDisplayName: null));
 
         _conversationMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))
@@ -175,8 +173,8 @@ public sealed class DeleteConversationMessageAttachmentHandlerTests
         var uploadedFile = ApplicationTestBuilders.CreateUploadedFile(id: attachmentId, uploaderUserId: participantOne, fileName: "notes.txt", contentType: "text/plain", sizeBytes: 12, storageKey: "attachments/file.txt");
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne), AllParticipants: Array.Empty<ConversationParticipant>(), CallerUsername: null, CallerDisplayName: null));
 
         _conversationMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))

--- a/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageHandlerTests.cs
@@ -8,6 +8,7 @@ using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Uploads;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
@@ -24,6 +25,8 @@ public sealed class DeleteConversationMessageHandlerTests
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IMessageRepository> _directMessageRepositoryMock;
     private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
+    private readonly Mock<IUserRepository> _userRepositoryMock;
+    private readonly Mock<IConversationParticipantRepository> _participantRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IConversationMessageNotifier> _directMessageNotifierMock;
@@ -35,6 +38,8 @@ public sealed class DeleteConversationMessageHandlerTests
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _directMessageRepositoryMock = new Mock<IMessageRepository>();
         _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
+        _userRepositoryMock = new Mock<IUserRepository>();
+        _participantRepositoryMock = new Mock<IConversationParticipantRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
         _directMessageNotifierMock = new Mock<IConversationMessageNotifier>();
@@ -53,11 +58,13 @@ public sealed class DeleteConversationMessageHandlerTests
         _orchestrator = new MessageEditDeleteOrchestrator(
             _directMessageRepositoryMock.Object,
             _messageAttachmentRepositoryMock.Object,
+            _userRepositoryMock.Object,
             _unitOfWorkMock.Object,
             uploadedFileCleanupService);
 
         _handler = new DeleteMessageHandler(
             _conversationRepositoryMock.Object,
+            _participantRepositoryMock.Object,
             _directMessageNotifierMock.Object,
             NullLogger<ConversationMessageEditDeleteScope>.Instance,
             _orchestrator);

--- a/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/DeleteConversationMessageHandlerTests.cs
@@ -10,6 +10,7 @@ using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.Entities.Conversations;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
@@ -26,7 +27,6 @@ public sealed class DeleteConversationMessageHandlerTests
     private readonly Mock<IMessageRepository> _directMessageRepositoryMock;
     private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
     private readonly Mock<IUserRepository> _userRepositoryMock;
-    private readonly Mock<IConversationParticipantRepository> _participantRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IConversationMessageNotifier> _directMessageNotifierMock;
@@ -39,7 +39,6 @@ public sealed class DeleteConversationMessageHandlerTests
         _directMessageRepositoryMock = new Mock<IMessageRepository>();
         _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
         _userRepositoryMock = new Mock<IUserRepository>();
-        _participantRepositoryMock = new Mock<IConversationParticipantRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
         _directMessageNotifierMock = new Mock<IConversationMessageNotifier>();
@@ -64,7 +63,6 @@ public sealed class DeleteConversationMessageHandlerTests
 
         _handler = new DeleteMessageHandler(
             _conversationRepositoryMock.Object,
-            _participantRepositoryMock.Object,
             _directMessageNotifierMock.Object,
             NullLogger<ConversationMessageEditDeleteScope>.Instance,
             _orchestrator);
@@ -77,8 +75,8 @@ public sealed class DeleteConversationMessageHandlerTests
         var callerId = UserId.New();
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversationId, It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((ConversationAccess?)null);
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversationId, It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConversationAccessWithAllParticipants?)null);
 
         var response = await _handler.HandleAsync(new DeleteConversationMessageInput(conversationId, MessageId.New()), callerId, TestContext.Current.CancellationToken);
 
@@ -97,8 +95,8 @@ public sealed class DeleteConversationMessageHandlerTests
         var conversation = ApplicationTestBuilders.CreateConversation(participantOne, participantTwo);
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: null));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: null, AllParticipants: Array.Empty<ConversationParticipant>(), CallerUsername: null, CallerDisplayName: null));
 
         var response = await _handler.HandleAsync(new DeleteConversationMessageInput(conversation.Id, MessageId.New()), outsider, TestContext.Current.CancellationToken);
 
@@ -117,8 +115,8 @@ public sealed class DeleteConversationMessageHandlerTests
         var messageId = MessageId.New();
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne), AllParticipants: Array.Empty<ConversationParticipant>(), CallerUsername: null, CallerDisplayName: null));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -142,8 +140,8 @@ public sealed class DeleteConversationMessageHandlerTests
         var message = ApplicationTestBuilders.CreateConversationMessage(ConversationId.New(), participantOne);
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne), AllParticipants: Array.Empty<ConversationParticipant>(), CallerUsername: null, CallerDisplayName: null));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -167,8 +165,8 @@ public sealed class DeleteConversationMessageHandlerTests
         var message = ApplicationTestBuilders.CreateConversationMessage(conversation.Id, participantTwo);
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne), AllParticipants: Array.Empty<ConversationParticipant>(), CallerUsername: null, CallerDisplayName: null));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -192,8 +190,8 @@ public sealed class DeleteConversationMessageHandlerTests
         var message = ApplicationTestBuilders.CreateConversationMessage(conversation.Id, participantOne);
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne), AllParticipants: Array.Empty<ConversationParticipant>(), CallerUsername: null, CallerDisplayName: null));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -215,8 +213,8 @@ public sealed class DeleteConversationMessageHandlerTests
         var message = ApplicationTestBuilders.CreateConversationMessage(conversation.Id, participantOne);
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne), AllParticipants: Array.Empty<ConversationParticipant>(), CallerUsername: null, CallerDisplayName: null));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -258,8 +256,8 @@ public sealed class DeleteConversationMessageHandlerTests
         var message = ApplicationTestBuilders.CreateConversationMessage(conversation.Id, participantOne);
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne), AllParticipants: Array.Empty<ConversationParticipant>(), CallerUsername: null, CallerDisplayName: null));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))

--- a/tests/Harmonie.Application.Tests/Messages/DeleteMessageAttachmentHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/DeleteMessageAttachmentHandlerTests.cs
@@ -6,8 +6,10 @@ using Harmonie.Application.Features.Channels.DeleteMessageAttachment;
 using Harmonie.Application.Features.Channels.Messages;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Uploads;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Guilds;
 using Harmonie.Domain.Enums;
@@ -24,10 +26,12 @@ namespace Harmonie.Application.Tests.Messages;
 public sealed class DeleteMessageAttachmentHandlerTests
 {
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
+    private readonly Mock<IGuildMemberRepository> _guildMemberRepositoryMock;
     private readonly Mock<IMessageRepository> _messageRepositoryMock;
     private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
     private readonly Mock<IUploadedFileRepository> _uploadedFileRepositoryMock;
     private readonly Mock<IObjectStorageService> _objectStorageServiceMock;
+    private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly MessageEditDeleteOrchestrator _orchestrator;
@@ -36,9 +40,11 @@ public sealed class DeleteMessageAttachmentHandlerTests
     public DeleteMessageAttachmentHandlerTests()
     {
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
+        _guildMemberRepositoryMock = new Mock<IGuildMemberRepository>();
         _messageRepositoryMock = new Mock<IMessageRepository>();
         _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
         _uploadedFileRepositoryMock = new Mock<IUploadedFileRepository>();
+        _userRepositoryMock = new Mock<IUserRepository>();
         _objectStorageServiceMock = new Mock<IObjectStorageService>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
@@ -53,11 +59,13 @@ public sealed class DeleteMessageAttachmentHandlerTests
         _orchestrator = new MessageEditDeleteOrchestrator(
             _messageRepositoryMock.Object,
             _messageAttachmentRepositoryMock.Object,
+            _userRepositoryMock.Object,
             _unitOfWorkMock.Object,
             uploadedFileCleanupService);
 
         _handler = new DeleteMessageAttachmentHandler(
             _guildChannelRepositoryMock.Object,
+            _guildMemberRepositoryMock.Object,
             new Mock<ITextChannelNotifier>().Object,
             NullLogger<ChannelMessageEditDeleteScope>.Instance,
             _orchestrator);

--- a/tests/Harmonie.Application.Tests/Messages/DeleteMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/DeleteMessageHandlerTests.cs
@@ -6,8 +6,10 @@ using Harmonie.Application.Features.Channels.DeleteMessage;
 using Harmonie.Application.Features.Channels.Messages;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Uploads;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Guilds;
 using Harmonie.Domain.Entities.Messages;
@@ -25,8 +27,10 @@ namespace Harmonie.Application.Tests.Messages;
 public sealed class DeleteMessageHandlerTests
 {
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
+    private readonly Mock<IGuildMemberRepository> _guildMemberRepositoryMock;
     private readonly Mock<IMessageRepository> _channelMessageRepositoryMock;
     private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
+    private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<ITextChannelNotifier> _textChannelNotifierMock;
@@ -36,8 +40,10 @@ public sealed class DeleteMessageHandlerTests
     public DeleteMessageHandlerTests()
     {
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
+        _guildMemberRepositoryMock = new Mock<IGuildMemberRepository>();
         _channelMessageRepositoryMock = new Mock<IMessageRepository>();
         _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
+        _userRepositoryMock = new Mock<IUserRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
         _textChannelNotifierMock = new Mock<ITextChannelNotifier>();
@@ -56,11 +62,13 @@ public sealed class DeleteMessageHandlerTests
         _orchestrator = new MessageEditDeleteOrchestrator(
             _channelMessageRepositoryMock.Object,
             _messageAttachmentRepositoryMock.Object,
+            _userRepositoryMock.Object,
             _unitOfWorkMock.Object,
             uploadedFileCleanupService);
 
         _handler = new DeleteMessageHandler(
             _guildChannelRepositoryMock.Object,
+            _guildMemberRepositoryMock.Object,
             _textChannelNotifierMock.Object,
             NullLogger<ChannelMessageEditDeleteScope>.Instance,
             _orchestrator);

--- a/tests/Harmonie.Application.Tests/Messages/EditConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/EditConversationMessageHandlerTests.cs
@@ -8,6 +8,7 @@ using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Uploads;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
@@ -24,6 +25,8 @@ public sealed class EditConversationMessageHandlerTests
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IMessageRepository> _directMessageRepositoryMock;
     private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
+    private readonly Mock<IUserRepository> _userRepositoryMock;
+    private readonly Mock<IConversationParticipantRepository> _participantRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IConversationMessageNotifier> _directMessageNotifierMock;
@@ -35,6 +38,8 @@ public sealed class EditConversationMessageHandlerTests
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _directMessageRepositoryMock = new Mock<IMessageRepository>();
         _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
+        _userRepositoryMock = new Mock<IUserRepository>();
+        _participantRepositoryMock = new Mock<IConversationParticipantRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
         _directMessageNotifierMock = new Mock<IConversationMessageNotifier>();
@@ -49,6 +54,11 @@ public sealed class EditConversationMessageHandlerTests
             .Setup(x => x.GetByMessageIdAsync(It.IsAny<MessageId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<MessageAttachment>());
 
+        _directMessageRepositoryMock
+            .Setup(x => x.GetMentionedUserIdsByMessageIdAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, IReadOnlyList<Guid>>());
+
         var uploadedFileCleanupService = new UploadedFileCleanupService(
             new Mock<IUploadedFileRepository>().Object,
             new Mock<IObjectStorageService>().Object,
@@ -57,11 +67,13 @@ public sealed class EditConversationMessageHandlerTests
         _orchestrator = new MessageEditDeleteOrchestrator(
             _directMessageRepositoryMock.Object,
             _messageAttachmentRepositoryMock.Object,
+            _userRepositoryMock.Object,
             _unitOfWorkMock.Object,
             uploadedFileCleanupService);
 
         _handler = new EditMessageHandler(
             _conversationRepositoryMock.Object,
+            _participantRepositoryMock.Object,
             _directMessageNotifierMock.Object,
             NullLogger<ConversationMessageEditDeleteScope>.Instance,
             _orchestrator);

--- a/tests/Harmonie.Application.Tests/Messages/EditConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/EditConversationMessageHandlerTests.cs
@@ -10,6 +10,7 @@ using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.Entities.Conversations;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Messages;
@@ -26,7 +27,6 @@ public sealed class EditConversationMessageHandlerTests
     private readonly Mock<IMessageRepository> _directMessageRepositoryMock;
     private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
     private readonly Mock<IUserRepository> _userRepositoryMock;
-    private readonly Mock<IConversationParticipantRepository> _participantRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IConversationMessageNotifier> _directMessageNotifierMock;
@@ -39,7 +39,6 @@ public sealed class EditConversationMessageHandlerTests
         _directMessageRepositoryMock = new Mock<IMessageRepository>();
         _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
         _userRepositoryMock = new Mock<IUserRepository>();
-        _participantRepositoryMock = new Mock<IConversationParticipantRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
         _directMessageNotifierMock = new Mock<IConversationMessageNotifier>();
@@ -73,7 +72,6 @@ public sealed class EditConversationMessageHandlerTests
 
         _handler = new EditMessageHandler(
             _conversationRepositoryMock.Object,
-            _participantRepositoryMock.Object,
             _directMessageNotifierMock.Object,
             NullLogger<ConversationMessageEditDeleteScope>.Instance,
             _orchestrator);
@@ -100,8 +98,8 @@ public sealed class EditConversationMessageHandlerTests
         var callerId = UserId.New();
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversationId, It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((ConversationAccess?)null);
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversationId, It.IsAny<UserId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConversationAccessWithAllParticipants?)null);
 
         var response = await _handler.HandleAsync(
             new EditConversationMessageInput(conversationId, MessageId.New(), "updated content"),
@@ -123,8 +121,8 @@ public sealed class EditConversationMessageHandlerTests
         var conversation = ApplicationTestBuilders.CreateConversation(participantOne, participantTwo);
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: null));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, outsider, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: null, AllParticipants: Array.Empty<ConversationParticipant>(), CallerUsername: null, CallerDisplayName: null));
 
         var response = await _handler.HandleAsync(
             new EditConversationMessageInput(conversation.Id, MessageId.New(), "updated content"),
@@ -146,8 +144,8 @@ public sealed class EditConversationMessageHandlerTests
         var messageId = MessageId.New();
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne), AllParticipants: Array.Empty<ConversationParticipant>(), CallerUsername: null, CallerDisplayName: null));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -174,8 +172,8 @@ public sealed class EditConversationMessageHandlerTests
         var messageFromOtherConversation = ApplicationTestBuilders.CreateConversationMessage(ConversationId.New(), participantOne);
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne), AllParticipants: Array.Empty<ConversationParticipant>(), CallerUsername: null, CallerDisplayName: null));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -202,8 +200,8 @@ public sealed class EditConversationMessageHandlerTests
         var message = ApplicationTestBuilders.CreateConversationMessage(conversation.Id, participantTwo);
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne), AllParticipants: Array.Empty<ConversationParticipant>(), CallerUsername: null, CallerDisplayName: null));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -230,8 +228,8 @@ public sealed class EditConversationMessageHandlerTests
         var message = ApplicationTestBuilders.CreateConversationMessage(conversation.Id, participantOne);
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne), AllParticipants: Array.Empty<ConversationParticipant>(), CallerUsername: null, CallerDisplayName: null));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -261,8 +259,8 @@ public sealed class EditConversationMessageHandlerTests
         var message = ApplicationTestBuilders.CreateConversationMessage(conversation.Id, participantOne);
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne), AllParticipants: Array.Empty<ConversationParticipant>(), CallerUsername: null, CallerDisplayName: null));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))
@@ -305,8 +303,8 @@ public sealed class EditConversationMessageHandlerTests
         var message = ApplicationTestBuilders.CreateConversationMessage(conversation.Id, participantOne);
 
         _conversationRepositoryMock
-            .Setup(x => x.GetByIdWithParticipantCheckAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ConversationAccess(conversation, Participant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne)));
+            .Setup(x => x.GetByIdWithAllParticipantsAsync(conversation.Id, participantOne, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationAccessWithAllParticipants(conversation, CallerParticipant: ApplicationTestBuilders.CreateConversationParticipant(conversation.Id, participantOne), AllParticipants: Array.Empty<ConversationParticipant>(), CallerUsername: null, CallerDisplayName: null));
 
         _directMessageRepositoryMock
             .Setup(x => x.GetByIdAsync(messageId, It.IsAny<CancellationToken>()))

--- a/tests/Harmonie.Application.Tests/Messages/EditMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/EditMessageHandlerTests.cs
@@ -6,8 +6,10 @@ using Harmonie.Application.Features.Channels.EditMessage;
 using Harmonie.Application.Features.Channels.Messages;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Uploads;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Guilds;
 using Harmonie.Domain.Entities.Messages;
@@ -25,8 +27,10 @@ namespace Harmonie.Application.Tests.Messages;
 public sealed class EditMessageHandlerTests
 {
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
+    private readonly Mock<IGuildMemberRepository> _guildMemberRepositoryMock;
     private readonly Mock<IMessageRepository> _channelMessageRepositoryMock;
     private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
+    private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<ITextChannelNotifier> _textChannelNotifierMock;
@@ -36,8 +40,10 @@ public sealed class EditMessageHandlerTests
     public EditMessageHandlerTests()
     {
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
+        _guildMemberRepositoryMock = new Mock<IGuildMemberRepository>();
         _channelMessageRepositoryMock = new Mock<IMessageRepository>();
         _messageAttachmentRepositoryMock = new Mock<IMessageAttachmentRepository>();
+        _userRepositoryMock = new Mock<IUserRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
         _textChannelNotifierMock = new Mock<ITextChannelNotifier>();
@@ -52,6 +58,11 @@ public sealed class EditMessageHandlerTests
             .Setup(x => x.GetByMessageIdAsync(It.IsAny<MessageId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<MessageAttachment>());
 
+        _channelMessageRepositoryMock
+            .Setup(x => x.GetMentionedUserIdsByMessageIdAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, IReadOnlyList<Guid>>());
+
         var uploadedFileCleanupService = new UploadedFileCleanupService(
             new Mock<IUploadedFileRepository>().Object,
             new Mock<IObjectStorageService>().Object,
@@ -60,11 +71,13 @@ public sealed class EditMessageHandlerTests
         _orchestrator = new MessageEditDeleteOrchestrator(
             _channelMessageRepositoryMock.Object,
             _messageAttachmentRepositoryMock.Object,
+            _userRepositoryMock.Object,
             _unitOfWorkMock.Object,
             uploadedFileCleanupService);
 
         _handler = new EditMessageHandler(
             _guildChannelRepositoryMock.Object,
+            _guildMemberRepositoryMock.Object,
             _textChannelNotifierMock.Object,
             NullLogger<ChannelMessageEditDeleteScope>.Instance,
             _orchestrator);

--- a/tests/Harmonie.Application.Tests/Messages/MessageEditDeleteOrchestratorTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/MessageEditDeleteOrchestratorTests.cs
@@ -82,7 +82,7 @@ public sealed class MessageEditDeleteOrchestratorTests
             .ReturnsAsync(new AuthorizationResult<OrchestratorTestContext>.Authorized(Ctx));
         mock.Setup(x => x.CanDeleteOthersMessages(Ctx)).Returns(canDeleteOthers);
         mock.Setup(x => x.NotifyMessageUpdatedAsync(
-            Ctx, It.IsAny<MessageId>(), It.IsAny<string?>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            Ctx, It.IsAny<MessageId>(), It.IsAny<string?>(), It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         mock.Setup(x => x.NotifyMessageDeletedAsync(
             Ctx, It.IsAny<MessageId>(), It.IsAny<CancellationToken>()))
@@ -218,7 +218,7 @@ public sealed class MessageEditDeleteOrchestratorTests
             .Returns(Task.CompletedTask);
         scopeMock
             .Setup(x => x.NotifyMessageUpdatedAsync(
-                Ctx, message.Id, TestContent, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+                Ctx, message.Id, TestContent, It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
             .Callback(() => callOrder.Add("notify"))
             .Returns(Task.CompletedTask);
 
@@ -231,7 +231,7 @@ public sealed class MessageEditDeleteOrchestratorTests
         _messageRepositoryMock.Verify(x => x.UpdateAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()), Times.Once);
         _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
         scopeMock.Verify(
-            x => x.NotifyMessageUpdatedAsync(Ctx, message.Id, TestContent, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            x => x.NotifyMessageUpdatedAsync(Ctx, message.Id, TestContent, It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
             Times.Once);
         // UpdatedAtUtc is validated before commit → callOrder is: update, commit, notify
         callOrder.Should().Equal("update", "commit", "notify");

--- a/tests/Harmonie.Application.Tests/Messages/MessageEditDeleteOrchestratorTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/MessageEditDeleteOrchestratorTests.cs
@@ -5,6 +5,7 @@ using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Uploads;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.Entities.Uploads;
@@ -30,6 +31,7 @@ public sealed class MessageEditDeleteOrchestratorTests
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IUploadedFileRepository> _uploadedFileRepositoryMock;
     private readonly Mock<IObjectStorageService> _objectStorageServiceMock;
+    private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly MessageEditDeleteOrchestrator _orchestrator;
 
     private static readonly OrchestratorTestContext Ctx = new();
@@ -42,6 +44,12 @@ public sealed class MessageEditDeleteOrchestratorTests
         _transactionMock = _unitOfWorkMock.SetupTransactionMock();
         _uploadedFileRepositoryMock = new Mock<IUploadedFileRepository>();
         _objectStorageServiceMock = new Mock<IObjectStorageService>();
+        _userRepositoryMock = new Mock<IUserRepository>();
+
+        _messageRepositoryMock
+            .Setup(x => x.GetMentionedUserIdsByMessageIdAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, IReadOnlyList<Guid>>());
 
         var uploadedFileCleanupService = new UploadedFileCleanupService(
             _uploadedFileRepositoryMock.Object,
@@ -51,6 +59,7 @@ public sealed class MessageEditDeleteOrchestratorTests
         _orchestrator = new MessageEditDeleteOrchestrator(
             _messageRepositoryMock.Object,
             _messageAttachmentRepositoryMock.Object,
+            _userRepositoryMock.Object,
             _unitOfWorkMock.Object,
             uploadedFileCleanupService);
     }
@@ -121,7 +130,7 @@ public sealed class MessageEditDeleteOrchestratorTests
     {
         var scope = CreateAuthorizedScope();
         var result = await _orchestrator.EditAsync(
-            scope.Object, ChannelScope(), AnyMessageId(), "   ", AnyUser(), TestContext.Current.CancellationToken);
+            scope.Object, ChannelScope(), AnyMessageId(), "   ", null, AnyUser(), TestContext.Current.CancellationToken);
 
         result.Success.Should().BeFalse();
         result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.ContentEmpty);
@@ -133,7 +142,7 @@ public sealed class MessageEditDeleteOrchestratorTests
     {
         var scope = CreateDeniedScope("AUTH_DENIED", "Not allowed");
         var result = await _orchestrator.EditAsync(
-            scope.Object, ChannelScope(), AnyMessageId(), TestContent, AnyUser(), TestContext.Current.CancellationToken);
+            scope.Object, ChannelScope(), AnyMessageId(), TestContent, null, AnyUser(), TestContext.Current.CancellationToken);
 
         result.Success.Should().BeFalse();
         result.Error!.Code.Should().Be("AUTH_DENIED");
@@ -147,7 +156,7 @@ public sealed class MessageEditDeleteOrchestratorTests
         SetupMessageNotFound(messageId);
 
         var result = await _orchestrator.EditAsync(
-            scope.Object, ChannelScope(), messageId, TestContent, AnyUser(), TestContext.Current.CancellationToken);
+            scope.Object, ChannelScope(), messageId, TestContent, null, AnyUser(), TestContext.Current.CancellationToken);
 
         result.Success.Should().BeFalse();
         result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
@@ -162,7 +171,7 @@ public sealed class MessageEditDeleteOrchestratorTests
         SetupMessageExists(messageId, wrongScope);
 
         var result = await _orchestrator.EditAsync(
-            scope.Object, ChannelScope(), messageId, TestContent, AnyUser(), TestContext.Current.CancellationToken);
+            scope.Object, ChannelScope(), messageId, TestContent, null, AnyUser(), TestContext.Current.CancellationToken);
 
         result.Success.Should().BeFalse();
         result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
@@ -179,7 +188,7 @@ public sealed class MessageEditDeleteOrchestratorTests
         SetupMessageExists(messageId, messageScope, authorId);
 
         var result = await _orchestrator.EditAsync(
-            scope.Object, messageScope, messageId, TestContent, callerId, TestContext.Current.CancellationToken);
+            scope.Object, messageScope, messageId, TestContent, null, callerId, TestContext.Current.CancellationToken);
 
         result.Success.Should().BeFalse();
         result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.EditForbidden);
@@ -214,7 +223,7 @@ public sealed class MessageEditDeleteOrchestratorTests
             .Returns(Task.CompletedTask);
 
         var result = await _orchestrator.EditAsync(
-            scopeMock.Object, messageScope, messageId, TestContent, authorId, TestContext.Current.CancellationToken);
+            scopeMock.Object, messageScope, messageId, TestContent, null, authorId, TestContext.Current.CancellationToken);
 
         result.Success.Should().BeTrue();
         result.Data!.Content.Should().Be(TestContent);

--- a/tests/Harmonie.Application.Tests/Messages/MessageEditDeleteOrchestratorTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/MessageEditDeleteOrchestratorTests.cs
@@ -7,6 +7,7 @@ using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.Common;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.Entities.Uploads;
 using Harmonie.Domain.ValueObjects.Channels;
@@ -570,5 +571,105 @@ public sealed class MessageEditDeleteOrchestratorTests
 
         // Cleanup must happen outside the transaction: delete → commit → dispose → cleanup
         callOrder.Should().Equal("deleteRef", "commit", "txDispose", "cleanup");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  EditAsync — mentions
+
+    [Fact]
+    public async Task EditAsync_WithValidMentions_ShouldReplaceAndReturnMentions()
+    {
+        var scopeMock = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var messageScope = ChannelScope();
+        var authorId = UserId.New();
+        var mentionUser = UserId.New();
+        SetupMessageExists(messageId, messageScope, authorId);
+
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.GetByMessageIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<MessageAttachment>());
+
+        _userRepositoryMock
+            .Setup(x => x.GetManyByIdsAsync(
+                It.IsAny<IReadOnlyList<UserId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { ApplicationTestBuilders.CreateUser(mentionUser) });
+
+        scopeMock
+            .Setup(x => x.ValidateMentionedUsersAsync(
+                It.IsAny<IReadOnlyCollection<UserId>>(), Ctx, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        _messageRepositoryMock
+            .Setup(x => x.ReplaceMentionsAsync(
+                messageId, It.IsAny<IReadOnlyCollection<UserId>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _orchestrator.EditAsync(
+            scopeMock.Object, messageScope, messageId, TestContent,
+            new List<Guid> { mentionUser.Value }, authorId, TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        result.Data!.MentionedUserIds.Should().ContainSingle().Which.Should().Be(mentionUser.Value);
+    }
+
+    [Fact]
+    public async Task EditAsync_WithEmptyMentionList_ShouldClearMentions()
+    {
+        var scopeMock = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var messageScope = ChannelScope();
+        var authorId = UserId.New();
+        SetupMessageExists(messageId, messageScope, authorId);
+
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.GetByMessageIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<MessageAttachment>());
+
+        _messageRepositoryMock
+            .Setup(x => x.ReplaceMentionsAsync(
+                It.IsAny<MessageId>(), It.Is<IReadOnlyCollection<UserId>>(c => c.Count == 0), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _orchestrator.EditAsync(
+            scopeMock.Object, messageScope, messageId, TestContent,
+            Array.Empty<Guid>(), authorId, TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        result.Data!.MentionedUserIds.Should().BeEmpty();
+        _messageRepositoryMock.Verify(
+            x => x.ReplaceMentionsAsync(
+                It.IsAny<MessageId>(), It.IsAny<IReadOnlyCollection<UserId>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EditAsync_WithNullMentions_ShouldNotTouchMentions()
+    {
+        var scopeMock = CreateAuthorizedScope();
+        var messageId = AnyMessageId();
+        var messageScope = ChannelScope();
+        var authorId = UserId.New();
+        SetupMessageExists(messageId, messageScope, authorId);
+
+        _messageAttachmentRepositoryMock
+            .Setup(x => x.GetByMessageIdAsync(messageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<MessageAttachment>());
+
+        _messageRepositoryMock
+            .Setup(x => x.GetMentionedUserIdsByMessageIdAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, IReadOnlyList<Guid>>());
+
+        var result = await _orchestrator.EditAsync(
+            scopeMock.Object, messageScope, messageId, TestContent,
+            null, authorId, TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        result.Data!.MentionedUserIds.Should().BeEmpty();
+        _messageRepositoryMock.Verify(
+            x => x.ReplaceMentionsAsync(
+                It.IsAny<MessageId>(), It.IsAny<IReadOnlyCollection<UserId>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }

--- a/tests/Harmonie.Application.Tests/Messages/MessageSendOrchestratorTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/MessageSendOrchestratorTests.cs
@@ -5,6 +5,7 @@ using Harmonie.Application.Features.Channels.SendMessage;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Uploads;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.Entities.Uploads;
@@ -27,6 +28,7 @@ public sealed class MessageSendOrchestratorTests
     private readonly Mock<IUploadedFileRepository> _uploadedFileRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
+    private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly MessageSendOrchestrator _orchestrator;
 
     public MessageSendOrchestratorTests()
@@ -36,11 +38,13 @@ public sealed class MessageSendOrchestratorTests
         _uploadedFileRepositoryMock = new Mock<IUploadedFileRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = _unitOfWorkMock.SetupTransactionMock();
+        _userRepositoryMock = new Mock<IUserRepository>();
 
         _orchestrator = new MessageSendOrchestrator(
             _messageRepositoryMock.Object,
             _messageAttachmentRepositoryMock.Object,
             new MessageAttachmentResolver(_uploadedFileRepositoryMock.Object),
+            _userRepositoryMock.Object,
             _unitOfWorkMock.Object);
     }
 
@@ -59,7 +63,7 @@ public sealed class MessageSendOrchestratorTests
                 new ApplicationError("AUTH_DENIED", "Not allowed")));
 
         var result = await _orchestrator.SendAsync(
-            scopeMock.Object, AnyScope(), "hello", null, null, AnyUser(), TestContext.Current.CancellationToken);
+            scopeMock.Object, AnyScope(), "hello", null, null, null, AnyUser(), TestContext.Current.CancellationToken);
 
         result.Success.Should().BeFalse();
         result.Error!.Code.Should().Be("AUTH_DENIED");
@@ -82,7 +86,7 @@ public sealed class MessageSendOrchestratorTests
                 replyTargetId, otherScope, UserId.New(), "u", null, "content", false, false, null));
 
         var result = await _orchestrator.SendAsync(
-            scope.Object, messageScope, "hello", null, replyTargetId.Value, AnyUser(), TestContext.Current.CancellationToken);
+            scope.Object, messageScope, "hello", null, replyTargetId.Value, null, AnyUser(), TestContext.Current.CancellationToken);
 
         result.Success.Should().BeFalse();
         result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.NotFound);
@@ -109,7 +113,7 @@ public sealed class MessageSendOrchestratorTests
             .Returns(Task.CompletedTask);
 
         var result = await _orchestrator.SendAsync(
-            scope.Object, messageScope, "hello", null, replyTargetId.Value, AnyUser(),
+            scope.Object, messageScope, "hello", null, replyTargetId.Value, null, AnyUser(),
             TestContext.Current.CancellationToken);
 
         result.Success.Should().BeTrue();
@@ -134,7 +138,7 @@ public sealed class MessageSendOrchestratorTests
             .ReturnsAsync(Array.Empty<UploadedFile>());
 
         var result = await _orchestrator.SendAsync(
-            scope.Object, AnyScope(), "hello", [fileId.Value], null, AnyUser(), TestContext.Current.CancellationToken);
+            scope.Object, AnyScope(), "hello", [fileId.Value], null, null, AnyUser(), TestContext.Current.CancellationToken);
 
         result.Success.Should().BeFalse();
         result.Error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
@@ -148,7 +152,7 @@ public sealed class MessageSendOrchestratorTests
         var scope = CreateAuthorizedScope();
 
         var result = await _orchestrator.SendAsync(
-            scope.Object, AnyScope(), null, null, null, AnyUser(), TestContext.Current.CancellationToken);
+            scope.Object, AnyScope(), null, null, null, null, AnyUser(), TestContext.Current.CancellationToken);
 
         result.Success.Should().BeFalse();
         result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.ContentEmpty);
@@ -194,7 +198,7 @@ public sealed class MessageSendOrchestratorTests
             .Returns(Task.CompletedTask);
 
         var result = await _orchestrator.SendAsync(
-            scopeMock.Object, AnyScope(), "https://example.com", null, null, AnyUser(), TestContext.Current.CancellationToken);
+            scopeMock.Object, AnyScope(), "https://example.com", null, null, null, AnyUser(), TestContext.Current.CancellationToken);
 
         result.Success.Should().BeTrue();
         result.Data.Should().NotBeNull();
@@ -235,7 +239,7 @@ public sealed class MessageSendOrchestratorTests
             .Returns(Task.CompletedTask);
 
         await _orchestrator.SendAsync(
-            scopeMock.Object, AnyScope(), "hello world, no urls here", null, null, AnyUser(), TestContext.Current.CancellationToken);
+            scopeMock.Object, AnyScope(), "hello world, no urls here", null, null, null, AnyUser(), TestContext.Current.CancellationToken);
 
         scopeMock.Verify(
             x => x.ScheduleLinkPreviewResolution(

--- a/tests/Harmonie.Application.Tests/Messages/MessageSendOrchestratorTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/MessageSendOrchestratorTests.cs
@@ -7,6 +7,7 @@ using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.Common;
 using Harmonie.Domain.Entities.Messages;
 using Harmonie.Domain.Entities.Uploads;
 using Harmonie.Domain.Enums;
@@ -245,6 +246,81 @@ public sealed class MessageSendOrchestratorTests
             x => x.ScheduleLinkPreviewResolution(
                 context, It.IsAny<Message>(), It.IsAny<IReadOnlyList<Uri>>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    // ── 7. Mention validation ───────────────────────────────────────────
+
+    [Fact]
+    public async Task SendAsync_WithValidMentions_ShouldPersistAndReturnMentionedUserIds()
+    {
+        var scopeMock = CreateAuthorizedScope();
+        var mentionUser = UserId.New();
+        var context = new ChannelSendMessageScope.Context(
+            GuildChannelId.New(), "general", GuildId.New(), "MyGuild", "caller", "Display");
+
+        scopeMock
+            .Setup(x => x.ValidateMentionedUsersAsync(
+                It.IsAny<IReadOnlyCollection<UserId>>(), It.IsAny<ChannelSendMessageScope.Context>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        _userRepositoryMock
+            .Setup(x => x.GetManyByIdsAsync(
+                It.IsAny<IReadOnlyList<UserId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { ApplicationTestBuilders.CreateUser(mentionUser) });
+
+        _messageRepositoryMock
+            .Setup(x => x.AddAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _orchestrator.SendAsync(
+            scopeMock.Object, AnyScope(), "hello @someone", null, null,
+            new List<Guid> { mentionUser.Value }, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeTrue();
+        result.Data!.MentionedUserIds.Should().ContainSingle().Which.Should().Be(mentionUser.Value);
+    }
+
+    [Fact]
+    public async Task SendAsync_WithNonExistentMentionedUser_ShouldReturnMentionedUserNotFound()
+    {
+        var scopeMock = CreateAuthorizedScope();
+        var missingUserId = Guid.NewGuid();
+
+        _userRepositoryMock
+            .Setup(x => x.GetManyByIdsAsync(
+                It.IsAny<IReadOnlyList<UserId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Harmonie.Domain.Entities.Users.User>());
+
+        var result = await _orchestrator.SendAsync(
+            scopeMock.Object, AnyScope(), "hello", null, null,
+            new List<Guid> { missingUserId }, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.MentionedUserNotFound);
+    }
+
+    [Fact]
+    public async Task SendAsync_WithNonMemberMentionedUser_ShouldReturnMentionedUserNotMember()
+    {
+        var scopeMock = CreateAuthorizedScope();
+        var mentionUser = UserId.New();
+
+        _userRepositoryMock
+            .Setup(x => x.GetManyByIdsAsync(
+                It.IsAny<IReadOnlyList<UserId>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { ApplicationTestBuilders.CreateUser(mentionUser) });
+
+        scopeMock
+            .Setup(x => x.ValidateMentionedUsersAsync(
+                It.IsAny<IReadOnlyCollection<UserId>>(), It.IsAny<ChannelSendMessageScope.Context>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure("Not a member"));
+
+        var result = await _orchestrator.SendAsync(
+            scopeMock.Object, AnyScope(), "hello", null, null,
+            new List<Guid> { mentionUser.Value }, AnyUser(), TestContext.Current.CancellationToken);
+
+        result.Success.Should().BeFalse();
+        result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.MentionedUserNotMember);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────

--- a/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
@@ -7,6 +7,7 @@ using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Uploads;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Conversations;
 using Harmonie.Domain.ValueObjects.Conversations;
@@ -29,6 +30,7 @@ public sealed class SendConversationMessageHandlerTests
     private readonly Mock<IMessageRepository> _directMessageRepositoryMock;
     private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
     private readonly Mock<IUploadedFileRepository> _uploadedFileRepositoryMock;
+    private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<ILinkPreviewRepository> _linkPreviewRepositoryMock;
@@ -43,6 +45,7 @@ public sealed class SendConversationMessageHandlerTests
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _participantRepositoryMock = new Mock<IConversationParticipantRepository>();
         _directMessageRepositoryMock = new Mock<IMessageRepository>();
+        _userRepositoryMock = new Mock<IUserRepository>();
         _uploadedFileRepositoryMock = new Mock<IUploadedFileRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
@@ -78,6 +81,7 @@ public sealed class SendConversationMessageHandlerTests
             _directMessageRepositoryMock.Object,
             _messageAttachmentRepositoryMock.Object,
             new MessageAttachmentResolver(_uploadedFileRepositoryMock.Object),
+            _userRepositoryMock.Object,
             _unitOfWorkMock.Object);
 
         _handler = new SendMessageHandler(

--- a/tests/Harmonie.Application.Tests/Messages/SendMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SendMessageHandlerTests.cs
@@ -5,8 +5,10 @@ using Harmonie.Application.Features.Channels.SendMessage;
 using Harmonie.Application.Services;
 using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
+using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Messages;
 using Harmonie.Application.Interfaces.Uploads;
+using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
 using Harmonie.Domain.Entities.Guilds;
 using Harmonie.Domain.Entities.Messages;
@@ -27,9 +29,11 @@ namespace Harmonie.Application.Tests.Messages;
 public sealed class SendMessageHandlerTests
 {
     private readonly Mock<IGuildChannelRepository> _guildChannelRepositoryMock;
+    private readonly Mock<IGuildMemberRepository> _guildMemberRepositoryMock;
     private readonly Mock<IMessageRepository> _channelMessageRepositoryMock;
     private readonly Mock<IMessageAttachmentRepository> _messageAttachmentRepositoryMock;
     private readonly Mock<IUploadedFileRepository> _uploadedFileRepositoryMock;
+    private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<ILinkPreviewRepository> _linkPreviewRepositoryMock;
@@ -42,7 +46,9 @@ public sealed class SendMessageHandlerTests
     public SendMessageHandlerTests()
     {
         _guildChannelRepositoryMock = new Mock<IGuildChannelRepository>();
+        _guildMemberRepositoryMock = new Mock<IGuildMemberRepository>();
         _channelMessageRepositoryMock = new Mock<IMessageRepository>();
+        _userRepositoryMock = new Mock<IUserRepository>();
         _uploadedFileRepositoryMock = new Mock<IUploadedFileRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = new Mock<IUnitOfWorkTransaction>();
@@ -78,10 +84,12 @@ public sealed class SendMessageHandlerTests
             _channelMessageRepositoryMock.Object,
             _messageAttachmentRepositoryMock.Object,
             new MessageAttachmentResolver(_uploadedFileRepositoryMock.Object),
+            _userRepositoryMock.Object,
             _unitOfWorkMock.Object);
 
         _handler = new SendMessageHandler(
             _guildChannelRepositoryMock.Object,
+            _guildMemberRepositoryMock.Object,
             _textChannelNotifierMock.Object,
             new LinkPreviewResolutionService(
                 _serviceScopeFactoryMock.Object,

--- a/tests/Harmonie.Domain.Tests/MessageTests.cs
+++ b/tests/Harmonie.Domain.Tests/MessageTests.cs
@@ -195,4 +195,105 @@ public sealed class MessageTests
         message.DeletedAtUtc.Should().NotBeNull();
         message.UpdatedAtUtc.Should().NotBeNull();
     }
+
+    [Fact]
+    public void Create_WithValidMentions_ShouldIncludeMentionedUserIds()
+    {
+        var userId = UserId.New();
+        var mentionA = UserId.New();
+        var mentionB = UserId.New();
+
+        var result = Message.Create(
+            new MessageScope.Channel(GuildChannelId.New()),
+            userId,
+            content: null,
+            mentionedUserIds: new[] { mentionA, mentionB });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.MentionedUserIds.Should().BeEquivalentTo([mentionA, mentionB]);
+    }
+
+    [Fact]
+    public void Create_WithNoMentions_ShouldHaveEmptyCollection()
+    {
+        var result = Message.Create(
+            new MessageScope.Channel(GuildChannelId.New()),
+            UserId.New(),
+            content: null,
+            mentionedUserIds: null);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.MentionedUserIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Create_WithDuplicateMentionedUserIds_ShouldFail()
+    {
+        var duplicateId = UserId.New();
+
+        var result = Message.Create(
+            new MessageScope.Channel(GuildChannelId.New()),
+            UserId.New(),
+            content: null,
+            mentionedUserIds: new[] { duplicateId, duplicateId });
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("distinct");
+    }
+
+    [Fact]
+    public void Create_WithMoreThanMaxMentions_ShouldFail()
+    {
+        var ids = Enumerable.Range(0, Message.MaxMentionedUsers + 1)
+            .Select(_ => UserId.New())
+            .ToArray();
+
+        var result = Message.Create(
+            new MessageScope.Channel(GuildChannelId.New()),
+            UserId.New(),
+            content: null,
+            mentionedUserIds: ids);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain(Message.MaxMentionedUsers.ToString());
+    }
+
+    [Fact]
+    public void Create_WithExactlyMaxMentions_ShouldSucceed()
+    {
+        var ids = Enumerable.Range(0, Message.MaxMentionedUsers)
+            .Select(_ => UserId.New())
+            .ToArray();
+
+        var result = Message.Create(
+            new MessageScope.Channel(GuildChannelId.New()),
+            UserId.New(),
+            content: null,
+            mentionedUserIds: ids);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.MentionedUserIds.Should().HaveCount(Message.MaxMentionedUsers);
+    }
+
+    [Fact]
+    public void Rehydrate_ShouldDefensiveCopyMentionedUserIds()
+    {
+        var mutableList = new List<UserId> { UserId.New(), UserId.New() };
+
+        var message = Message.Rehydrate(
+            MessageId.New(),
+            new MessageScope.Channel(GuildChannelId.New()),
+            UserId.New(),
+            replyToMessageId: null,
+            content: null,
+            DateTime.UtcNow,
+            updatedAtUtc: null,
+            deletedAtUtc: null,
+            mentionedUserIds: mutableList);
+
+        // Verify we got a copy, not the original mutable list
+        message.MentionedUserIds.Should().HaveCount(2);
+        mutableList.Clear();
+        message.MentionedUserIds.Should().HaveCount(2);
+    }
 }

--- a/tools/Harmonie.Migrations/Scripts/20260509_1_CreateMessageMentionsTable.sql
+++ b/tools/Harmonie.Migrations/Scripts/20260509_1_CreateMessageMentionsTable.sql
@@ -1,0 +1,14 @@
+-- Migration: Create message mentions table
+-- Date: 2026-05-09
+-- Description: Stores mentioned user IDs per message for @mention support
+
+CREATE TABLE IF NOT EXISTS message_mentions (
+    message_id UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    mentioned_user_id UUID NOT NULL REFERENCES users(id),
+    CONSTRAINT pk_message_mentions PRIMARY KEY (message_id, mentioned_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_message_mentions_message_id
+    ON message_mentions(message_id);
+
+COMMENT ON TABLE message_mentions IS 'Mentioned users for messages (channel and conversation)';

--- a/tools/Harmonie.Migrations/Scripts/20260509_1_CreateMessageMentionsTable.sql
+++ b/tools/Harmonie.Migrations/Scripts/20260509_1_CreateMessageMentionsTable.sql
@@ -8,7 +8,8 @@ CREATE TABLE IF NOT EXISTS message_mentions (
     CONSTRAINT pk_message_mentions PRIMARY KEY (message_id, mentioned_user_id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_message_mentions_message_id
-    ON message_mentions(message_id);
+-- Index for "find all messages where a user is mentioned" queries
+CREATE INDEX IF NOT EXISTS idx_message_mentions_mentioned_user_id
+    ON message_mentions(mentioned_user_id);
 
 COMMENT ON TABLE message_mentions IS 'Mentioned users for messages (channel and conversation)';

--- a/tools/Harmonie.Migrations/Scripts/20260509_1_CreateMessageMentionsTable.sql
+++ b/tools/Harmonie.Migrations/Scripts/20260509_1_CreateMessageMentionsTable.sql
@@ -4,7 +4,7 @@
 
 CREATE TABLE IF NOT EXISTS message_mentions (
     message_id UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
-    mentioned_user_id UUID NOT NULL REFERENCES users(id),
+    mentioned_user_id UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
     CONSTRAINT pk_message_mentions PRIMARY KEY (message_id, mentioned_user_id)
 );
 

--- a/tools/Harmonie.Migrations/Scripts/20260509_2_FixMessageMentionsIndexes.sql
+++ b/tools/Harmonie.Migrations/Scripts/20260509_2_FixMessageMentionsIndexes.sql
@@ -1,0 +1,9 @@
+-- Migration: Fix message_mentions indexes
+-- Date: 2026-05-09
+-- Description: Replace redundant idx_message_mentions_message_id (covered by PK)
+--              with idx_message_mentions_mentioned_user_id for user-lookup queries.
+
+DROP INDEX IF EXISTS idx_message_mentions_message_id;
+
+CREATE INDEX IF NOT EXISTS idx_message_mentions_mentioned_user_id
+    ON message_mentions(mentioned_user_id);

--- a/tools/Harmonie.Migrations/Scripts/20260509_2_FixMessageMentionsIndexes.sql
+++ b/tools/Harmonie.Migrations/Scripts/20260509_2_FixMessageMentionsIndexes.sql
@@ -1,9 +1,0 @@
--- Migration: Fix message_mentions indexes
--- Date: 2026-05-09
--- Description: Replace redundant idx_message_mentions_message_id (covered by PK)
---              with idx_message_mentions_mentioned_user_id for user-lookup queries.
-
-DROP INDEX IF EXISTS idx_message_mentions_message_id;
-
-CREATE INDEX IF NOT EXISTS idx_message_mentions_mentioned_user_id
-    ON message_mentions(mentioned_user_id);


### PR DESCRIPTION
## Summary

Add the ability to mention users in channel and conversation messages (like Discord/Teams). Mentioned users are sent **explicitly** by the client as a list of user IDs alongside the message content.

## Changes

### Domain
- `Message` entity extended with `MentionedUserIds` (immutable, distinct, max 50)
- Invariants enforced at construction

### Application Layer
- `SendMessageRequest` / `EditMessageRequest` DTOs gain `MentionedUserIds`
- FluentValidation: each ID non-empty GUID, distinct, count ≤ 50
- `MessageSendOrchestrator`: batch-validates users exist (`IUserRepository.GetManyByIdsAsync`) + are members (`ISendMessageScope.ValidateMentionedUsersAsync`)
- `MessageEditDeleteOrchestrator`: atomically replaces mention set on edit
- Channel scope validates via `IGuildMemberRepository.IsMemberAsync`
- Conversation scope validates via participant list

### Persistence
- New `message_mentions` table (message_id FK → messages CASCADE, mentioned_user_id FK → users)
- `IMessageRepository`: `AddMentionsAsync`, `ReplaceMentionsAsync`, `GetMentionedUserIdsByMessageIdAsync`
- Mentions persisted in the same transaction as the message

### Read paths
- `GetMessagesItemResponse` exposes `MentionedUserIds`
- `MessagePage` carries `MentionedUserIdsByMessageId`
- `MessagePaginationRepository` loads mentions for channel + conversation pages

### Error codes
- `MESSAGE_MENTIONED_USER_NOT_FOUND` — user does not exist
- `MESSAGE_MENTIONED_USER_NOT_MEMBER` — user is not a member/participant

### Migration
- `20260509_1_CreateMessageMentionsTable.sql`

## Out of scope (separate issues)
- SignalR events carrying `MentionedUserIds` (can be added in follow-up)
- `@everyone`, `@role`
- Notifications when mentioned
- Search results hydration

## Tests
- ✅ All 1287 tests pass (Domain 200, Infrastructure 17, Application 553, API 43, Integration 474)
- ✅ Build: 0 warnings, 0 errors

Closes #392