### PR TITLE
fix: prevent duplicate direct conversations on concurrent open (#401)

### DIFF
--- a/src/Harmonie.Application/Features/Conversations/OpenConversation/OpenConversationHandler.cs
+++ b/src/Harmonie.Application/Features/Conversations/OpenConversation/OpenConversationHandler.cs
@@ -14,6 +14,7 @@ public sealed class OpenConversationHandler : IAuthenticatedHandler<OpenConversa
     private readonly IUserRepository _userRepository;
     private readonly IConversationRepository _conversationRepository;
     private readonly IConversationParticipantRepository _participantRepository;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly IRealtimeGroupManager _realtimeGroupManager;
     private readonly IConversationNotifier _conversationNotifier;
     private readonly ILogger<OpenConversationHandler> _logger;
@@ -22,6 +23,7 @@ public sealed class OpenConversationHandler : IAuthenticatedHandler<OpenConversa
         IUserRepository userRepository,
         IConversationRepository conversationRepository,
         IConversationParticipantRepository participantRepository,
+        IUnitOfWork unitOfWork,
         IRealtimeGroupManager realtimeGroupManager,
         IConversationNotifier conversationNotifier,
         ILogger<OpenConversationHandler> logger)
@@ -29,6 +31,7 @@ public sealed class OpenConversationHandler : IAuthenticatedHandler<OpenConversa
         _userRepository = userRepository;
         _conversationRepository = conversationRepository;
         _participantRepository = participantRepository;
+        _unitOfWork = unitOfWork;
         _realtimeGroupManager = realtimeGroupManager;
         _conversationNotifier = conversationNotifier;
         _logger = logger;
@@ -66,10 +69,32 @@ public sealed class OpenConversationHandler : IAuthenticatedHandler<OpenConversa
                 "Current user was not found");
         }
 
+        // Transactional scope so a request losing the creation race never leaves
+        // a partially-created conversation behind.
+        await using var transaction = await _unitOfWork.BeginAsync(cancellationToken);
+
         var result = await _conversationRepository.GetOrCreateDirectAsync(
             currentUserId,
             targetUserId,
             cancellationToken);
+
+        if (!result.WasCreated)
+        {
+            // Reopen: clear hidden_at_utc for hidden participants so the conversation reappears
+            var participants = await _participantRepository.GetByConversationIdAsync(result.Conversation.Id, cancellationToken);
+
+            var hidden = participants
+                .Where(p => p.HiddenAtUtc is not null)
+                .ToArray();
+
+            foreach (var p in hidden)
+                p.Unhide();
+
+            if (hidden.Length > 0)
+                await _participantRepository.UpdateRangeAsync(hidden, cancellationToken);
+        }
+
+        await transaction.CommitAsync(cancellationToken);
 
         if (result.WasCreated)
         {
@@ -96,22 +121,6 @@ public sealed class OpenConversationHandler : IAuthenticatedHandler<OpenConversa
                 _logger,
                 "Failed to notify direct conversation {ConversationId} creation",
                 conversationId);
-        }
-        else
-        {
-            // Reopen: clear hidden_at_utc for hidden participants so the conversation reappears
-            var conversationId = result.Conversation.Id;
-            var participants = await _participantRepository.GetByConversationIdAsync(conversationId, cancellationToken);
-
-            var hidden = participants
-                .Where(p => p.HiddenAtUtc is not null)
-                .ToArray();
-
-            foreach (var p in hidden)
-                p.Unhide();
-
-            if (hidden.Length > 0)
-                await _participantRepository.UpdateRangeAsync(hidden, cancellationToken);
         }
 
         var payload = new OpenConversationResponse(

--- a/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
@@ -76,7 +76,9 @@ public sealed class ConversationRepository : IConversationRepository
             return new ConversationGetOrCreateResult(existing!, WasCreated: false);
         }
 
-        // Step 2: create the conversation, participants and lookup entry
+        // Step 2: create the conversation and claim the lookup entry.
+        // The lookup primary key (user1_id, user2_id) is the concurrency guard:
+        // when two requests race past the select above, only one insert wins.
         var newConversationId = ConversationId.New();
         var createdAtUtc = DateTime.UtcNow;
 
@@ -89,6 +91,46 @@ public sealed class ConversationRepository : IConversationRepository
             new { Id = newConversationId.Value, CreatedAtUtc = createdAtUtc },
             transaction: _dbSession.Transaction,
             cancellationToken: cancellationToken));
