### PR TITLE
Add Web Push notification device registration

### DIFF
--- a/src/Harmonie.API/Endpoints/NotificationEndpoints.cs
+++ b/src/Harmonie.API/Endpoints/NotificationEndpoints.cs
@@ -1,0 +1,11 @@
+using Harmonie.Application.Features.Notifications.RegisterWebPushDevice;
+
+namespace Harmonie.API.Endpoints;
+
+public static class NotificationEndpoints
+{
+    public static void MapNotificationEndpoints(this IEndpointRouteBuilder app)
+    {
+        RegisterWebPushDeviceEndpoint.Map(app);
+    }
+}

--- a/src/Harmonie.API/Program.cs
+++ b/src/Harmonie.API/Program.cs
@@ -67,6 +67,7 @@ app.MapConversationEndpoints();
 app.MapUserEndpoints();
 app.MapUploadEndpoints();
 app.MapVoiceEndpoints();
+app.MapNotificationEndpoints();
 app.MapHub<RealtimeHub>("/hubs/realtime");
 
 app.Run();

--- a/src/Harmonie.Application/DependencyInjection.cs
+++ b/src/Harmonie.Application/DependencyInjection.cs
@@ -31,6 +31,7 @@ public static class DependencyInjection
         services.AddUserHandlers();
         services.AddUploadHandlers();
         services.AddVoiceHandlers();
+        services.AddNotificationHandlers();
 
         return services;
     }

--- a/src/Harmonie.Application/Features/Notifications/RegisterWebPushDevice/RegisterWebPushDeviceEndpoint.cs
+++ b/src/Harmonie.Application/Features/Notifications/RegisterWebPushDevice/RegisterWebPushDeviceEndpoint.cs
@@ -1,0 +1,61 @@
+using FluentValidation;
+using Harmonie.Application.Common;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Harmonie.Application.Features.Notifications.RegisterWebPushDevice;
+
+public static class RegisterWebPushDeviceEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        app.MapPut("/api/notifications/push-subscriptions", HandleAsync)
+            .WithName("RegisterWebPushDevice")
+            .WithTags("Notifications")
+            .RequireAuthorization()
+            .WithSummary("Register a Web Push notification device")
+            .WithDescription("Registers or updates the authenticated user's Web Push subscription. Internally this is stored as a web_push notification device so other push platforms can be added later.")
+            .WithJsonRequestBodyDocumentation(
+                "Web Push subscription returned by PushManager.subscribe().",
+                (
+                    "webPushSubscription",
+                    "Register a browser Web Push subscription",
+                    new
+                    {
+                        endpoint = "https://updates.push.services.mozilla.com/wpush/v2/example",
+                        expirationTime = (long?)null,
+                        keys = new
+                        {
+                            p256dh = "base64url-p256dh-key",
+                            auth = "base64url-auth-secret"
+                        }
+                    }))
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesErrors(
+                ApplicationErrorCodes.Common.ValidationFailed,
+                ApplicationErrorCodes.Auth.InvalidCredentials,
+                ApplicationErrorCodes.User.NotFound);
+    }
+
+    private static async Task<IResult> HandleAsync(
+        [FromBody] RegisterWebPushDeviceRequest request,
+        [FromServices] IAuthenticatedHandler<RegisterWebPushDeviceRequest, bool> handler,
+        [FromServices] IValidator<RegisterWebPushDeviceRequest> validator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var validationError = await request.ValidateAsync(validator, cancellationToken);
+        if (validationError is not null)
+            return ApplicationResponse<bool>.Fail(validationError).ToHttpResult(httpContext);
+
+        var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
+        var response = await handler.HandleAsync(request, currentUserId, cancellationToken);
+
+        if (!response.Success)
+            return response.ToHttpResult(httpContext);
+
+        return Results.NoContent();
+    }
+}

