### PR TITLE
Add transport-agnostic message notification outbox

### DIFF
--- a/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
+++ b/src/Harmonie.Application/Common/Messages/MessageSendOrchestrator.cs
@@ -2,6 +2,7 @@ using Harmonie.Application.Common;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Notifications;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Services;
 using Harmonie.Domain.Common;
@@ -22,6 +23,7 @@ public sealed class MessageSendOrchestrator
     private readonly IMessageAttachmentRepository _messageAttachmentRepository;
     private readonly MessageAttachmentResolver _attachmentResolver;
     private readonly IUserRepository _userRepository;
+    private readonly IMessageNotificationOutboxRepository _messageNotificationOutboxRepository;
     private readonly IUnitOfWork _unitOfWork;
 
     public MessageSendOrchestrator(
@@ -29,12 +31,14 @@ public sealed class MessageSendOrchestrator
         IMessageAttachmentRepository messageAttachmentRepository,
         MessageAttachmentResolver attachmentResolver,
         IUserRepository userRepository,
+        IMessageNotificationOutboxRepository messageNotificationOutboxRepository,
         IUnitOfWork unitOfWork)
     {
         _messageRepository = messageRepository;
         _messageAttachmentRepository = messageAttachmentRepository;
         _attachmentResolver = attachmentResolver;
         _userRepository = userRepository;
+        _messageNotificationOutboxRepository = messageNotificationOutboxRepository;
         _unitOfWork = unitOfWork;
     }
 
@@ -179,6 +183,7 @@ public sealed class MessageSendOrchestrator
         if (mentionUserIds is { Length: > 0 })
             await _messageRepository.AddMentionsAsync(messageResult.Value.Id, mentionUserIds, ct);
         await scope.ApplyInTransactionSideEffectsAsync(context, ct);
+        await _messageNotificationOutboxRepository.AddPendingAsync(messageResult.Value.Id, DateTime.UtcNow, ct);
         await transaction.CommitAsync(ct);
 
         // ── Reply preview DTO ───────────────────────────────────────────