+
+        const string insertLookupSql = """
+                                        INSERT INTO direct_conversation_lookup (user1_id, user2_id, conversation_id)
+                                        VALUES (@User1Id, @User2Id, @ConversationId)
+                                        ON CONFLICT (user1_id, user2_id) DO NOTHING
+                                        """;
+        var lookupRowsInserted = await connection.ExecuteAsync(new CommandDefinition(
+            insertLookupSql,
+            new { User1Id = user1Id, User2Id = user2Id, ConversationId = newConversationId.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken));
+
+        if (lookupRowsInserted == 0)
+        {
+            // Lost the race: a concurrent request created the conversation for this
+            // pair first. Discard our conversation and return the winning one.
+            const string deleteConversationSql = """
+                                                  DELETE FROM conversations WHERE id = @Id
+                                                  """;
+            await connection.ExecuteAsync(new CommandDefinition(
+                deleteConversationSql,
+                new { Id = newConversationId.Value },
+                transaction: _dbSession.Transaction,
+                cancellationToken: cancellationToken));
+
+            var winningConversationId = await connection.QueryFirstOrDefaultAsync<Guid?>(new CommandDefinition(
+                selectLookupSql,
+                new { User1Id = user1Id, User2Id = user2Id },
+                transaction: _dbSession.Transaction,
+                cancellationToken: cancellationToken));
+
+            if (winningConversationId is null)
+                throw new InvalidOperationException("Direct conversation lookup entry disappeared after insert conflict.");
+
+            var winner = await GetByIdAsync(ConversationId.From(winningConversationId.Value), cancellationToken);
+            if (winner is null)
+                throw new InvalidOperationException("Direct conversation referenced by lookup entry was not found.");
+
+            return new ConversationGetOrCreateResult(winner, WasCreated: false);
+        }
 
         const string insertParticipantsSql = """
                                               INSERT INTO conversation_participants (conversation_id, user_id, joined_at_utc)
@@ -104,17 +146,6 @@ public sealed class ConversationRepository : IConversationRepository
                 UserId2 = secondUserId.Value,
                 JoinedAt = createdAtUtc
             },
-            transaction: _dbSession.Transaction,
-            cancellationToken: cancellationToken));
-
-        const string insertLookupSql = """
-                                        INSERT INTO direct_conversation_lookup (user1_id, user2_id, conversation_id)
-                                        VALUES (@User1Id, @User2Id, @ConversationId)
-                                        ON CONFLICT (user1_id, user2_id) DO NOTHING
-                                        """;
-        await connection.ExecuteAsync(new CommandDefinition(
-            insertLookupSql,
-            new { User1Id = user1Id, User2Id = user2Id, ConversationId = newConversationId.Value },
             transaction: _dbSession.Transaction,
             cancellationToken: cancellationToken));
 

--- a/tests/Harmonie.API.IntegrationTests/Conversations/ConversationEndpointsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/ConversationEndpointsTests.cs
@@ -72,6 +72,47 @@ public sealed class ConversationEndpointsTests : IClassFixture<HarmonieWebApplic
     }
 
     [Fact]
+    public async Task OpenConversation_ConcurrentRequestsForSamePair_ShouldCreateSingleConversation()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var target = await AuthTestHelper.RegisterAsync(_client);
+
+        var openTasks = Enumerable.Range(0, 6)
+            .Select(i => i % 2 == 0
+                ? _client.SendAuthorizedPostAsync(
+                    "/api/conversations",
+                    new OpenConversationRequest(target.UserId),
+                    caller.AccessToken)
+                : _client.SendAuthorizedPostAsync(
+                    "/api/conversations",
+                    new OpenConversationRequest(caller.UserId),
+                    target.AccessToken))
+            .ToArray();
+
+        var responses = await Task.WhenAll(openTasks);
+
+        var payloads = new List<OpenConversationResponse>();
+        foreach (var response in responses)
+        {
+            response.StatusCode.Should().BeOneOf(HttpStatusCode.Created, HttpStatusCode.OK);
+            var payload = await response.Content.ReadFromJsonAsync<OpenConversationResponse>(TestContext.Current.CancellationToken);
+            payload.Should().NotBeNull();
+            payloads.Add(payload!);
+        }
+
+        payloads.Select(p => p.ConversationId).Distinct().Should().HaveCount(1);
+        payloads.Count(p => p.Created).Should().Be(1);
+
+        var listResponse = await _client.SendAuthorizedGetAsync("/api/conversations", caller.AccessToken);
+        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var listPayload = await listResponse.Content.ReadFromJsonAsync<ListConversationsResponse>(TestContext.Current.CancellationToken);
+        listPayload.Should().NotBeNull();
+        listPayload!.Conversations.Should().ContainSingle(c =>
+            c.Participants.Any(p => p.UserId == target.UserId));
+    }
+
+    [Fact]
     public async Task OpenConversation_WhenTargetUserDoesNotExist_ShouldReturnNotFound()
     {
         var caller = await AuthTestHelper.RegisterAsync(_client);

--- a/tests/Harmonie.Application.Tests/Conversations/OpenConversationHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Conversations/OpenConversationHandlerTests.cs
@@ -21,6 +21,8 @@ public sealed class OpenConversationHandlerTests
     private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IConversationRepository> _conversationRepositoryMock;
     private readonly Mock<IConversationParticipantRepository> _participantRepositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IConversationNotifier> _conversationNotifierMock;
     private readonly OpenConversationHandler _handler;
 
@@ -29,6 +31,8 @@ public sealed class OpenConversationHandlerTests
         _userRepositoryMock = new Mock<IUserRepository>();
         _conversationRepositoryMock = new Mock<IConversationRepository>();
         _participantRepositoryMock = new Mock<IConversationParticipantRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _transactionMock = _unitOfWorkMock.SetupTransactionMock();
         _conversationNotifierMock = new Mock<IConversationNotifier>();
 
         _participantRepositoryMock
@@ -43,6 +47,7 @@ public sealed class OpenConversationHandlerTests
             _userRepositoryMock.Object,
             _conversationRepositoryMock.Object,
             _participantRepositoryMock.Object,
+            _unitOfWorkMock.Object,
             new Mock<IRealtimeGroupManager>().Object,
             _conversationNotifierMock.Object,
             NullLogger<OpenConversationHandler>.Instance);
@@ -242,6 +247,34 @@ public sealed class OpenConversationHandlerTests
         _participantRepositoryMock.Verify(
             x => x.UpdateRangeAsync(It.IsAny<IReadOnlyList<ConversationParticipant>>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenConversationIsOpened_ShouldCommitTransaction()
+    {
+        var callerUserId = UserId.New();
+        var targetUserId = UserId.New();
+        var callerUser = CreateUser(callerUserId, "caller");
+        var targetUser = CreateUser(targetUserId, "target");
+        var conversation = ApplicationTestBuilders.CreateConversation(callerUserId, targetUserId);
+
+        _userRepositoryMock
+            .Setup(x => x.GetManyByIdsAsync(
+                It.Is<IReadOnlyList<UserId>>(ids => ids.Contains(callerUserId) && ids.Contains(targetUserId)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([callerUser, targetUser]);
+
+        _conversationRepositoryMock
+            .Setup(x => x.GetOrCreateDirectAsync(callerUserId, targetUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationGetOrCreateResult(conversation, true));
+
+        var response = await _handler.HandleAsync(
+            new OpenConversationRequest(targetUserId),
+            callerUserId,
+            TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        _transactionMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/tools/Harmonie.Migrations/Scripts/20260612_1_DeduplicateDirectConversations.sql
+++ b/tools/Harmonie.Migrations/Scripts/20260612_1_DeduplicateDirectConversations.sql
@@ -1,0 +1,71 @@
+-- Migration: Deduplicate direct conversations
+-- Date: 2026-06-12
+-- Description: A race in direct conversation creation could persist several
+--              conversations for the same user pair: the lookup insert used
+--              ON CONFLICT DO NOTHING, so the losing request silently kept its
+--              own conversation (issue #401). This script merges every
+--              duplicate into the canonical conversation referenced by
+--              direct_conversation_lookup, then removes the duplicates.
+--              Read states that exist on both sides are dropped with the
+--              duplicate: worst case some messages show as unread again,
+--              never as silently read.
+
+-- Step 1: ensure every direct pair has a canonical lookup entry.
+-- Normally guaranteed by the lookup table backfill; this is a fail-safe so the
+-- merge below never deletes a conversation without a canonical target.
+-- Oldest conversation of the pair wins.
+INSERT INTO direct_conversation_lookup (user1_id, user2_id, conversation_id)
+SELECT DISTINCT ON (cp1.user_id, cp2.user_id)
+       cp1.user_id,
+       cp2.user_id,
+       c.id
+FROM conversations c
+JOIN conversation_participants cp1 ON cp1.conversation_id = c.id
+JOIN conversation_participants cp2 ON cp2.conversation_id = c.id AND cp1.user_id < cp2.user_id
+WHERE c.type = 'direct'
+ORDER BY cp1.user_id, cp2.user_id, c.created_at_utc, c.id
+ON CONFLICT (user1_id, user2_id) DO NOTHING;
+
+-- Step 2: re-point messages from duplicate conversations to the canonical one.
+UPDATE messages m
+SET conversation_id = dcl.conversation_id
+FROM conversations c
+JOIN conversation_participants cp1 ON cp1.conversation_id = c.id
+JOIN conversation_participants cp2 ON cp2.conversation_id = c.id AND cp1.user_id < cp2.user_id
+JOIN direct_conversation_lookup dcl ON dcl.user1_id = cp1.user_id AND dcl.user2_id = cp2.user_id
+WHERE m.conversation_id = c.id
+  AND c.type = 'direct'
+  AND c.id <> dcl.conversation_id;
+
+-- Step 3: move read states to the canonical conversation when the user has
+-- none there yet. Conflicting read states stay on the duplicate and are
+-- removed with it in step 4.
+UPDATE conversation_read_states crs
+SET conversation_id = dcl.conversation_id
+FROM conversations c
+JOIN conversation_participants cp1 ON cp1.conversation_id = c.id
+JOIN conversation_participants cp2 ON cp2.conversation_id = c.id AND cp1.user_id < cp2.user_id
+JOIN direct_conversation_lookup dcl ON dcl.user1_id = cp1.user_id AND dcl.user2_id = cp2.user_id
+WHERE crs.conversation_id = c.id
+  AND c.type = 'direct'
+  AND c.id <> dcl.conversation_id
+  AND NOT EXISTS (
+      SELECT 1
+      FROM conversation_read_states existing
+      WHERE existing.user_id = crs.user_id
+        AND existing.conversation_id = dcl.conversation_id
+  );
+
+-- Step 4: delete duplicate conversations. Participants and leftover read
+-- states are removed by ON DELETE CASCADE; messages were moved in step 2.
+DELETE FROM conversations c
+USING conversation_participants cp1,
+      conversation_participants cp2,
+      direct_conversation_lookup dcl
+WHERE cp1.conversation_id = c.id
+  AND cp2.conversation_id = c.id
+  AND cp1.user_id < cp2.user_id
+  AND dcl.user1_id = cp1.user_id
+  AND dcl.user2_id = cp2.user_id
+  AND c.type = 'direct'
+  AND c.id <> dcl.conversation_id;


### PR DESCRIPTION
## Summary

Fixes #401 — a user could end up with two direct conversations with the same person (the issue shows two conversations with Quenteffroy created 2 ms apart).

### Root cause
`ConversationRepository.GetOrCreateDirectAsync` raced between the `direct_conversation_lookup` select and insert. Two concurrent open requests both missed the fast-path select and both created a conversation; the lookup insert used `ON CONFLICT (user1_id, user2_id) DO NOTHING`, so the losing request **silently kept its own conversation** — orphaned from the lookup table but fully visible in the conversation list.

### Fix
- **Repository**: reorder the inserts (conversation → lookup → participants) and check the lookup insert's affected row count. When the insert conflicts, the request lost the race: its conversation is discarded and the winning conversation is returned with `created: false`. The lookup primary key is now the actual concurrency guard.
- **Handler**: `OpenConversationHandler` wraps the get-or-create and the reopen/unhide path in an `IUnitOfWork` transaction (same convention as `UpdateGroupConversationHandler` / `AcknowledgeRead`), so a crash mid-creation can no longer leave partial rows. Notifications stay after commit.
- **Migration** `20260612_1_DeduplicateDirectConversations.sql` (backfill in the same rollout): merges existing duplicates into the canonical conversation referenced by the lookup table — re-points messages (pins/reactions/mentions follow since they reference messages), moves read states when the user has none on the canonical side, then deletes the duplicates. Conflicting read states are dropped with the duplicate: worst case some messages show as unread again, never as silently read.

### Tests
- New integration test: 6 concurrent open requests (both directions) → single conversation id, exactly one `created: true`, single entry in the conversation list.
- Updated `OpenConversationHandlerTests` for the new `IUnitOfWork` dependency + commit assertion.
- `Harmonie.Application.Tests`: 563 passed. `Harmonie.API.IntegrationTests`: 500 passed (after running the new migration).