--- a/src/Harmonie.Application/Features/Notifications/RegisterWebPushDevice/RegisterWebPushDeviceHandler.cs
+++ b/src/Harmonie.Application/Features/Notifications/RegisterWebPushDevice/RegisterWebPushDeviceHandler.cs
@@ -1,0 +1,53 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Application.Interfaces.Users;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Features.Notifications.RegisterWebPushDevice;
+
+public sealed class RegisterWebPushDeviceHandler : IAuthenticatedHandler<RegisterWebPushDeviceRequest, bool>
+{
+    private readonly IUserRepository _userRepository;
+    private readonly INotificationDeviceRepository _notificationDeviceRepository;
+
+    public RegisterWebPushDeviceHandler(
+        IUserRepository userRepository,
+        INotificationDeviceRepository notificationDeviceRepository)
+    {
+        _userRepository = userRepository;
+        _notificationDeviceRepository = notificationDeviceRepository;
+    }
+
+    public async Task<ApplicationResponse<bool>> HandleAsync(
+        RegisterWebPushDeviceRequest request,
+        UserId currentUserId,
+        CancellationToken cancellationToken = default)
+    {
+        var user = await _userRepository.GetByIdAsync(currentUserId, cancellationToken);
+        if (user is null)
+        {
+            return ApplicationResponse<bool>.Fail(
+                ApplicationErrorCodes.User.NotFound,
+                "User was not found");
+        }
+
+        DateTime? expiresAtUtc = null;
+        if (request.ExpirationTime.HasValue)
+        {
+            expiresAtUtc = DateTimeOffset
+                .FromUnixTimeMilliseconds(request.ExpirationTime.Value)
+                .UtcDateTime;
+        }
+
+        await _notificationDeviceRepository.UpsertWebPushAsync(
+            new WebPushNotificationDeviceRegistration(
+                currentUserId,
+                request.Endpoint,
+                request.Keys.P256dh,
+                request.Keys.Auth,
+                expiresAtUtc),
+            cancellationToken);
+
+        return ApplicationResponse<bool>.Ok(true);
+    }
+}

--- a/src/Harmonie.Application/Features/Notifications/RegisterWebPushDevice/RegisterWebPushDeviceRequest.cs
+++ b/src/Harmonie.Application/Features/Notifications/RegisterWebPushDevice/RegisterWebPushDeviceRequest.cs
@@ -1,0 +1,10 @@
+namespace Harmonie.Application.Features.Notifications.RegisterWebPushDevice;
+
+public sealed record RegisterWebPushDeviceRequest(
+    string Endpoint,
+    long? ExpirationTime,
+    RegisterWebPushDeviceKeysRequest Keys);
+
+public sealed record RegisterWebPushDeviceKeysRequest(
+    string P256dh,
+    string Auth);

--- a/src/Harmonie.Application/Features/Notifications/RegisterWebPushDevice/RegisterWebPushDeviceValidator.cs
+++ b/src/Harmonie.Application/Features/Notifications/RegisterWebPushDevice/RegisterWebPushDeviceValidator.cs
@@ -1,0 +1,43 @@
+using FluentValidation;
+
+namespace Harmonie.Application.Features.Notifications.RegisterWebPushDevice;
+
+public sealed class RegisterWebPushDeviceValidator : AbstractValidator<RegisterWebPushDeviceRequest>
+{
+    private static readonly long MaxUnixTimeMilliseconds = DateTimeOffset.MaxValue.ToUnixTimeMilliseconds();
+
+    public RegisterWebPushDeviceValidator()
+    {
+        RuleFor(x => x.Endpoint)
+            .NotEmpty()
+            .WithMessage("Endpoint is required")
+            .Must(BeHttpsAbsoluteUri)
+            .WithMessage("Endpoint must be an absolute HTTPS URI");
+
+        RuleFor(x => x.ExpirationTime)
+            .GreaterThan(0L)
+            .WithMessage("ExpirationTime must be a positive Unix time in milliseconds")
+            .LessThanOrEqualTo(MaxUnixTimeMilliseconds)
+            .WithMessage("ExpirationTime is out of range")
+            .When(x => x.ExpirationTime.HasValue);
+
+        RuleFor(x => x.Keys)
+            .NotNull()
+            .WithMessage("Keys are required");
+
+        When(x => x.Keys is not null, () =>
+        {
+            RuleFor(x => x.Keys.P256dh)
+                .NotEmpty()
+                .WithMessage("P256dh key is required");
+
+            RuleFor(x => x.Keys.Auth)
+                .NotEmpty()
+                .WithMessage("Auth key is required");
+        });
+    }
+
+    private static bool BeHttpsAbsoluteUri(string endpoint)
+        => Uri.TryCreate(endpoint, UriKind.Absolute, out var uri)
+           && uri.Scheme == Uri.UriSchemeHttps;
+}