--- a/src/Harmonie.Application/Interfaces/Notifications/IMessageNotificationOutboxRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Notifications/IMessageNotificationOutboxRepository.cs
@@ -1,0 +1,36 @@
+using Harmonie.Domain.ValueObjects.Messages;
+
+namespace Harmonie.Application.Interfaces.Notifications;
+
+public static class MessageNotificationOutboxStatuses
+{
+    public const string Pending = "pending";
+    public const string Processing = "processing";
+    public const string Processed = "processed";
+    public const string Failed = "failed";
+}
+
+public sealed record MessageNotificationOutboxJob(
+    Guid Id,
+    MessageId MessageId,
+    string Status,
+    int Attempts,
+    DateTime NextAttemptAtUtc,
+    DateTime? LockedUntilUtc,
+    string? LastError,
+    DateTime CreatedAtUtc,
+    DateTime? ProcessedAtUtc);
+
+public interface IMessageNotificationOutboxRepository
+{
+    Task AddPendingAsync(
+        MessageId messageId,
+        DateTime nextAttemptAtUtc,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<MessageNotificationOutboxJob>> ClaimPendingAsync(
+        int batchSize,
+        DateTime nowUtc,
+        TimeSpan lockDuration,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Harmonie.Infrastructure/DependencyInjection.cs
+++ b/src/Harmonie.Infrastructure/DependencyInjection.cs
@@ -74,6 +74,7 @@ public static class DependencyInjection
         services.AddScoped<IConversationReadStateRepository, ConversationReadStateRepository>();
         services.AddScoped<IUserSubscriptionRepository, UserSubscriptionRepository>();
         services.AddScoped<INotificationDeviceRepository, NotificationDeviceRepository>();
+        services.AddScoped<IMessageNotificationOutboxRepository, MessageNotificationOutboxRepository>();
 
         return services;
     }

--- a/src/Harmonie.Infrastructure/Persistence/Notifications/MessageNotificationOutboxRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Notifications/MessageNotificationOutboxRepository.cs
@@ -1,0 +1,157 @@
+using Dapper;
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Infrastructure.Persistence.Common;
+
+namespace Harmonie.Infrastructure.Persistence.Notifications;
+
+public sealed class MessageNotificationOutboxRepository : IMessageNotificationOutboxRepository
+{
+    private readonly DbSession _dbSession;
+
+    public MessageNotificationOutboxRepository(DbSession dbSession)
+    {
+        _dbSession = dbSession;
+    }
+
+    public async Task AddPendingAsync(
+        MessageId messageId,
+        DateTime nextAttemptAtUtc,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+                           INSERT INTO message_notification_outbox (
+                               id,
+                               message_id,
+                               status,
+                               attempts,
+                               next_attempt_at_utc,
+                               locked_until_utc,
+                               last_error,
+                               created_at_utc,
+                               processed_at_utc)
+                           VALUES (
+                               @Id,
+                               @MessageId,
+                               @Status,
+                               0,
+                               @NextAttemptAtUtc,
+                               NULL,
+                               NULL,
+                               @CreatedAtUtc,
+                               NULL)
+                           """;
+
+        var nowUtc = DateTime.UtcNow;
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new
+            {
+                Id = Guid.NewGuid(),
+                MessageId = messageId.Value,
+                Status = MessageNotificationOutboxStatuses.Pending,
+                NextAttemptAtUtc = nextAttemptAtUtc,
+                CreatedAtUtc = nowUtc
+            },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        await connection.ExecuteAsync(command);
+    }
+
+    public async Task<IReadOnlyList<MessageNotificationOutboxJob>> ClaimPendingAsync(
+        int batchSize,
+        DateTime nowUtc,
+        TimeSpan lockDuration,
+        CancellationToken cancellationToken = default)
+    {
+        if (batchSize <= 0)
+            return [];
+
+        const string sql = """
+                           WITH claimable AS (
+                               SELECT id
+                               FROM message_notification_outbox
+                               WHERE (
+                                       status = @PendingStatus
+                                       AND next_attempt_at_utc <= @NowUtc
+                                   )
+                                   OR (
+                                       status = @ProcessingStatus
+                                       AND locked_until_utc IS NOT NULL
+                                       AND locked_until_utc <= @NowUtc
+                                   )
+                               ORDER BY next_attempt_at_utc ASC, created_at_utc ASC, id ASC
+                               LIMIT @BatchSize
+                               FOR UPDATE SKIP LOCKED
+                           )
+                           UPDATE message_notification_outbox outbox
+                           SET status = @ProcessingStatus,
+                               attempts = outbox.attempts + 1,
+                               locked_until_utc = @LockedUntilUtc,
+                               last_error = NULL
+                           FROM claimable
+                           WHERE outbox.id = claimable.id
+                           RETURNING
+                               outbox.id AS "Id",
+                               outbox.message_id AS "MessageId",
+                               outbox.status AS "Status",
+                               outbox.attempts AS "Attempts",
+                               outbox.next_attempt_at_utc AS "NextAttemptAtUtc",
+                               outbox.locked_until_utc AS "LockedUntilUtc",
+                               outbox.last_error AS "LastError",
+                               outbox.created_at_utc AS "CreatedAtUtc",
+                               outbox.processed_at_utc AS "ProcessedAtUtc"
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new
+            {
+                PendingStatus = MessageNotificationOutboxStatuses.Pending,
+                ProcessingStatus = MessageNotificationOutboxStatuses.Processing,
+                NowUtc = nowUtc,
+                LockedUntilUtc = nowUtc.Add(lockDuration),
+                BatchSize = batchSize
+            },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        var rows = await connection.QueryAsync<MessageNotificationOutboxJobRow>(command);
+        return rows
+            .Select(row => new MessageNotificationOutboxJob(
+                row.Id,
+                MessageId.From(row.MessageId),
+                row.Status,
+                row.Attempts,
+                row.NextAttemptAtUtc,
+                row.LockedUntilUtc,
+                row.LastError,
+                row.CreatedAtUtc,
+                row.ProcessedAtUtc))
+            .ToArray();
+    }
+
+    private sealed class MessageNotificationOutboxJobRow
+    {
+        public Guid Id { get; init; }
+
+        public Guid MessageId { get; init; }
+
+        public string Status { get; init; } = string.Empty;
+
+        public int Attempts { get; init; }
+
+        public DateTime NextAttemptAtUtc { get; init; }
+
+        public DateTime? LockedUntilUtc { get; init; }
+
+        public string? LastError { get; init; }
+
+        public DateTime CreatedAtUtc { get; init; }
+
+        public DateTime? ProcessedAtUtc { get; init; }
+    }
+}

--- a/tests/Harmonie.API.IntegrationTests/Notifications/MessageNotificationOutboxTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Notifications/MessageNotificationOutboxTests.cs
@@ -1,0 +1,190 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Harmonie.API.IntegrationTests.Common;
+using Harmonie.Application.Features.Channels.SendMessage;
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Infrastructure.Persistence.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Harmonie.API.IntegrationTests.Notifications;
+
+public sealed class MessageNotificationOutboxTests : IClassFixture<HarmonieWebApplicationFactory>
+{
+    private readonly HarmonieWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public MessageNotificationOutboxTests(HarmonieWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task SendChannelMessage_WhenSuccessful_ShouldCreatePendingOutboxJob()
+    {
+        var user = await AuthTestHelper.RegisterAsync(_client);
+        var (_, channelId) = await ChannelTestHelper.CreateGuildAndChannelAsync(_client, user.AccessToken);
+
+        var message = await ChannelTestHelper.SendChannelMessageAsync(
+            _client,
+            channelId,
+            "hello channel outbox",
+            user.AccessToken);
+
+        var job = await GetOutboxJobAsync(message.MessageId);
+        job.Should().NotBeNull();
+        job!.MessageId.Should().Be(message.MessageId);
+        job.Status.Should().Be(MessageNotificationOutboxStatuses.Pending);
+        job.Attempts.Should().Be(0);
+        job.ProcessedAtUtc.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SendConversationMessage_WhenSuccessful_ShouldCreatePendingOutboxJob()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var target = await AuthTestHelper.RegisterAsync(_client);
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, caller.AccessToken, target.UserId);
+
+        var message = await ConversationTestHelper.SendConversationMessageAsync(
+            _client,
+            conversationId,
+            "hello conversation outbox",
+            caller.AccessToken);
+
+        var job = await GetOutboxJobAsync(message.MessageId);
+        job.Should().NotBeNull();
+        job!.MessageId.Should().Be(message.MessageId);
+        job.Status.Should().Be(MessageNotificationOutboxStatuses.Pending);
+        job.Attempts.Should().Be(0);
+        job.ProcessedAtUtc.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SendChannelMessage_WhenRequestFails_ShouldNotCreateOutboxJob()
+    {
+        var user = await AuthTestHelper.RegisterAsync(_client);
+        var (_, channelId) = await ChannelTestHelper.CreateGuildAndChannelAsync(_client, user.AccessToken);
+        var uniqueContent = $"failed outbox marker {Guid.NewGuid():N}";
+
+        var response = await _client.SendAuthorizedPostAsync(
+            $"/api/channels/{channelId}/messages",
+            new SendMessageRequest(uniqueContent, ReplyToMessageId: Guid.NewGuid()),
+            user.AccessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var count = await CountOutboxJobsForMessageContentAsync(uniqueContent);
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ClaimPendingAsync_WhenJobIsClaimed_ShouldNotReturnItAgainWhileLocked()
+    {
+        var user = await AuthTestHelper.RegisterAsync(_client);
+        var (_, channelId) = await ChannelTestHelper.CreateGuildAndChannelAsync(_client, user.AccessToken);
+        var message = await ChannelTestHelper.SendChannelMessageAsync(
+            _client,
+            channelId,
+            "claim me once",
+            user.AccessToken);
+        await SetOutboxNextAttemptAsync(message.MessageId, new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var firstClaim = await ClaimPendingAsync(batchSize: 1);
+        firstClaim.Should().ContainSingle(job => job.MessageId.Value == message.MessageId);
+
+        var secondClaim = await ClaimPendingAsync(batchSize: 10);
+        secondClaim.Should().NotContain(job => job.MessageId.Value == message.MessageId);
+
+        var stored = await GetOutboxJobAsync(message.MessageId);
+        stored.Should().NotBeNull();
+        stored!.Status.Should().Be(MessageNotificationOutboxStatuses.Processing);
+        stored.Attempts.Should().Be(1);
+        stored.LockedUntilUtc.Should().NotBeNull();
+    }
+
+    private async Task<IReadOnlyList<MessageNotificationOutboxJob>> ClaimPendingAsync(int batchSize)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var repository = scope.ServiceProvider.GetRequiredService<IMessageNotificationOutboxRepository>();
+        return await repository.ClaimPendingAsync(
+            batchSize,
+            DateTime.UtcNow.AddMinutes(1),
+            TimeSpan.FromMinutes(5),
+            TestContext.Current.CancellationToken);
+    }
+
+    private async Task SetOutboxNextAttemptAsync(Guid messageId, DateTime nextAttemptAtUtc)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var dbSession = scope.ServiceProvider.GetRequiredService<DbSession>();
+        var connection = await dbSession.GetOpenConnectionAsync(TestContext.Current.CancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+                              UPDATE message_notification_outbox
+                              SET next_attempt_at_utc = @NextAttemptAtUtc
+                              WHERE message_id = @MessageId
+                              """;
+        command.Parameters.AddWithValue("NextAttemptAtUtc", nextAttemptAtUtc);
+        command.Parameters.AddWithValue("MessageId", messageId);
+
+        var rows = await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        rows.Should().Be(1);
+    }
+
+    private async Task<StoredOutboxJob?> GetOutboxJobAsync(Guid messageId)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var dbSession = scope.ServiceProvider.GetRequiredService<DbSession>();
+        var connection = await dbSession.GetOpenConnectionAsync(TestContext.Current.CancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+                              SELECT message_id, status, attempts, locked_until_utc, processed_at_utc
+                              FROM message_notification_outbox
+                              WHERE message_id = @MessageId
+                              """;
+        command.Parameters.AddWithValue("MessageId", messageId);
+
+        await using var reader = await command.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        if (!await reader.ReadAsync(TestContext.Current.CancellationToken))
+            return null;
+
+        return new StoredOutboxJob(
+            reader.GetGuid(0),
+            reader.GetString(1),
+            reader.GetInt32(2),
+            reader.IsDBNull(3) ? null : reader.GetDateTime(3),
+            reader.IsDBNull(4) ? null : reader.GetDateTime(4));
+    }
+
+    private async Task<long> CountOutboxJobsForMessageContentAsync(string content)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var dbSession = scope.ServiceProvider.GetRequiredService<DbSession>();
+        var connection = await dbSession.GetOpenConnectionAsync(TestContext.Current.CancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+                              SELECT COUNT(*)
+                              FROM message_notification_outbox outbox
+                              JOIN messages m ON m.id = outbox.message_id
+                              WHERE m.content = @Content
+                              """;
+        command.Parameters.AddWithValue("Content", content);
+
+        var result = await command.ExecuteScalarAsync(TestContext.Current.CancellationToken);
+        result.Should().BeOfType<long>();
+        return (long)result;
+    }
+
+    private sealed record StoredOutboxJob(
+        Guid MessageId,
+        string Status,
+        int Attempts,
+        DateTime? LockedUntilUtc,
+        DateTime? ProcessedAtUtc);
+}

--- a/tests/Harmonie.Application.Tests/Messages/MessageSendOrchestratorTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/MessageSendOrchestratorTests.cs
@@ -4,6 +4,7 @@ using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Features.Channels.SendMessage;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Notifications;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
@@ -30,6 +31,7 @@ public sealed class MessageSendOrchestratorTests
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IUnitOfWorkTransaction> _transactionMock;
     private readonly Mock<IUserRepository> _userRepositoryMock;
+    private readonly Mock<IMessageNotificationOutboxRepository> _messageNotificationOutboxRepositoryMock;
     private readonly MessageSendOrchestrator _orchestrator;
 
     public MessageSendOrchestratorTests()
@@ -40,12 +42,20 @@ public sealed class MessageSendOrchestratorTests
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _transactionMock = _unitOfWorkMock.SetupTransactionMock();
         _userRepositoryMock = new Mock<IUserRepository>();
+        _messageNotificationOutboxRepositoryMock = new Mock<IMessageNotificationOutboxRepository>();
+        _messageNotificationOutboxRepositoryMock
+            .Setup(x => x.AddPendingAsync(
+                It.IsAny<MessageId>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
         _orchestrator = new MessageSendOrchestrator(
             _messageRepositoryMock.Object,
             _messageAttachmentRepositoryMock.Object,
             new MessageAttachmentResolver(_uploadedFileRepositoryMock.Object),
             _userRepositoryMock.Object,
+            _messageNotificationOutboxRepositoryMock.Object,
             _unitOfWorkMock.Object);
     }
 
@@ -157,6 +167,13 @@ public sealed class MessageSendOrchestratorTests
 
         result.Success.Should().BeFalse();
         result.Error!.Code.Should().Be(ApplicationErrorCodes.Message.ContentEmpty);
+
+        _messageNotificationOutboxRepositoryMock.Verify(
+            x => x.AddPendingAsync(
+                It.IsAny<MessageId>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     // ── 5. Happy path: side effects, notify, link previews called in order ──
@@ -193,6 +210,14 @@ public sealed class MessageSendOrchestratorTests
             .Setup(x => x.AddAsync(It.IsAny<Message>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
+        _messageNotificationOutboxRepositoryMock
+            .Setup(x => x.AddPendingAsync(
+                It.IsAny<MessageId>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("outbox"))
+            .Returns(Task.CompletedTask);
+
         _transactionMock
             .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
             .Callback(() => callOrder.Add("commit"))
@@ -210,7 +235,14 @@ public sealed class MessageSendOrchestratorTests
         _transactionMock.Verify(
             x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
 
-        callOrder.Should().Equal("sideEffects", "commit", "notify", "linkPreviews");
+        _messageNotificationOutboxRepositoryMock.Verify(
+            x => x.AddPendingAsync(
+                It.IsAny<MessageId>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        callOrder.Should().Equal("sideEffects", "outbox", "commit", "notify", "linkPreviews");
     }
 
     // ── 6. Link previews only triggered when URLs present ────────────────

--- a/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SendConversationMessageHandlerTests.cs
@@ -6,6 +6,7 @@ using Harmonie.Application.Services;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Conversations;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Notifications;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
@@ -37,6 +38,7 @@ public sealed class SendConversationMessageHandlerTests
     private readonly Mock<ILinkPreviewFetcher> _linkPreviewFetcherMock;
     private readonly Mock<IServiceScopeFactory> _serviceScopeFactoryMock;
     private readonly Mock<IMessageEventPublisher> _directMessageNotifierMock;
+    private readonly Mock<IMessageNotificationOutboxRepository> _messageNotificationOutboxRepositoryMock;
     private readonly MessageSendOrchestrator _orchestrator;
     private readonly SendMessageHandler _handler;
 
@@ -52,12 +54,19 @@ public sealed class SendConversationMessageHandlerTests
         _linkPreviewRepositoryMock = new Mock<ILinkPreviewRepository>();
         _linkPreviewFetcherMock = new Mock<ILinkPreviewFetcher>();
         _directMessageNotifierMock = new Mock<IMessageEventPublisher>();
+        _messageNotificationOutboxRepositoryMock = new Mock<IMessageNotificationOutboxRepository>();
 
         _transactionMock = _unitOfWorkMock.SetupTransactionMock();
 
         _directMessageNotifierMock
             .Setup(x => x.PublishCreatedAsync(
                 It.IsAny<MessageCreatedEventEnvelope>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _messageNotificationOutboxRepositoryMock
+            .Setup(x => x.AddPendingAsync(
+                It.IsAny<MessageId>(),
+                It.IsAny<DateTime>(),
                 It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
@@ -82,6 +91,7 @@ public sealed class SendConversationMessageHandlerTests
             _messageAttachmentRepositoryMock.Object,
             new MessageAttachmentResolver(_uploadedFileRepositoryMock.Object),
             _userRepositoryMock.Object,
+            _messageNotificationOutboxRepositoryMock.Object,
             _unitOfWorkMock.Object);
 
         _handler = new SendMessageHandler(

--- a/tests/Harmonie.Application.Tests/Messages/SendMessageHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Messages/SendMessageHandlerTests.cs
@@ -7,6 +7,7 @@ using Harmonie.Application.Interfaces.Channels;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Guilds;
 using Harmonie.Application.Interfaces.Messages;
+using Harmonie.Application.Interfaces.Notifications;
 using Harmonie.Application.Interfaces.Uploads;
 using Harmonie.Application.Interfaces.Users;
 using Harmonie.Application.Tests.Common;
@@ -40,6 +41,7 @@ public sealed class SendMessageHandlerTests
     private readonly Mock<ILinkPreviewFetcher> _linkPreviewFetcherMock;
     private readonly Mock<IServiceScopeFactory> _serviceScopeFactoryMock;
     private readonly Mock<IMessageEventPublisher> _textChannelNotifierMock;
+    private readonly Mock<IMessageNotificationOutboxRepository> _messageNotificationOutboxRepositoryMock;
     private readonly MessageSendOrchestrator _orchestrator;
     private readonly SendMessageHandler _handler;
 
@@ -55,12 +57,19 @@ public sealed class SendMessageHandlerTests
         _linkPreviewRepositoryMock = new Mock<ILinkPreviewRepository>();
         _linkPreviewFetcherMock = new Mock<ILinkPreviewFetcher>();
         _textChannelNotifierMock = new Mock<IMessageEventPublisher>();
+        _messageNotificationOutboxRepositoryMock = new Mock<IMessageNotificationOutboxRepository>();
 
         _transactionMock = _unitOfWorkMock.SetupTransactionMock();
 
         _textChannelNotifierMock
             .Setup(x => x.PublishCreatedAsync(
                 It.IsAny<MessageCreatedEventEnvelope>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _messageNotificationOutboxRepositoryMock
+            .Setup(x => x.AddPendingAsync(
+                It.IsAny<MessageId>(),
+                It.IsAny<DateTime>(),
                 It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
@@ -85,6 +94,7 @@ public sealed class SendMessageHandlerTests
             _messageAttachmentRepositoryMock.Object,
             new MessageAttachmentResolver(_uploadedFileRepositoryMock.Object),
             _userRepositoryMock.Object,
+            _messageNotificationOutboxRepositoryMock.Object,
             _unitOfWorkMock.Object);
 
         _handler = new SendMessageHandler(

--- a/tools/Harmonie.Migrations/Scripts/20260613_2_CreateMessageNotificationOutboxTable.sql
+++ b/tools/Harmonie.Migrations/Scripts/20260613_2_CreateMessageNotificationOutboxTable.sql
@@ -1,0 +1,33 @@
+-- Migration: Create message_notification_outbox table
+-- Date: 2026-06-13
+-- Description: Stores transport-agnostic message notification jobs for asynchronous worker dispatch.
+
+CREATE TABLE IF NOT EXISTS message_notification_outbox (
+    id UUID PRIMARY KEY,
+    message_id UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    status TEXT NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at_utc TIMESTAMPTZ NOT NULL,
+    locked_until_utc TIMESTAMPTZ NULL,
+    last_error TEXT NULL,
+    created_at_utc TIMESTAMPTZ NOT NULL,
+    processed_at_utc TIMESTAMPTZ NULL,
+    CONSTRAINT chk_message_notification_outbox_status
+        CHECK (status IN ('pending', 'processing', 'processed', 'failed')),
+    CONSTRAINT chk_message_notification_outbox_attempts_non_negative
+        CHECK (attempts >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_message_notification_outbox_pending
+    ON message_notification_outbox(status, next_attempt_at_utc, created_at_utc)
+    WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_message_notification_outbox_processing_lock
+    ON message_notification_outbox(status, locked_until_utc)
+    WHERE status = 'processing';
+
+CREATE INDEX IF NOT EXISTS idx_message_notification_outbox_message_id
+    ON message_notification_outbox(message_id);
+
+COMMENT ON TABLE message_notification_outbox IS 'Transport-agnostic outbox for asynchronous message notification dispatch';
+COMMENT ON COLUMN message_notification_outbox.message_id IS 'Message whose notification recipients and platform payloads are resolved during worker dispatch';


### PR DESCRIPTION
## Summary

- Add a transport-agnostic `message_notification_outbox` table for async message notification dispatch.
- Add `IMessageNotificationOutboxRepository` with pending insert and safe claim support.
- Persist one pending outbox job in the same transaction as successful message creation.
- Keep SignalR publication unchanged after commit.
- Add Application and integration coverage for channel/conversation message outbox creation, failed sends, and claim locking.

## Tests

- `dotnet build --configuration Release`
- `ConnectionStrings__DefaultConnection='Host=localhost;Port=54321;Database=harmonie;Username=harmonie_user;Password=harmonie_password' dotnet run --project tools/Harmonie.Migrations`
- `ConnectionStrings__DefaultConnection='Host=localhost;Port=54321;Database=harmonie;Username=harmonie_user;Password=harmonie_password' dotnet test`

Closes #412
