### PR TITLE
Add dedicated Harmonie.Workers host

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,6 +38,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.0" />
   </ItemGroup>
   <!-- Testing -->

--- a/Harmonie.sln
+++ b/Harmonie.sln
@@ -46,6 +46,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmonie.Infrastructure.Tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmonie.API.Tests", "tests\Harmonie.API.Tests\Harmonie.API.Tests.csproj", "{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmonie.Workers", "src\Harmonie.Workers\Harmonie.Workers.csproj", "{4B03C010-5B78-454D-B589-13AC20B1D13B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -176,6 +178,18 @@ Global
 		{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F}.Release|x64.Build.0 = Release|Any CPU
 		{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F}.Release|x86.ActiveCfg = Release|Any CPU
 		{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F}.Release|x86.Build.0 = Release|Any CPU
+		{4B03C010-5B78-454D-B589-13AC20B1D13B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4B03C010-5B78-454D-B589-13AC20B1D13B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4B03C010-5B78-454D-B589-13AC20B1D13B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4B03C010-5B78-454D-B589-13AC20B1D13B}.Debug|x64.Build.0 = Debug|Any CPU
+		{4B03C010-5B78-454D-B589-13AC20B1D13B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4B03C010-5B78-454D-B589-13AC20B1D13B}.Debug|x86.Build.0 = Debug|Any CPU
+		{4B03C010-5B78-454D-B589-13AC20B1D13B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4B03C010-5B78-454D-B589-13AC20B1D13B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4B03C010-5B78-454D-B589-13AC20B1D13B}.Release|x64.ActiveCfg = Release|Any CPU
+		{4B03C010-5B78-454D-B589-13AC20B1D13B}.Release|x64.Build.0 = Release|Any CPU
+		{4B03C010-5B78-454D-B589-13AC20B1D13B}.Release|x86.ActiveCfg = Release|Any CPU
+		{4B03C010-5B78-454D-B589-13AC20B1D13B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -191,6 +205,7 @@ Global
 		{D1E7A1F1-8C2E-4D3A-9F5B-1234567890C1} = {E1E7A1F1-8C2E-4D3A-9F5B-1234567890D3}
 		{41BF7DBE-349D-41F0-8779-CD2A42AAB553} = {E1E7A1F1-8C2E-4D3A-9F5B-1234567890D2}
 		{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F} = {E1E7A1F1-8C2E-4D3A-9F5B-1234567890D2}
+		{4B03C010-5B78-454D-B589-13AC20B1D13B} = {E1E7A1F1-8C2E-4D3A-9F5B-1234567890D1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F1E7A1F1-8C2E-4D3A-9F5B-1234567890E1}

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ src/
   Harmonie.Application/      # Vertical slices (feature endpoints/handlers/validators)
   Harmonie.Domain/           # Entities, value objects, domain rules
   Harmonie.Infrastructure/   # Dapper repositories, JWT service, hashing
+  Harmonie.Workers/          # Independent background worker host
 tests/
   Harmonie.Domain.Tests/
   Harmonie.Application.Tests/

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -87,6 +87,24 @@ services:
     networks:
       - harmonie-network
 
+  # Harmonie background workers (optional)
+  harmonie-workers:
+    profiles: ["workers"]
+    build:
+      context: .
+      dockerfile: src/Harmonie.Workers/Dockerfile
+    container_name: harmonie-workers
+    environment:
+      - DOTNET_ENVIRONMENT=Development
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=harmonie;Username=harmonie_user;Password=harmonie_password
+    depends_on:
+      postgres:
+        condition: service_healthy
+      harmonie-migrations:
+        condition: service_completed_successfully
+    networks:
+      - harmonie-network
+
 volumes:
   postgres-data:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,24 @@ services:
     networks:
       - harmonie-network
 
+  # Harmonie background workers (optional)
+  harmonie-workers:
+    profiles: ["workers"]
+    build:
+      context: .
+      dockerfile: src/Harmonie.Workers/Dockerfile
+    container_name: harmonie-workers
+    environment:
+      - DOTNET_ENVIRONMENT=Development
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=harmonie;Username=harmonie_user;Password=harmonie_password
+    depends_on:
+      postgres:
+        condition: service_healthy
+      harmonie-migrations:
+        condition: service_completed_successfully
+    networks:
+      - harmonie-network
+
 volumes:
   postgres-data:
     driver: local

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,6 +43,14 @@ Responsibilities:
 - Dapper-based repositories
 - JWT generation/validation and password hashing
 - Options/configuration objects
+- Modular DI registration so API and worker hosts can opt into only the infrastructure they need
+
+## Workers (`src/Harmonie.Workers`)
+
+Responsibilities:
+- Independent background worker host
+- Long-running/background orchestration that should not share the HTTP API process
+- Reuses Application services and Infrastructure adapters without depending on `Harmonie.API`
 
 ## Data and Migration Strategy
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -76,7 +76,30 @@ be backed by an S3-compatible service.
 - Health: `GET /health`
 - OpenAPI: browse Scalar API reference at `/scalar` (Development only)
 
-## 5. Run Tests
+## 5. Run Background Workers
+
+The worker host is a separate executable in the same solution. It currently provides the runtime host for background notification work and can be run independently from the API.
+
+PowerShell:
+
+```powershell
+$env:DOTNET_ENVIRONMENT = "Development"
+dotnet run --project src/Harmonie.Workers
+```
+
+Bash:
+
+```bash
+DOTNET_ENVIRONMENT=Development dotnet run --project src/Harmonie.Workers
+```
+
+With compose, the worker service is optional and behind the `workers` profile:
+
+```bash
+podman compose --profile workers up -d harmonie-workers
+```
+
+## 6. Run Tests
 
 ```bash
 dotnet test

--- a/src/Harmonie.Infrastructure/DependencyInjection.cs
+++ b/src/Harmonie.Infrastructure/DependencyInjection.cs
@@ -25,41 +25,26 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Harmonie.Infrastructure;
+
 public static class DependencyInjection
 {
     public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
     {
-        services.AddOptions<JwtSettings>()
-            .Bind(configuration.GetSection("Jwt"))
-            .ValidateDataAnnotations()
-            .ValidateOnStart();
+        services.AddPersistence(configuration);
+        services.AddAuthInfrastructure(configuration);
+        services.AddLiveKitInfrastructure(configuration);
+        services.AddObjectStorageInfrastructure(configuration);
+        services.AddLinkPreviewInfrastructure();
+
+        return services;
+    }
+
+    public static IServiceCollection AddPersistence(this IServiceCollection services, IConfiguration configuration)
+    {
         services.AddOptions<DatabaseSettings>()
             .Configure(options => options.ConnectionString = configuration.GetConnectionString("DefaultConnection") ?? string.Empty)
             .ValidateDataAnnotations()
             .ValidateOnStart();
-        services.AddOptions<LiveKitSettings>()
-            .Bind(configuration.GetSection("LiveKit"))
-            .ValidateDataAnnotations()
-            .ValidateOnStart();
-        services.AddOptions<ObjectStorageSettings>()
-            .Bind(configuration.GetSection("ObjectStorage"))
-            .ValidateDataAnnotations()
-            .Validate(
-                settings => Uri.TryCreate(settings.LocalBaseUrl, UriKind.Absolute, out _),
-                "ObjectStorage:LocalBaseUrl must be a valid absolute URL.")
-            .ValidateOnStart();
-        services.AddScoped<IPasswordHasher, PasswordHasher>();
-        services.AddScoped<IJwtTokenService, JwtTokenService>();
-        services.AddScoped<ILiveKitTokenService, LiveKitTokenService>();
-        services.AddScoped<ILiveKitWebhookReceiver, LiveKitWebhookReceiver>();
-        services.AddSingleton(sp =>
-        {
-            _ = sp.GetRequiredService<IOptions<LiveKitSettings>>().Value;
-            return new HttpClient();
-        });
-        services.AddSingleton<ILiveKitRoomApiClient, LiveKitSdkRoomApiClient>();
-        services.AddScoped<ILiveKitRoomService, LiveKitRoomService>();
-        services.AddScoped<IObjectStorageService, LocalFileSystemObjectStorageService>();
 
         var connectionString = configuration.GetConnectionString("DefaultConnection")
             ?? throw new InvalidOperationException("Connection string 'DefaultConnection' is required.");
@@ -87,7 +72,59 @@ public static class DependencyInjection
         services.AddScoped<IConversationReadStateRepository, ConversationReadStateRepository>();
         services.AddScoped<IUserSubscriptionRepository, UserSubscriptionRepository>();
 
-        // Link preview
+        return services;
+    }
+
+    public static IServiceCollection AddAuthInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddOptions<JwtSettings>()
+            .Bind(configuration.GetSection("Jwt"))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddScoped<IPasswordHasher, PasswordHasher>();
+        services.AddScoped<IJwtTokenService, JwtTokenService>();
+
+        return services;
+    }
+
+    public static IServiceCollection AddLiveKitInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddOptions<LiveKitSettings>()
+            .Bind(configuration.GetSection("LiveKit"))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddSingleton(sp =>
+        {
+            _ = sp.GetRequiredService<IOptions<LiveKitSettings>>().Value;
+            return new HttpClient();
+        });
+        services.AddSingleton<ILiveKitRoomApiClient, LiveKitSdkRoomApiClient>();
+        services.AddScoped<ILiveKitTokenService, LiveKitTokenService>();
+        services.AddScoped<ILiveKitWebhookReceiver, LiveKitWebhookReceiver>();
+        services.AddScoped<ILiveKitRoomService, LiveKitRoomService>();
+
+        return services;
+    }
+
+    public static IServiceCollection AddObjectStorageInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddOptions<ObjectStorageSettings>()
+            .Bind(configuration.GetSection("ObjectStorage"))
+            .ValidateDataAnnotations()
+            .Validate(
+                settings => Uri.TryCreate(settings.LocalBaseUrl, UriKind.Absolute, out _),
+                "ObjectStorage:LocalBaseUrl must be a valid absolute URL.")
+            .ValidateOnStart();
+
+        services.AddScoped<IObjectStorageService, LocalFileSystemObjectStorageService>();
+
+        return services;
+    }
+
+    public static IServiceCollection AddLinkPreviewInfrastructure(this IServiceCollection services)
+    {
         services.AddHttpClient<ILinkPreviewFetcher, LinkPreviewFetcher>(client =>
         {
             client.Timeout = TimeSpan.FromSeconds(5);

--- a/src/Harmonie.Workers/Dockerfile
+++ b/src/Harmonie.Workers/Dockerfile
@@ -1,0 +1,35 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+# Copy solution and project files
+COPY ["Directory.Packages.props", "./"]
+COPY ["Harmonie.sln", "./"]
+COPY ["src/Harmonie.Domain/Harmonie.Domain.csproj", "src/Harmonie.Domain/"]
+COPY ["src/Harmonie.Application/Harmonie.Application.csproj", "src/Harmonie.Application/"]
+COPY ["src/Harmonie.Infrastructure/Harmonie.Infrastructure.csproj", "src/Harmonie.Infrastructure/"]
+COPY ["src/Harmonie.Workers/Harmonie.Workers.csproj", "src/Harmonie.Workers/"]
+
+# Restore dependencies
+RUN dotnet restore "src/Harmonie.Workers/Harmonie.Workers.csproj"
+
+# Copy everything else and build
+COPY . .
+WORKDIR "/src/src/Harmonie.Workers"
+RUN dotnet build "Harmonie.Workers.csproj" -c Release -o /app/build
+
+# Publish stage
+FROM build AS publish
+RUN dotnet publish "Harmonie.Workers.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS final
+WORKDIR /app
+
+# Copy published app
+COPY --from=publish /app/publish .
+
+# Set environment
+ENV DOTNET_ENVIRONMENT=Production
+
+ENTRYPOINT ["dotnet", "Harmonie.Workers.dll"]

--- a/src/Harmonie.Workers/Harmonie.Workers.csproj
+++ b/src/Harmonie.Workers/Harmonie.Workers.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Harmonie.Application\Harmonie.Application.csproj" />
+    <ProjectReference Include="..\Harmonie.Infrastructure\Harmonie.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/Harmonie.Workers/Program.cs
+++ b/src/Harmonie.Workers/Program.cs
@@ -1,0 +1,15 @@
+using Harmonie.Infrastructure;
+using Harmonie.Workers.Workers.Notifications;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
+{
+    Args = args,
+    ContentRootPath = AppContext.BaseDirectory
+});
+
+builder.Services.AddPersistence(builder.Configuration);
+builder.Services.AddHostedService<PushNotificationWorker>();
+
+await builder.Build().RunAsync();

--- a/src/Harmonie.Workers/Properties/launchSettings.json
+++ b/src/Harmonie.Workers/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Harmonie.Workers": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Harmonie.Workers/Workers/Notifications/PushNotificationWorker.cs
+++ b/src/Harmonie.Workers/Workers/Notifications/PushNotificationWorker.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Harmonie.Workers.Workers.Notifications;
+
+public sealed class PushNotificationWorker : BackgroundService
+{
+    private readonly ILogger<PushNotificationWorker> _logger;
+
+    public PushNotificationWorker(ILogger<PushNotificationWorker> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Push notification worker started. Dispatch is not implemented yet.");
+
+        try
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, stoppingToken);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Expected during graceful shutdown.
+        }
+    }
+}

--- a/src/Harmonie.Workers/appsettings.Development.json
+++ b/src/Harmonie.Workers/appsettings.Development.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=harmonie;Username=harmonie_user;Password=harmonie_password"
+  }
+}

--- a/src/Harmonie.Workers/appsettings.json
+++ b/src/Harmonie.Workers/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add a new `Harmonie.Workers` executable host to the solution.
- Add a placeholder `PushNotificationWorker` for future Web Push dispatch work.
- Split Infrastructure DI into modular registration methods so non-API hosts can opt into persistence only.
- Add a dedicated workers Dockerfile and optional compose service behind the `workers` profile.
- Document independent worker startup in README/architecture/getting started docs.

## Tests

- `ConnectionStrings__DefaultConnection='Host=localhost;Port=54321;Database=harmonie;Username=harmonie_user;Password=harmonie_password' dotnet test`

Closes #410