--- a/src/Harmonie.Application/Interfaces/Notifications/INotificationDeviceRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Notifications/INotificationDeviceRepository.cs
@@ -1,0 +1,17 @@
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Interfaces.Notifications;
+
+public sealed record WebPushNotificationDeviceRegistration(
+    UserId UserId,
+    string Endpoint,
+    string P256dh,
+    string Auth,
+    DateTime? ExpiresAtUtc);
+
+public interface INotificationDeviceRepository
+{
+    Task UpsertWebPushAsync(
+        WebPushNotificationDeviceRegistration registration,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Harmonie.Application/Registration/NotificationRegistration.cs
+++ b/src/Harmonie.Application/Registration/NotificationRegistration.cs
@@ -1,0 +1,15 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Notifications.RegisterWebPushDevice;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Harmonie.Application.Registration;
+
+public static class NotificationRegistration
+{
+    public static IServiceCollection AddNotificationHandlers(this IServiceCollection services)
+    {
+        services.AddAuthenticatedHandler<RegisterWebPushDeviceRequest, bool, RegisterWebPushDeviceHandler>();
+
+        return services;
+    }
+}

--- a/src/Harmonie.Infrastructure/DependencyInjection.cs
+++ b/src/Harmonie.Infrastructure/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Notifications;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Interfaces.Voice;
@@ -17,6 +18,7 @@ using Harmonie.Infrastructure.Persistence.Common;
 using Harmonie.Infrastructure.Persistence.Conversations;
 using Harmonie.Infrastructure.Persistence.Guilds;
 using Harmonie.Infrastructure.Persistence.Messages;
+using Harmonie.Infrastructure.Persistence.Notifications;
 using Harmonie.Infrastructure.Persistence.Uploads;
 using Harmonie.Infrastructure.Persistence.Users;
 using Harmonie.Infrastructure.Services;
@@ -71,6 +73,7 @@ public static class DependencyInjection
         services.AddScoped<IChannelReadStateRepository, ChannelReadStateRepository>();
         services.AddScoped<IConversationReadStateRepository, ConversationReadStateRepository>();
         services.AddScoped<IUserSubscriptionRepository, UserSubscriptionRepository>();
+        services.AddScoped<INotificationDeviceRepository, NotificationDeviceRepository>();
 
         return services;
     }

--- a/src/Harmonie.Infrastructure/Persistence/Notifications/NotificationDeviceRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Notifications/NotificationDeviceRepository.cs
@@ -1,0 +1,72 @@
+using Dapper;
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Infrastructure.Persistence.Common;
+
+namespace Harmonie.Infrastructure.Persistence.Notifications;
+
+public sealed class NotificationDeviceRepository : INotificationDeviceRepository
+{
+    private const string WebPushPlatform = "web_push";
+
+    private readonly DbSession _dbSession;
+
+    public NotificationDeviceRepository(DbSession dbSession)
+    {
+        _dbSession = dbSession;
+    }
+
+    public async Task UpsertWebPushAsync(
+        WebPushNotificationDeviceRegistration registration,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+                           INSERT INTO notification_devices (
+                               id,
+                               user_id,
+                               platform,
+                               token,
+                               web_push_p256dh,
+                               web_push_auth,
+                               expires_at_utc,
+                               created_at_utc,
+                               updated_at_utc)
+                           VALUES (
+                               @Id,
+                               @UserId,
+                               @Platform,
+                               @Token,
+                               @WebPushP256dh,
+                               @WebPushAuth,
+                               @ExpiresAtUtc,
+                               @NowUtc,
+                               @NowUtc)
+                           ON CONFLICT (platform, token)
+                           DO UPDATE SET
+                               user_id = EXCLUDED.user_id,
+                               web_push_p256dh = EXCLUDED.web_push_p256dh,
+                               web_push_auth = EXCLUDED.web_push_auth,
+                               expires_at_utc = EXCLUDED.expires_at_utc,
+                               updated_at_utc = EXCLUDED.updated_at_utc
+                           """;
+
+        var nowUtc = DateTime.UtcNow;
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new
+            {
+                Id = Guid.NewGuid(),
+                UserId = registration.UserId.Value,
+                Platform = WebPushPlatform,
+                Token = registration.Endpoint,
+                WebPushP256dh = registration.P256dh,
+                WebPushAuth = registration.Auth,
+                registration.ExpiresAtUtc,
+                NowUtc = nowUtc
+            },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        await connection.ExecuteAsync(command);
+    }
+}

--- a/tests/Harmonie.API.IntegrationTests/Notifications/RegisterWebPushDeviceEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Notifications/RegisterWebPushDeviceEndpointTests.cs
@@ -1,0 +1,169 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Harmonie.API.IntegrationTests.Common;
+using Harmonie.Infrastructure.Persistence.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Harmonie.API.IntegrationTests.Notifications;
+
+public sealed class RegisterWebPushDeviceEndpointTests : IClassFixture<HarmonieWebApplicationFactory>
+{
+    private readonly HarmonieWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public RegisterWebPushDeviceEndpointTests(HarmonieWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task RegisterWebPushDevice_WithValidSubscription_ShouldStoreNotificationDevice()
+    {
+        var user = await AuthTestHelper.RegisterAsync(_client);
+        var endpoint = $"https://push.example/subscriptions/{Guid.NewGuid():N}";
+
+        var response = await _client.SendAuthorizedPutAsync(
+            "/api/notifications/push-subscriptions",
+            new
+            {
+                endpoint,
+                expirationTime = (long?)null,
+                keys = new
+                {
+                    p256dh = "p256dh-key",
+                    auth = "auth-secret"
+                }
+            },
+            user.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var stored = await GetStoredDeviceAsync(endpoint);
+        stored.Should().NotBeNull();
+        stored!.UserId.Should().Be(user.UserId);
+        stored.Platform.Should().Be("web_push");
+        stored.Token.Should().Be(endpoint);
+        stored.WebPushP256dh.Should().Be("p256dh-key");
+        stored.WebPushAuth.Should().Be("auth-secret");
+    }
+
+    [Fact]
+    public async Task RegisterWebPushDevice_WhenEndpointAlreadyExists_ShouldUpdateExistingDevice()
+    {
+        var firstUser = await AuthTestHelper.RegisterAsync(_client);
+        var secondUser = await AuthTestHelper.RegisterAsync(_client);
+        var endpoint = $"https://push.example/subscriptions/{Guid.NewGuid():N}";
+
+        var firstResponse = await _client.SendAuthorizedPutAsync(
+            "/api/notifications/push-subscriptions",
+            CreateRequest(endpoint, "old-p256dh", "old-auth"),
+            firstUser.AccessToken);
+        firstResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var secondResponse = await _client.SendAuthorizedPutAsync(
+            "/api/notifications/push-subscriptions",
+            CreateRequest(endpoint, "new-p256dh", "new-auth"),
+            secondUser.AccessToken);
+        secondResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var count = await CountStoredDevicesAsync(endpoint);
+        count.Should().Be(1);
+
+        var stored = await GetStoredDeviceAsync(endpoint);
+        stored.Should().NotBeNull();
+        stored!.UserId.Should().Be(secondUser.UserId);
+        stored.WebPushP256dh.Should().Be("new-p256dh");
+        stored.WebPushAuth.Should().Be("new-auth");
+    }
+
+    [Fact]
+    public async Task RegisterWebPushDevice_WithInvalidEndpoint_ShouldReturnBadRequest()
+    {
+        var user = await AuthTestHelper.RegisterAsync(_client);
+
+        var response = await _client.SendAuthorizedPutAsync(
+            "/api/notifications/push-subscriptions",
+            CreateRequest("http://push.example/subscriptions/not-secure", "p256dh", "auth"),
+            user.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task RegisterWebPushDevice_WithoutAuthentication_ShouldReturnUnauthorized()
+    {
+        var response = await _client.PutAsJsonAsync(
+            "/api/notifications/push-subscriptions",
+            CreateRequest($"https://push.example/subscriptions/{Guid.NewGuid():N}", "p256dh", "auth"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    private static object CreateRequest(string endpoint, string p256dh, string auth)
+        => new
+        {
+            endpoint,
+            expirationTime = (long?)null,
+            keys = new
+            {
+                p256dh,
+                auth
+            }
+        };
+
+    private async Task<StoredNotificationDevice?> GetStoredDeviceAsync(string endpoint)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var dbSession = scope.ServiceProvider.GetRequiredService<DbSession>();
+        var connection = await dbSession.GetOpenConnectionAsync(TestContext.Current.CancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+                              SELECT user_id, platform, token, web_push_p256dh, web_push_auth
+                              FROM notification_devices
+                              WHERE platform = 'web_push' AND token = @Token
+                              """;
+        command.Parameters.AddWithValue("Token", endpoint);
+
+        await using var reader = await command.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        if (!await reader.ReadAsync(TestContext.Current.CancellationToken))
+            return null;
+
+        return new StoredNotificationDevice(
+            reader.GetGuid(0),
+            reader.GetString(1),
+            reader.GetString(2),
+            reader.GetString(3),
+            reader.GetString(4));
+    }
+
+    private async Task<long> CountStoredDevicesAsync(string endpoint)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var dbSession = scope.ServiceProvider.GetRequiredService<DbSession>();
+        var connection = await dbSession.GetOpenConnectionAsync(TestContext.Current.CancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+                              SELECT COUNT(*)
+                              FROM notification_devices
+                              WHERE platform = 'web_push' AND token = @Token
+                              """;
+        command.Parameters.AddWithValue("Token", endpoint);
+
+        var result = await command.ExecuteScalarAsync(TestContext.Current.CancellationToken);
+        result.Should().BeOfType<long>();
+        return (long)result;
+    }
+
+    private sealed record StoredNotificationDevice(
+        Guid UserId,
+        string Platform,
+        string Token,
+        string WebPushP256dh,
+        string WebPushAuth);
+}

--- a/tests/Harmonie.API.IntegrationTests/Notifications/RegisterWebPushDeviceEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Notifications/RegisterWebPushDeviceEndpointTests.cs
@@ -115,6 +115,8 @@ public sealed class RegisterWebPushDeviceEndpointTests : IClassFixture<HarmonieW
             }
         };
 
+    // TODO: Replace this direct SQL read with production repository methods once the notification
+    // dispatch worker needs query methods for registered devices.
     private async Task<StoredNotificationDevice?> GetStoredDeviceAsync(string endpoint)
     {
         await using var scope = _factory.Services.CreateAsyncScope();
@@ -141,6 +143,8 @@ public sealed class RegisterWebPushDeviceEndpointTests : IClassFixture<HarmonieW
             reader.GetString(4));
     }
 
+    // TODO: Replace this direct SQL read with production repository methods once the notification
+    // dispatch worker needs query methods for registered devices.
     private async Task<long> CountStoredDevicesAsync(string endpoint)
     {
         await using var scope = _factory.Services.CreateAsyncScope();

--- a/tests/Harmonie.Application.Tests/Notifications/RegisterWebPushDeviceTests.cs
+++ b/tests/Harmonie.Application.Tests/Notifications/RegisterWebPushDeviceTests.cs
@@ -1,0 +1,129 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Notifications.RegisterWebPushDevice;
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Application.Interfaces.Users;
+using Harmonie.Application.Tests.Common;
+using Harmonie.Domain.Entities.Users;
+using Harmonie.Domain.ValueObjects.Users;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Notifications;
+
+public sealed class RegisterWebPushDeviceTests
+{
+    private readonly Mock<IUserRepository> _userRepositoryMock = new();
+    private readonly Mock<INotificationDeviceRepository> _notificationDeviceRepositoryMock = new();
+
+    [Fact]
+    public async Task Handler_WithValidWebPushSubscription_ShouldUpsertWebPushDevice()
+    {
+        var user = ApplicationTestBuilders.CreateUser();
+        var expirationTime = DateTimeOffset.UtcNow.AddDays(30).ToUnixTimeMilliseconds();
+        var request = CreateRequest(expirationTime);
+        var handler = CreateHandler();
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        var response = await handler.HandleAsync(request, user.Id, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data.Should().BeTrue();
+
+        _notificationDeviceRepositoryMock.Verify(
+            x => x.UpsertWebPushAsync(
+                It.Is<WebPushNotificationDeviceRegistration>(registration =>
+                    registration.UserId == user.Id &&
+                    registration.Endpoint == request.Endpoint &&
+                    registration.P256dh == request.Keys.P256dh &&
+                    registration.Auth == request.Keys.Auth &&
+                    registration.ExpiresAtUtc.HasValue),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handler_WhenUserDoesNotExist_ShouldReturnNotFoundAndNotUpsert()
+    {
+        var userId = UserId.New();
+        var handler = CreateHandler();
+
+        _userRepositoryMock
+            .Setup(x => x.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        var response = await handler.HandleAsync(CreateRequest(), userId, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeFalse();
+        response.Error.Should().NotBeNull();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.User.NotFound);
+
+        _notificationDeviceRepositoryMock.Verify(
+            x => x.UpsertWebPushAsync(
+                It.IsAny<WebPushNotificationDeviceRegistration>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Theory]
+    [InlineData(null, "p256dh", "auth")]
+    [InlineData("", "p256dh", "auth")]
+    [InlineData("http://push.example/subscription", "p256dh", "auth")]
+    [InlineData("not-a-uri", "p256dh", "auth")]
+    [InlineData("https://push.example/subscription", "", "auth")]
+    [InlineData("https://push.example/subscription", "p256dh", "")]
+    public async Task Validator_WithInvalidRequest_ShouldFail(
+        string? endpoint,
+        string p256dh,
+        string auth)
+    {
+        var validator = new RegisterWebPushDeviceValidator();
+        var request = new RegisterWebPushDeviceRequest(
+            endpoint ?? string.Empty,
+            ExpirationTime: null,
+            new RegisterWebPushDeviceKeysRequest(p256dh, auth));
+
+        var result = await validator.ValidateAsync(request, TestContext.Current.CancellationToken);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Validator_WithValidRequest_ShouldPass()
+    {
+        var validator = new RegisterWebPushDeviceValidator();
+
+        var result = await validator.ValidateAsync(CreateRequest(), TestContext.Current.CancellationToken);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(-1L)]
+    public async Task Validator_WithInvalidExpirationTime_ShouldFail(long expirationTime)
+    {
+        var validator = new RegisterWebPushDeviceValidator();
+        var request = CreateRequest(expirationTime);
+
+        var result = await validator.ValidateAsync(request, TestContext.Current.CancellationToken);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    private RegisterWebPushDeviceHandler CreateHandler()
+        => new(
+            _userRepositoryMock.Object,
+            _notificationDeviceRepositoryMock.Object);
+
+    private static RegisterWebPushDeviceRequest CreateRequest(long? expirationTime = null)
+        => new(
+            "https://push.example/subscription/123",
+            expirationTime,
+            new RegisterWebPushDeviceKeysRequest(
+                "p256dh-key",
+                "auth-secret"));
+}

--- a/tools/Harmonie.Migrations/Scripts/20260613_1_CreateNotificationDevicesTable.sql
+++ b/tools/Harmonie.Migrations/Scripts/20260613_1_CreateNotificationDevicesTable.sql
@@ -1,0 +1,37 @@
+-- Migration: Create notification_devices table
+-- Date: 2026-06-13
+-- Description: Stores user notification delivery devices. Initial platform is Web Push for the PWA.
+
+CREATE TABLE IF NOT EXISTS notification_devices (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    platform TEXT NOT NULL,
+    token TEXT NOT NULL,
+    web_push_p256dh TEXT NULL,
+    web_push_auth TEXT NULL,
+    expires_at_utc TIMESTAMPTZ NULL,
+    created_at_utc TIMESTAMPTZ NOT NULL,
+    updated_at_utc TIMESTAMPTZ NOT NULL,
+    CONSTRAINT chk_notification_devices_token_not_empty
+        CHECK (btrim(token) <> ''),
+    CONSTRAINT chk_notification_devices_web_push_fields
+        CHECK (
+            platform <> 'web_push'
+            OR (
+                web_push_p256dh IS NOT NULL
+                AND btrim(web_push_p256dh) <> ''
+                AND web_push_auth IS NOT NULL
+                AND btrim(web_push_auth) <> ''
+            )
+        )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_notification_devices_platform_token
+    ON notification_devices(platform, token);
+
+CREATE INDEX IF NOT EXISTS idx_notification_devices_user_id
+    ON notification_devices(user_id);
+
+COMMENT ON TABLE notification_devices IS 'User notification delivery devices. Web Push is the first supported platform; FCM/APNs can be added later.';
+COMMENT ON COLUMN notification_devices.platform IS 'Delivery platform, e.g. web_push, android_fcm, ios_apns.';
+COMMENT ON COLUMN notification_devices.token IS 'Platform token. For Web Push this is the subscription endpoint.';


### PR DESCRIPTION
## Summary

- Add `notification_devices` storage for future-ready push delivery devices, starting with `web_push`.
- Add authenticated `PUT /api/notifications/push-subscriptions` registration endpoint.
- Add Web Push request validation for HTTPS endpoint, keys, and expiration timestamp.
- Add `INotificationDeviceRepository` and Dapper upsert implementation keyed by `(platform, token)`.
- Register notification endpoint, handler, and persistence dependencies.
- Add Application and integration coverage for validation, handler flow, persistence, upsert, auth, and invalid endpoint behavior.

## Tests

- `dotnet build --configuration Release`
- `ConnectionStrings__DefaultConnection='Host=localhost;Port=54321;Database=harmonie;Username=harmonie_user;Password=harmonie_password' dotnet run --project tools/Harmonie.Migrations`
- `ConnectionStrings__DefaultConnection='Host=localhost;Port=54321;Database=harmonie;Username=harmonie_user;Password=harmonie_password' dotnet test`

Closes #411
