### PR TITLE
Dispatch Web Push notifications through delivery pipeline

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,6 +32,7 @@
   <!-- External services -->
   <ItemGroup>
     <PackageVersion Include="Livekit.Server.Sdk.Dotnet" Version="1.2.1" />
+    <PackageVersion Include="WebPush" Version="1.0.13" />
   </ItemGroup>
   <!-- Configuration -->
   <ItemGroup>

--- a/Harmonie.sln
+++ b/Harmonie.sln
@@ -48,6 +48,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmonie.API.Tests", "tests
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmonie.Workers", "src\Harmonie.Workers\Harmonie.Workers.csproj", "{4B03C010-5B78-454D-B589-13AC20B1D13B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harmonie.Workers.Tests", "tests\Harmonie.Workers.Tests\Harmonie.Workers.Tests.csproj", "{C826F5E1-1C0B-48D1-A132-8AEAF534148A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -190,6 +192,18 @@ Global
 		{4B03C010-5B78-454D-B589-13AC20B1D13B}.Release|x64.Build.0 = Release|Any CPU
 		{4B03C010-5B78-454D-B589-13AC20B1D13B}.Release|x86.ActiveCfg = Release|Any CPU
 		{4B03C010-5B78-454D-B589-13AC20B1D13B}.Release|x86.Build.0 = Release|Any CPU
+		{C826F5E1-1C0B-48D1-A132-8AEAF534148A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C826F5E1-1C0B-48D1-A132-8AEAF534148A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C826F5E1-1C0B-48D1-A132-8AEAF534148A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C826F5E1-1C0B-48D1-A132-8AEAF534148A}.Debug|x64.Build.0 = Debug|Any CPU
+		{C826F5E1-1C0B-48D1-A132-8AEAF534148A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C826F5E1-1C0B-48D1-A132-8AEAF534148A}.Debug|x86.Build.0 = Debug|Any CPU
+		{C826F5E1-1C0B-48D1-A132-8AEAF534148A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C826F5E1-1C0B-48D1-A132-8AEAF534148A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C826F5E1-1C0B-48D1-A132-8AEAF534148A}.Release|x64.ActiveCfg = Release|Any CPU
+		{C826F5E1-1C0B-48D1-A132-8AEAF534148A}.Release|x64.Build.0 = Release|Any CPU
+		{C826F5E1-1C0B-48D1-A132-8AEAF534148A}.Release|x86.ActiveCfg = Release|Any CPU
+		{C826F5E1-1C0B-48D1-A132-8AEAF534148A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -206,6 +220,7 @@ Global
 		{41BF7DBE-349D-41F0-8779-CD2A42AAB553} = {E1E7A1F1-8C2E-4D3A-9F5B-1234567890D2}
 		{A8CD8BE2-2396-48A0-ADFE-9943DB2E2C3F} = {E1E7A1F1-8C2E-4D3A-9F5B-1234567890D2}
 		{4B03C010-5B78-454D-B589-13AC20B1D13B} = {E1E7A1F1-8C2E-4D3A-9F5B-1234567890D1}
+		{C826F5E1-1C0B-48D1-A132-8AEAF534148A} = {E1E7A1F1-8C2E-4D3A-9F5B-1234567890D2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F1E7A1F1-8C2E-4D3A-9F5B-1234567890E1}

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -97,6 +97,10 @@ services:
     environment:
       - DOTNET_ENVIRONMENT=Development
       - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=harmonie;Username=harmonie_user;Password=harmonie_password
+      - PushNotifications__Enabled=false
+      - VAPID_PUBLIC_KEY=
+      - VAPID_PRIVATE_KEY=
+      - VAPID_SUBJECT=mailto:contact@harmonie.app
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,10 @@ services:
     environment:
       - DOTNET_ENVIRONMENT=Development
       - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=harmonie;Username=harmonie_user;Password=harmonie_password
+      - PushNotifications__Enabled=false
+      - VAPID_PUBLIC_KEY=
+      - VAPID_PRIVATE_KEY=
+      - VAPID_SUBJECT=mailto:contact@harmonie.app
     depends_on:
       postgres:
         condition: service_healthy

--- a/src/Harmonie.Application/DependencyInjection.cs
+++ b/src/Harmonie.Application/DependencyInjection.cs
@@ -26,7 +26,7 @@ public static class DependencyInjection
         services.AddScoped<PinnedMessageFetchOrchestrator>();
         services.AddScoped<MessageNotificationRecipientResolver>();
         services.AddScoped<MessageNotificationPayloadFactory>();
-        services.AddScoped<NotificationDispatchService>();
+        services.AddScoped<INotificationDispatchService, NotificationDispatchService>();
 
         services.AddAuthHandlers();
         services.AddGuildHandlers();

--- a/src/Harmonie.Application/DependencyInjection.cs
+++ b/src/Harmonie.Application/DependencyInjection.cs
@@ -3,6 +3,7 @@ using FluentValidation;
 using Harmonie.Application.Common.Messages;
 using Harmonie.Application.Common.Uploads;
 using Harmonie.Application.Services;
+using Harmonie.Application.Services.Notifications;
 using Harmonie.Application.Registration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -23,6 +24,9 @@ public static class DependencyInjection
         services.AddScoped<ReadOrchestrator>();
         services.AddScoped<MessageFetchOrchestrator>();
         services.AddScoped<PinnedMessageFetchOrchestrator>();
+        services.AddScoped<MessageNotificationRecipientResolver>();
+        services.AddScoped<MessageNotificationPayloadFactory>();
+        services.AddScoped<NotificationDispatchService>();
 
         services.AddAuthHandlers();
         services.AddGuildHandlers();

--- a/src/Harmonie.Application/Interfaces/Notifications/IMessageNotificationContextRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Notifications/IMessageNotificationContextRepository.cs
@@ -1,0 +1,32 @@
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Guilds;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Interfaces.Notifications;
+
+public abstract record MessageNotificationTarget
+{
+    private MessageNotificationTarget() { }
+
+    public sealed record Channel(GuildId GuildId, GuildChannelId ChannelId, string ChannelName) : MessageNotificationTarget;
+
+    public sealed record Conversation(ConversationId ConversationId) : MessageNotificationTarget;
+}
+
+public sealed record MessageNotificationContext(
+    MessageId MessageId,
+    UserId AuthorUserId,
+    string AuthorUsername,
+    string? AuthorDisplayName,
+    string? Content,
+    MessageNotificationTarget Target,
+    IReadOnlySet<UserId> CandidateRecipientUserIds);
+
+public interface IMessageNotificationContextRepository
+{
+    Task<MessageNotificationContext?> GetAsync(
+        MessageId messageId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Harmonie.Application/Interfaces/Notifications/IMessageNotificationContextRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Notifications/IMessageNotificationContextRepository.cs
@@ -10,9 +10,9 @@ public abstract record MessageNotificationTarget
 {
     private MessageNotificationTarget() { }
 
-    public sealed record Channel(GuildId GuildId, GuildChannelId ChannelId, string ChannelName) : MessageNotificationTarget;
+    public sealed record Channel(GuildId GuildId, string GuildName, GuildChannelId ChannelId, string ChannelName) : MessageNotificationTarget;
 
-    public sealed record Conversation(ConversationId ConversationId) : MessageNotificationTarget;
+    public sealed record Conversation(ConversationId ConversationId, string? ConversationName) : MessageNotificationTarget;
 }
 
 public sealed record MessageNotificationContext(
@@ -20,7 +20,6 @@ public sealed record MessageNotificationContext(
     UserId AuthorUserId,
     string AuthorUsername,
     string? AuthorDisplayName,
-    string? Content,
     MessageNotificationTarget Target,
     IReadOnlySet<UserId> CandidateRecipientUserIds);
 

--- a/src/Harmonie.Application/Interfaces/Notifications/IMessageNotificationOutboxRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Notifications/IMessageNotificationOutboxRepository.cs
@@ -33,4 +33,21 @@ public interface IMessageNotificationOutboxRepository
         DateTime nowUtc,
         TimeSpan lockDuration,
         CancellationToken cancellationToken = default);
+
+    Task MarkProcessedAsync(
+        Guid jobId,
+        DateTime processedAtUtc,
+        CancellationToken cancellationToken = default);
+
+    Task ScheduleRetryAsync(
+        Guid jobId,
+        DateTime nextAttemptAtUtc,
+        string error,
+        CancellationToken cancellationToken = default);
+
+    Task MarkFailedAsync(
+        Guid jobId,
+        string error,
+        DateTime failedAtUtc,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Harmonie.Application/Interfaces/Notifications/INotificationDeliveryAdapter.cs
+++ b/src/Harmonie.Application/Interfaces/Notifications/INotificationDeliveryAdapter.cs
@@ -8,13 +8,32 @@ public enum NotificationDeliveryResultStatus
     PermanentFailure
 }
 
+public static class NotificationDeliveryPayloadTypes
+{
+    public const string MessageCreated = "message.created";
+}
+
 public sealed record NotificationDeliveryPayload(
-    string Title,
-    string Body,
-    string TargetUrl,
-    string Tag,
-    string Icon,
-    string Badge);
+    string Type,
+    object Data);
+
+public sealed record MessageCreatedChannelNotificationData(
+    string Scope,
+    Guid MessageId,
+    Guid AuthorUserId,
+    string AuthorDisplayName,
+    Guid GuildId,
+    string GuildName,
+    Guid ChannelId,
+    string ChannelName);
+
+public sealed record MessageCreatedConversationNotificationData(
+    string Scope,
+    Guid MessageId,
+    Guid AuthorUserId,
+    string AuthorDisplayName,
+    Guid ConversationId,
+    string? ConversationName);
 
 public sealed record NotificationDeliveryResult(
     Guid DeviceId,

--- a/src/Harmonie.Application/Interfaces/Notifications/INotificationDeliveryAdapter.cs
+++ b/src/Harmonie.Application/Interfaces/Notifications/INotificationDeliveryAdapter.cs
@@ -1,0 +1,32 @@
+namespace Harmonie.Application.Interfaces.Notifications;
+
+public enum NotificationDeliveryResultStatus
+{
+    Succeeded,
+    InvalidDevice,
+    TransientFailure,
+    PermanentFailure
+}
+
+public sealed record NotificationDeliveryPayload(
+    string Title,
+    string Body,
+    string TargetUrl,
+    string Tag,
+    string Icon,
+    string Badge);
+
+public sealed record NotificationDeliveryResult(
+    Guid DeviceId,
+    NotificationDeliveryResultStatus Status,
+    string? Error = null);
+
+public interface INotificationDeliveryAdapter
+{
+    string Platform { get; }
+
+    Task<IReadOnlyList<NotificationDeliveryResult>> SendAsync(
+        NotificationDeliveryPayload payload,
+        IReadOnlyList<NotificationDevice> devices,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Harmonie.Application/Interfaces/Notifications/INotificationDeviceRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Notifications/INotificationDeviceRepository.cs
@@ -2,6 +2,20 @@ using Harmonie.Domain.ValueObjects.Users;
 
 namespace Harmonie.Application.Interfaces.Notifications;
 
+public static class NotificationDevicePlatforms
+{
+    public const string WebPush = "web_push";
+}
+
+public sealed record NotificationDevice(
+    Guid Id,
+    UserId UserId,
+    string Platform,
+    string Token,
+    string? WebPushP256dh,
+    string? WebPushAuth,
+    DateTime? ExpiresAtUtc);
+
 public sealed record WebPushNotificationDeviceRegistration(
     UserId UserId,
     string Endpoint,
@@ -13,5 +27,14 @@ public interface INotificationDeviceRepository
 {
     Task UpsertWebPushAsync(
         WebPushNotificationDeviceRegistration registration,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<NotificationDevice>> GetActiveByUserIdsAsync(
+        IReadOnlyCollection<UserId> userIds,
+        DateTime nowUtc,
+        CancellationToken cancellationToken = default);
+
+    Task DeleteAsync(
+        Guid deviceId,
         CancellationToken cancellationToken = default);
 }

--- a/src/Harmonie.Application/Interfaces/Notifications/INotificationDeviceRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Notifications/INotificationDeviceRepository.cs
@@ -37,4 +37,8 @@ public interface INotificationDeviceRepository
     Task DeleteAsync(
         Guid deviceId,
         CancellationToken cancellationToken = default);
+
+    Task DeleteManyAsync(
+        IReadOnlyCollection<Guid> deviceIds,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Harmonie.Application/Services/Notifications/INotificationDispatchService.cs
+++ b/src/Harmonie.Application/Services/Notifications/INotificationDispatchService.cs
@@ -1,0 +1,11 @@
+using Harmonie.Application.Interfaces.Notifications;
+
+namespace Harmonie.Application.Services.Notifications;
+
+public interface INotificationDispatchService
+{
+    Task DispatchAsync(
+        MessageNotificationOutboxJob job,
+        DateTime nowUtc,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Harmonie.Application/Services/Notifications/MessageNotificationPayloadFactory.cs
+++ b/src/Harmonie.Application/Services/Notifications/MessageNotificationPayloadFactory.cs
@@ -1,43 +1,44 @@
 using Harmonie.Application.Interfaces.Notifications;
-using Microsoft.Extensions.Options;
 
 namespace Harmonie.Application.Services.Notifications;
 
+public static class NotificationMessageScopes
+{
+    public const string Channel = "channel";
+    public const string Conversation = "conversation";
+}
+
 public sealed class MessageNotificationPayloadFactory
 {
-    private readonly PushNotificationOptions _options;
-
-    public MessageNotificationPayloadFactory(IOptions<PushNotificationOptions> options)
-    {
-        _options = options.Value;
-    }
-
     public NotificationDeliveryPayload Create(MessageNotificationContext context)
     {
         var authorName = string.IsNullOrWhiteSpace(context.AuthorDisplayName)
             ? context.AuthorUsername
             : context.AuthorDisplayName;
-        var body = string.IsNullOrWhiteSpace(context.Content) ? "New message" : context.Content;
 
-        return context.Target switch
+        object data = context.Target switch
         {
-            MessageNotificationTarget.Channel channel => new NotificationDeliveryPayload(
-                $"{authorName} | {channel.ChannelName}",
-                body,
-                $"/guilds/{channel.GuildId.Value}/channels/{channel.ChannelId.Value}",
-                $"message-{context.MessageId.Value}",
-                _options.Icon,
-                _options.Badge),
-
-            MessageNotificationTarget.Conversation conversation => new NotificationDeliveryPayload(
+            MessageNotificationTarget.Channel channel => new MessageCreatedChannelNotificationData(
+                NotificationMessageScopes.Channel,
+                context.MessageId.Value,
+                context.AuthorUserId.Value,
                 authorName,
-                body,
-                $"/conversations/{conversation.ConversationId.Value}",
-                $"message-{context.MessageId.Value}",
-                _options.Icon,
-                _options.Badge),
+                channel.GuildId.Value,
+                channel.GuildName,
+                channel.ChannelId.Value,
+                channel.ChannelName),
+
+            MessageNotificationTarget.Conversation conversation => new MessageCreatedConversationNotificationData(
+                NotificationMessageScopes.Conversation,
+                context.MessageId.Value,
+                context.AuthorUserId.Value,
+                authorName,
+                conversation.ConversationId.Value,
+                conversation.ConversationName),
 
             _ => throw new InvalidOperationException("Unsupported message notification target")
         };
+
+        return new NotificationDeliveryPayload(NotificationDeliveryPayloadTypes.MessageCreated, data);
     }
 }

--- a/src/Harmonie.Application/Services/Notifications/MessageNotificationPayloadFactory.cs
+++ b/src/Harmonie.Application/Services/Notifications/MessageNotificationPayloadFactory.cs
@@ -1,11 +1,16 @@
 using Harmonie.Application.Interfaces.Notifications;
+using Microsoft.Extensions.Options;
 
 namespace Harmonie.Application.Services.Notifications;
 
 public sealed class MessageNotificationPayloadFactory
 {
-    private const string DefaultIcon = "/harmonie.png";
-    private const string DefaultBadge = "/pwa-icon-192.png";
+    private readonly PushNotificationOptions _options;
+
+    public MessageNotificationPayloadFactory(IOptions<PushNotificationOptions> options)
+    {
+        _options = options.Value;
+    }
 
     public NotificationDeliveryPayload Create(MessageNotificationContext context)
     {
@@ -21,16 +26,16 @@ public sealed class MessageNotificationPayloadFactory
                 body,
                 $"/guilds/{channel.GuildId.Value}/channels/{channel.ChannelId.Value}",
                 $"message-{context.MessageId.Value}",
-                DefaultIcon,
-                DefaultBadge),
+                _options.Icon,
+                _options.Badge),
 
             MessageNotificationTarget.Conversation conversation => new NotificationDeliveryPayload(
                 authorName,
                 body,
                 $"/conversations/{conversation.ConversationId.Value}",
                 $"message-{context.MessageId.Value}",
-                DefaultIcon,
-                DefaultBadge),
+                _options.Icon,
+                _options.Badge),
 
             _ => throw new InvalidOperationException("Unsupported message notification target")
         };

--- a/src/Harmonie.Application/Services/Notifications/MessageNotificationPayloadFactory.cs
+++ b/src/Harmonie.Application/Services/Notifications/MessageNotificationPayloadFactory.cs
@@ -1,0 +1,38 @@
+using Harmonie.Application.Interfaces.Notifications;
+
+namespace Harmonie.Application.Services.Notifications;
+
+public sealed class MessageNotificationPayloadFactory
+{
+    private const string DefaultIcon = "/harmonie.png";
+    private const string DefaultBadge = "/pwa-icon-192.png";
+
+    public NotificationDeliveryPayload Create(MessageNotificationContext context)
+    {
+        var authorName = string.IsNullOrWhiteSpace(context.AuthorDisplayName)
+            ? context.AuthorUsername
+            : context.AuthorDisplayName;
+        var body = string.IsNullOrWhiteSpace(context.Content) ? "New message" : context.Content;
+
+        return context.Target switch
+        {
+            MessageNotificationTarget.Channel channel => new NotificationDeliveryPayload(
+                $"{authorName} | {channel.ChannelName}",
+                body,
+                $"/guilds/{channel.GuildId.Value}/channels/{channel.ChannelId.Value}",
+                $"message-{context.MessageId.Value}",
+                DefaultIcon,
+                DefaultBadge),
+
+            MessageNotificationTarget.Conversation conversation => new NotificationDeliveryPayload(
+                authorName,
+                body,
+                $"/conversations/{conversation.ConversationId.Value}",
+                $"message-{context.MessageId.Value}",
+                DefaultIcon,
+                DefaultBadge),
+
+            _ => throw new InvalidOperationException("Unsupported message notification target")
+        };
+    }
+}

--- a/src/Harmonie.Application/Services/Notifications/MessageNotificationRecipientResolver.cs
+++ b/src/Harmonie.Application/Services/Notifications/MessageNotificationRecipientResolver.cs
@@ -1,0 +1,14 @@
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Domain.ValueObjects.Users;
+
+namespace Harmonie.Application.Services.Notifications;
+
+public sealed class MessageNotificationRecipientResolver
+{
+    public IReadOnlySet<UserId> Resolve(MessageNotificationContext context)
+    {
+        return context.CandidateRecipientUserIds
+            .Where(userId => userId != context.AuthorUserId)
+            .ToHashSet();
+    }
+}

--- a/src/Harmonie.Application/Services/Notifications/NotificationDispatchService.cs
+++ b/src/Harmonie.Application/Services/Notifications/NotificationDispatchService.cs
@@ -1,0 +1,121 @@
+using Harmonie.Application.Interfaces.Notifications;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Harmonie.Application.Services.Notifications;
+
+public sealed class NotificationDispatchService
+{
+    private readonly IMessageNotificationContextRepository _contextRepository;
+    private readonly INotificationDeviceRepository _deviceRepository;
+    private readonly IMessageNotificationOutboxRepository _outboxRepository;
+    private readonly MessageNotificationRecipientResolver _recipientResolver;
+    private readonly MessageNotificationPayloadFactory _payloadFactory;
+    private readonly IReadOnlyDictionary<string, INotificationDeliveryAdapter> _adaptersByPlatform;
+    private readonly PushNotificationOptions _options;
+    private readonly ILogger<NotificationDispatchService> _logger;
+
+    public NotificationDispatchService(
+        IMessageNotificationContextRepository contextRepository,
+        INotificationDeviceRepository deviceRepository,
+        IMessageNotificationOutboxRepository outboxRepository,
+        MessageNotificationRecipientResolver recipientResolver,
+        MessageNotificationPayloadFactory payloadFactory,
+        IEnumerable<INotificationDeliveryAdapter> adapters,
+        IOptions<PushNotificationOptions> options,
+        ILogger<NotificationDispatchService> logger)
+    {
+        _contextRepository = contextRepository;
+        _deviceRepository = deviceRepository;
+        _outboxRepository = outboxRepository;
+        _recipientResolver = recipientResolver;
+        _payloadFactory = payloadFactory;
+        _adaptersByPlatform = adapters
+            .GroupBy(adapter => adapter.Platform, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task DispatchAsync(
+        MessageNotificationOutboxJob job,
+        DateTime nowUtc,
+        CancellationToken cancellationToken = default)
+    {
+        var context = await _contextRepository.GetAsync(job.MessageId, cancellationToken);
+        if (context is null)
+        {
+            await _outboxRepository.MarkProcessedAsync(job.Id, nowUtc, cancellationToken);
+            return;
+        }
+
+        var recipientIds = _recipientResolver.Resolve(context);
+        if (recipientIds.Count == 0)
+        {
+            await _outboxRepository.MarkProcessedAsync(job.Id, nowUtc, cancellationToken);
+            return;
+        }
+
+        var devices = await _deviceRepository.GetActiveByUserIdsAsync(recipientIds, nowUtc, cancellationToken);
+        if (devices.Count == 0)
+        {
+            await _outboxRepository.MarkProcessedAsync(job.Id, nowUtc, cancellationToken);
+            return;
+        }
+
+        var payload = _payloadFactory.Create(context);
+        var deliveryResults = new List<NotificationDeliveryResult>();
+        var unsupportedPlatforms = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var platformDevices in devices.GroupBy(device => device.Platform, StringComparer.OrdinalIgnoreCase))
+        {
+            if (!_adaptersByPlatform.TryGetValue(platformDevices.Key, out var adapter))
+            {
+                unsupportedPlatforms.Add(platformDevices.Key);
+                continue;
+            }
+
+            var results = await adapter.SendAsync(payload, platformDevices.ToArray(), cancellationToken);
+            deliveryResults.AddRange(results);
+        }
+
+        foreach (var invalidDevice in deliveryResults.Where(result => result.Status == NotificationDeliveryResultStatus.InvalidDevice))
+        {
+            await _deviceRepository.DeleteAsync(invalidDevice.DeviceId, cancellationToken);
+        }
+
+        var blockingFailures = deliveryResults
+            .Where(result => result.Status is NotificationDeliveryResultStatus.TransientFailure or NotificationDeliveryResultStatus.PermanentFailure)
+            .Select(result => result.Error ?? result.Status.ToString())
+            .Concat(unsupportedPlatforms.Select(platform => $"No notification adapter registered for platform '{platform}'"))
+            .ToArray();
+
+        if (blockingFailures.Length == 0)
+        {
+            await _outboxRepository.MarkProcessedAsync(job.Id, nowUtc, cancellationToken);
+            return;
+        }
+
+        var error = string.Join("; ", blockingFailures.Distinct(StringComparer.Ordinal).Take(5));
+        if (job.Attempts >= _options.MaxAttempts)
+        {
+            _logger.LogWarning(
+                "Message notification outbox job {JobId} failed after {Attempts} attempts: {Error}",
+                job.Id,
+                job.Attempts,
+                error);
+            await _outboxRepository.MarkFailedAsync(job.Id, error, nowUtc, cancellationToken);
+            return;
+        }
+
+        var nextAttemptAtUtc = nowUtc.Add(CalculateRetryDelay(job.Attempts));
+        await _outboxRepository.ScheduleRetryAsync(job.Id, nextAttemptAtUtc, error, cancellationToken);
+    }
+
+    private TimeSpan CalculateRetryDelay(int attempts)
+    {
+        var exponent = Math.Max(0, attempts - 1);
+        var multiplier = Math.Pow(2, Math.Min(exponent, 6));
+        return TimeSpan.FromSeconds(_options.RetryBaseDelaySeconds * multiplier);
+    }
+}

--- a/src/Harmonie.Application/Services/Notifications/NotificationDispatchService.cs
+++ b/src/Harmonie.Application/Services/Notifications/NotificationDispatchService.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 
 namespace Harmonie.Application.Services.Notifications;
 
-public sealed class NotificationDispatchService
+public sealed class NotificationDispatchService : INotificationDispatchService
 {
     private readonly IMessageNotificationContextRepository _contextRepository;
     private readonly INotificationDeviceRepository _deviceRepository;

--- a/src/Harmonie.Application/Services/Notifications/NotificationDispatchService.cs
+++ b/src/Harmonie.Application/Services/Notifications/NotificationDispatchService.cs
@@ -45,6 +45,10 @@ public sealed class NotificationDispatchService
         var context = await _contextRepository.GetAsync(job.MessageId, cancellationToken);
         if (context is null)
         {
+            _logger.LogInformation(
+                "Message notification outbox job {JobId} skipped because message {MessageId} no longer exists or is deleted.",
+                job.Id,
+                job.MessageId.Value);
             await _outboxRepository.MarkProcessedAsync(job.Id, nowUtc, cancellationToken);
             return;
         }
@@ -52,6 +56,10 @@ public sealed class NotificationDispatchService
         var recipientIds = _recipientResolver.Resolve(context);
         if (recipientIds.Count == 0)
         {
+            _logger.LogDebug(
+                "Message notification outbox job {JobId} completed without recipients for message {MessageId}.",
+                job.Id,
+                job.MessageId.Value);
             await _outboxRepository.MarkProcessedAsync(job.Id, nowUtc, cancellationToken);
             return;
         }
@@ -59,6 +67,10 @@ public sealed class NotificationDispatchService
         var devices = await _deviceRepository.GetActiveByUserIdsAsync(recipientIds, nowUtc, cancellationToken);
         if (devices.Count == 0)
         {
+            _logger.LogDebug(
+                "Message notification outbox job {JobId} completed because {RecipientCount} recipients have no active notification devices.",
+                job.Id,
+                recipientIds.Count);
             await _outboxRepository.MarkProcessedAsync(job.Id, nowUtc, cancellationToken);
             return;
         }
@@ -71,6 +83,11 @@ public sealed class NotificationDispatchService
         {
             if (!_adaptersByPlatform.TryGetValue(platformDevices.Key, out var adapter))
             {
+                _logger.LogWarning(
+                    "Message notification outbox job {JobId} found {DeviceCount} devices for unsupported notification platform {Platform}.",
+                    job.Id,
+                    platformDevices.Count(),
+                    platformDevices.Key);
                 unsupportedPlatforms.Add(platformDevices.Key);
                 continue;
             }
@@ -79,9 +96,18 @@ public sealed class NotificationDispatchService
             deliveryResults.AddRange(results);
         }
 
-        foreach (var invalidDevice in deliveryResults.Where(result => result.Status == NotificationDeliveryResultStatus.InvalidDevice))
+        var invalidDeviceIds = deliveryResults
+            .Where(result => result.Status == NotificationDeliveryResultStatus.InvalidDevice)
+            .Select(result => result.DeviceId)
+            .Distinct()
+            .ToArray();
+        if (invalidDeviceIds.Length > 0)
         {
-            await _deviceRepository.DeleteAsync(invalidDevice.DeviceId, cancellationToken);
+            _logger.LogInformation(
+                "Removing {InvalidDeviceCount} invalid notification devices after message notification outbox job {JobId}.",
+                invalidDeviceIds.Length,
+                job.Id);
+            await _deviceRepository.DeleteManyAsync(invalidDeviceIds, cancellationToken);
         }
 
         var blockingFailures = deliveryResults
@@ -92,6 +118,10 @@ public sealed class NotificationDispatchService
 
         if (blockingFailures.Length == 0)
         {
+            _logger.LogDebug(
+                "Message notification outbox job {JobId} processed for {DeviceCount} devices.",
+                job.Id,
+                devices.Count);
             await _outboxRepository.MarkProcessedAsync(job.Id, nowUtc, cancellationToken);
             return;
         }
@@ -109,6 +139,12 @@ public sealed class NotificationDispatchService
         }
 
         var nextAttemptAtUtc = nowUtc.Add(CalculateRetryDelay(job.Attempts));
+        _logger.LogWarning(
+            "Message notification outbox job {JobId} attempt {Attempts} failed and will retry at {NextAttemptAtUtc}: {Error}",
+            job.Id,
+            job.Attempts,
+            nextAttemptAtUtc,
+            error);
         await _outboxRepository.ScheduleRetryAsync(job.Id, nextAttemptAtUtc, error, cancellationToken);
     }
 

--- a/src/Harmonie.Application/Services/Notifications/PushNotificationOptions.cs
+++ b/src/Harmonie.Application/Services/Notifications/PushNotificationOptions.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Harmonie.Application.Services.Notifications;
+
+public sealed class PushNotificationOptions
+{
+    public const string SectionName = "PushNotifications";
+
+    public bool Enabled { get; set; }
+
+    [Range(1, 500)]
+    public int BatchSize { get; set; } = 25;
+
+    [Range(1, 3600)]
+    public int PollIntervalSeconds { get; set; } = 5;
+
+    [Range(1, 3600)]
+    public int LockDurationSeconds { get; set; } = 300;
+
+    [Range(1, 20)]
+    public int MaxAttempts { get; set; } = 5;
+
+    [Range(1, 3600)]
+    public int RetryBaseDelaySeconds { get; set; } = 30;
+}

--- a/src/Harmonie.Application/Services/Notifications/PushNotificationOptions.cs
+++ b/src/Harmonie.Application/Services/Notifications/PushNotificationOptions.cs
@@ -25,12 +25,4 @@ public sealed class PushNotificationOptions
 
     [Range(1, 3600)]
     public int RetryBaseDelaySeconds { get; set; } = 30;
-
-    [Required]
-    [MinLength(1)]
-    public string Icon { get; set; } = "/harmonie.png";
-
-    [Required]
-    [MinLength(1)]
-    public string Badge { get; set; } = "/pwa-icon-192.png";
 }

--- a/src/Harmonie.Application/Services/Notifications/PushNotificationOptions.cs
+++ b/src/Harmonie.Application/Services/Notifications/PushNotificationOptions.cs
@@ -17,9 +17,20 @@ public sealed class PushNotificationOptions
     [Range(1, 3600)]
     public int LockDurationSeconds { get; set; } = 300;
 
+    [Range(1, 50)]
+    public int MaxConcurrentJobs { get; set; } = 4;
+
     [Range(1, 20)]
     public int MaxAttempts { get; set; } = 5;
 
     [Range(1, 3600)]
     public int RetryBaseDelaySeconds { get; set; } = 30;
+
+    [Required]
+    [MinLength(1)]
+    public string Icon { get; set; } = "/harmonie.png";
+
+    [Required]
+    [MinLength(1)]
+    public string Badge { get; set; } = "/pwa-icon-192.png";
 }

--- a/src/Harmonie.Infrastructure/Configuration/WebPushSettings.cs
+++ b/src/Harmonie.Infrastructure/Configuration/WebPushSettings.cs
@@ -1,0 +1,17 @@
+namespace Harmonie.Infrastructure.Configuration;
+
+public sealed class WebPushSettings
+{
+    public const string SectionName = "WebPush";
+
+    public string PublicKey { get; set; } = string.Empty;
+
+    public string PrivateKey { get; set; } = string.Empty;
+
+    public string Subject { get; set; } = string.Empty;
+
+    public bool HasVapidCredentials =>
+        !string.IsNullOrWhiteSpace(PublicKey)
+        && !string.IsNullOrWhiteSpace(PrivateKey)
+        && !string.IsNullOrWhiteSpace(Subject);
+}

--- a/src/Harmonie.Infrastructure/DependencyInjection.cs
+++ b/src/Harmonie.Infrastructure/DependencyInjection.cs
@@ -22,9 +22,11 @@ using Harmonie.Infrastructure.Persistence.Notifications;
 using Harmonie.Infrastructure.Persistence.Uploads;
 using Harmonie.Infrastructure.Persistence.Users;
 using Harmonie.Infrastructure.Services;
+using Harmonie.Infrastructure.Services.Notifications;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using WebPush;
 
 namespace Harmonie.Infrastructure;
 
@@ -75,6 +77,7 @@ public static class DependencyInjection
         services.AddScoped<IUserSubscriptionRepository, UserSubscriptionRepository>();
         services.AddScoped<INotificationDeviceRepository, NotificationDeviceRepository>();
         services.AddScoped<IMessageNotificationOutboxRepository, MessageNotificationOutboxRepository>();
+        services.AddScoped<IMessageNotificationContextRepository, MessageNotificationContextRepository>();
 
         return services;
     }
@@ -134,6 +137,30 @@ public static class DependencyInjection
             client.Timeout = TimeSpan.FromSeconds(5);
             client.DefaultRequestHeaders.UserAgent.ParseAdd("Harmonie-LinkPreview/1.0");
         });
+
+        return services;
+    }
+
+    public static IServiceCollection AddNotificationDeliveryInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddOptions<WebPushSettings>()
+            .Configure(options =>
+            {
+                configuration.GetSection(WebPushSettings.SectionName).Bind(options);
+                options.PublicKey = configuration["VAPID_PUBLIC_KEY"] ?? options.PublicKey;
+                options.PrivateKey = configuration["VAPID_PRIVATE_KEY"] ?? options.PrivateKey;
+                options.Subject = configuration["VAPID_SUBJECT"] ?? options.Subject;
+            })
+            .Validate(
+                settings => !settings.HasVapidCredentials
+                            || Uri.TryCreate(settings.Subject, UriKind.Absolute, out _)
+                            || settings.Subject.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase),
+                "WebPush:Subject must be an absolute URI or mailto URI when VAPID credentials are configured.")
+            .ValidateOnStart();
+
+        services.AddSingleton<WebPushClient>();
+        services.AddSingleton<WebPushEndpointValidator>();
+        services.AddScoped<INotificationDeliveryAdapter, WebPushNotificationDeliveryAdapter>();
 
         return services;
     }

--- a/src/Harmonie.Infrastructure/Harmonie.Infrastructure.csproj
+++ b/src/Harmonie.Infrastructure/Harmonie.Infrastructure.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="HtmlAgilityPack" />
     <PackageReference Include="Livekit.Server.Sdk.Dotnet" />
     <PackageReference Include="Npgsql" />
+    <PackageReference Include="WebPush" />
     
     <!-- JWT -->
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />

--- a/src/Harmonie.Infrastructure/Persistence/Notifications/MessageNotificationContextRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Notifications/MessageNotificationContextRepository.cs
@@ -28,14 +28,17 @@ public sealed class MessageNotificationContextRepository : IMessageNotificationC
                                       m.author_user_id AS "AuthorUserId",
                                       u.username AS "AuthorUsername",
                                       u.display_name AS "AuthorDisplayName",
-                                      m.content AS "Content",
                                       m.channel_id AS "ChannelId",
                                       gc.guild_id AS "GuildId",
+                                      g.name AS "GuildName",
                                       gc.name AS "ChannelName",
-                                      m.conversation_id AS "ConversationId"
+                                      m.conversation_id AS "ConversationId",
+                                      c.name AS "ConversationName"
                                   FROM messages m
                                   JOIN users u ON u.id = m.author_user_id
                                   LEFT JOIN guild_channels gc ON gc.id = m.channel_id
+                                  LEFT JOIN guilds g ON g.id = gc.guild_id
+                                  LEFT JOIN conversations c ON c.id = m.conversation_id
                                   WHERE m.id = @MessageId
                                     AND m.deleted_at_utc IS NULL
                                   """;
@@ -51,7 +54,7 @@ public sealed class MessageNotificationContextRepository : IMessageNotificationC
         if (row is null)
             return null;
 
-        if (row.ChannelId is not null && row.GuildId is not null && row.ChannelName is not null)
+        if (row.ChannelId is not null && row.GuildId is not null && row.GuildName is not null && row.ChannelName is not null)
         {
             var recipientRows = await QueryRecipientIdsAsync(
                 """
@@ -67,9 +70,9 @@ public sealed class MessageNotificationContextRepository : IMessageNotificationC
                 UserId.From(row.AuthorUserId),
                 row.AuthorUsername,
                 row.AuthorDisplayName,
-                row.Content,
                 new MessageNotificationTarget.Channel(
                     GuildId.From(row.GuildId.Value),
+                    row.GuildName,
                     GuildChannelId.From(row.ChannelId.Value),
                     row.ChannelName),
                 recipientRows.Select(UserId.From).ToHashSet());
@@ -91,8 +94,7 @@ public sealed class MessageNotificationContextRepository : IMessageNotificationC
                 UserId.From(row.AuthorUserId),
                 row.AuthorUsername,
                 row.AuthorDisplayName,
-                row.Content,
-                new MessageNotificationTarget.Conversation(ConversationId.From(row.ConversationId.Value)),
+                new MessageNotificationTarget.Conversation(ConversationId.From(row.ConversationId.Value), row.ConversationName),
                 recipientRows.Select(UserId.From).ToHashSet());
         }
 
@@ -125,14 +127,16 @@ public sealed class MessageNotificationContextRepository : IMessageNotificationC
 
         public string? AuthorDisplayName { get; init; }
 
-        public string? Content { get; init; }
-
         public Guid? ChannelId { get; init; }
 
         public Guid? GuildId { get; init; }
 
+        public string? GuildName { get; init; }
+
         public string? ChannelName { get; init; }
 
         public Guid? ConversationId { get; init; }
+
+        public string? ConversationName { get; init; }
     }
 }

--- a/src/Harmonie.Infrastructure/Persistence/Notifications/MessageNotificationContextRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Notifications/MessageNotificationContextRepository.cs
@@ -1,0 +1,138 @@
+using Dapper;
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Guilds;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Harmonie.Infrastructure.Persistence.Common;
+
+namespace Harmonie.Infrastructure.Persistence.Notifications;
+
+public sealed class MessageNotificationContextRepository : IMessageNotificationContextRepository
+{
+    private readonly DbSession _dbSession;
+
+    public MessageNotificationContextRepository(DbSession dbSession)
+    {
+        _dbSession = dbSession;
+    }
+
+    public async Task<MessageNotificationContext?> GetAsync(
+        MessageId messageId,
+        CancellationToken cancellationToken = default)
+    {
+        const string messageSql = """
+                                  SELECT
+                                      m.id AS "MessageId",
+                                      m.author_user_id AS "AuthorUserId",
+                                      u.username AS "AuthorUsername",
+                                      u.display_name AS "AuthorDisplayName",
+                                      m.content AS "Content",
+                                      m.channel_id AS "ChannelId",
+                                      gc.guild_id AS "GuildId",
+                                      gc.name AS "ChannelName",
+                                      m.conversation_id AS "ConversationId"
+                                  FROM messages m
+                                  JOIN users u ON u.id = m.author_user_id
+                                  LEFT JOIN guild_channels gc ON gc.id = m.channel_id
+                                  WHERE m.id = @MessageId
+                                    AND m.deleted_at_utc IS NULL
+                                  """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var messageCommand = new CommandDefinition(
+            messageSql,
+            new { MessageId = messageId.Value },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        var row = await connection.QuerySingleOrDefaultAsync<MessageNotificationContextRow>(messageCommand);
+        if (row is null)
+            return null;
+
+        if (row.ChannelId is not null && row.GuildId is not null && row.ChannelName is not null)
+        {
+            var recipientRows = await QueryRecipientIdsAsync(
+                """
+                SELECT user_id
+                FROM guild_members
+                WHERE guild_id = @GuildId
+                """,
+                new { row.GuildId },
+                cancellationToken);
+
+            return new MessageNotificationContext(
+                MessageId.From(row.MessageId),
+                UserId.From(row.AuthorUserId),
+                row.AuthorUsername,
+                row.AuthorDisplayName,
+                row.Content,
+                new MessageNotificationTarget.Channel(
+                    GuildId.From(row.GuildId.Value),
+                    GuildChannelId.From(row.ChannelId.Value),
+                    row.ChannelName),
+                recipientRows.Select(UserId.From).ToHashSet());
+        }
+
+        if (row.ConversationId is not null)
+        {
+            var recipientRows = await QueryRecipientIdsAsync(
+                """
+                SELECT user_id
+                FROM conversation_participants
+                WHERE conversation_id = @ConversationId
+                """,
+                new { row.ConversationId },
+                cancellationToken);
+
+            return new MessageNotificationContext(
+                MessageId.From(row.MessageId),
+                UserId.From(row.AuthorUserId),
+                row.AuthorUsername,
+                row.AuthorDisplayName,
+                row.Content,
+                new MessageNotificationTarget.Conversation(ConversationId.From(row.ConversationId.Value)),
+                recipientRows.Select(UserId.From).ToHashSet());
+        }
+
+        return null;
+    }
+
+    private async Task<IReadOnlyList<Guid>> QueryRecipientIdsAsync(
+        string sql,
+        object parameters,
+        CancellationToken cancellationToken)
+    {
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            parameters,
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        var rows = await connection.QueryAsync<Guid>(command);
+        return rows.ToArray();
+    }
+
+    private sealed class MessageNotificationContextRow
+    {
+        public Guid MessageId { get; init; }
+
+        public Guid AuthorUserId { get; init; }
+
+        public string AuthorUsername { get; init; } = string.Empty;
+
+        public string? AuthorDisplayName { get; init; }
+
+        public string? Content { get; init; }
+
+        public Guid? ChannelId { get; init; }
+
+        public Guid? GuildId { get; init; }
+
+        public string? ChannelName { get; init; }
+
+        public Guid? ConversationId { get; init; }
+    }
+}

--- a/src/Harmonie.Infrastructure/Persistence/Notifications/MessageNotificationOutboxRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Notifications/MessageNotificationOutboxRepository.cs
@@ -134,6 +134,100 @@ public sealed class MessageNotificationOutboxRepository : IMessageNotificationOu
             .ToArray();
     }
 
+    public async Task MarkProcessedAsync(
+        Guid jobId,
+        DateTime processedAtUtc,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+                           UPDATE message_notification_outbox
+                           SET status = @Status,
+                               locked_until_utc = NULL,
+                               last_error = NULL,
+                               processed_at_utc = @ProcessedAtUtc
+                           WHERE id = @JobId
+                           """;
+
+        await ExecuteStateChangeAsync(
+            sql,
+            new
+            {
+                JobId = jobId,
+                Status = MessageNotificationOutboxStatuses.Processed,
+                ProcessedAtUtc = processedAtUtc
+            },
+            cancellationToken);
+    }
+
+    public async Task ScheduleRetryAsync(
+        Guid jobId,
+        DateTime nextAttemptAtUtc,
+        string error,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+                           UPDATE message_notification_outbox
+                           SET status = @Status,
+                               next_attempt_at_utc = @NextAttemptAtUtc,
+                               locked_until_utc = NULL,
+                               last_error = @Error
+                           WHERE id = @JobId
+                           """;
+
+        await ExecuteStateChangeAsync(
+            sql,
+            new
+            {
+                JobId = jobId,
+                Status = MessageNotificationOutboxStatuses.Pending,
+                NextAttemptAtUtc = nextAttemptAtUtc,
+                Error = error
+            },
+            cancellationToken);
+    }
+
+    public async Task MarkFailedAsync(
+        Guid jobId,
+        string error,
+        DateTime failedAtUtc,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+                           UPDATE message_notification_outbox
+                           SET status = @Status,
+                               locked_until_utc = NULL,
+                               last_error = @Error,
+                               processed_at_utc = @FailedAtUtc
+                           WHERE id = @JobId
+                           """;
+
+        await ExecuteStateChangeAsync(
+            sql,
+            new
+            {
+                JobId = jobId,
+                Status = MessageNotificationOutboxStatuses.Failed,
+                Error = error,
+                FailedAtUtc = failedAtUtc
+            },
+            cancellationToken);
+    }
+
+    private async Task ExecuteStateChangeAsync(
+        string sql,
+        object parameters,
+        CancellationToken cancellationToken)
+    {
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            parameters,
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        await connection.ExecuteAsync(command);
+    }
+
     private sealed class MessageNotificationOutboxJobRow
     {
         public Guid Id { get; init; }

--- a/src/Harmonie.Infrastructure/Persistence/Notifications/NotificationDeviceRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Notifications/NotificationDeviceRepository.cs
@@ -1,13 +1,12 @@
 using Dapper;
 using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Domain.ValueObjects.Users;
 using Harmonie.Infrastructure.Persistence.Common;
 
 namespace Harmonie.Infrastructure.Persistence.Notifications;
 
 public sealed class NotificationDeviceRepository : INotificationDeviceRepository
 {
-    private const string WebPushPlatform = "web_push";
-
     private readonly DbSession _dbSession;
 
     public NotificationDeviceRepository(DbSession dbSession)
@@ -57,7 +56,7 @@ public sealed class NotificationDeviceRepository : INotificationDeviceRepository
             {
                 Id = Guid.NewGuid(),
                 UserId = registration.UserId.Value,
-                Platform = WebPushPlatform,
+                Platform = NotificationDevicePlatforms.WebPush,
                 Token = registration.Endpoint,
                 WebPushP256dh = registration.P256dh,
                 WebPushAuth = registration.Auth,
@@ -68,5 +67,88 @@ public sealed class NotificationDeviceRepository : INotificationDeviceRepository
             cancellationToken: cancellationToken);
 
         await connection.ExecuteAsync(command);
+    }
+
+    public async Task<IReadOnlyList<NotificationDevice>> GetActiveByUserIdsAsync(
+        IReadOnlyCollection<UserId> userIds,
+        DateTime nowUtc,
+        CancellationToken cancellationToken = default)
+    {
+        if (userIds.Count == 0)
+            return [];
+
+        const string sql = """
+                           SELECT
+                               id AS "Id",
+                               user_id AS "UserId",
+                               platform AS "Platform",
+                               token AS "Token",
+                               web_push_p256dh AS "WebPushP256dh",
+                               web_push_auth AS "WebPushAuth",
+                               expires_at_utc AS "ExpiresAtUtc"
+                           FROM notification_devices
+                           WHERE user_id = ANY(@UserIds)
+                             AND (expires_at_utc IS NULL OR expires_at_utc > @NowUtc)
+                           ORDER BY updated_at_utc ASC, id ASC
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new
+            {
+                UserIds = userIds.Select(userId => userId.Value).ToArray(),
+                NowUtc = nowUtc
+            },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        var rows = await connection.QueryAsync<NotificationDeviceRow>(command);
+        return rows
+            .Select(row => new NotificationDevice(
+                row.Id,
+                UserId.From(row.UserId),
+                row.Platform,
+                row.Token,
+                row.WebPushP256dh,
+                row.WebPushAuth,
+                row.ExpiresAtUtc))
+            .ToArray();
+    }
+
+    public async Task DeleteAsync(
+        Guid deviceId,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+                           DELETE FROM notification_devices
+                           WHERE id = @DeviceId
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new { DeviceId = deviceId },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        await connection.ExecuteAsync(command);
+    }
+
+    private sealed class NotificationDeviceRow
+    {
+        public Guid Id { get; init; }
+
+        public Guid UserId { get; init; }
+
+        public string Platform { get; init; } = string.Empty;
+
+        public string Token { get; init; } = string.Empty;
+
+        public string? WebPushP256dh { get; init; }
+
+        public string? WebPushAuth { get; init; }
+
+        public DateTime? ExpiresAtUtc { get; init; }
     }
 }

--- a/src/Harmonie.Infrastructure/Persistence/Notifications/NotificationDeviceRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Notifications/NotificationDeviceRepository.cs
@@ -116,19 +116,29 @@ public sealed class NotificationDeviceRepository : INotificationDeviceRepository
             .ToArray();
     }
 
-    public async Task DeleteAsync(
+    public Task DeleteAsync(
         Guid deviceId,
         CancellationToken cancellationToken = default)
     {
+        return DeleteManyAsync([deviceId], cancellationToken);
+    }
+
+    public async Task DeleteManyAsync(
+        IReadOnlyCollection<Guid> deviceIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (deviceIds.Count == 0)
+            return;
+
         const string sql = """
                            DELETE FROM notification_devices
-                           WHERE id = @DeviceId
+                           WHERE id = ANY(@DeviceIds)
                            """;
 
         var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
         var command = new CommandDefinition(
             sql,
-            new { DeviceId = deviceId },
+            new { DeviceIds = deviceIds.ToArray() },
             transaction: _dbSession.Transaction,
             cancellationToken: cancellationToken);
 

--- a/src/Harmonie.Infrastructure/Services/Notifications/WebPushEndpointValidator.cs
+++ b/src/Harmonie.Infrastructure/Services/Notifications/WebPushEndpointValidator.cs
@@ -3,6 +3,9 @@ using System.Net.Sockets;
 
 namespace Harmonie.Infrastructure.Services.Notifications;
 
+/// <summary>
+/// Protects Web Push delivery from SSRF-style endpoints because subscription URLs are provided by clients.
+/// </summary>
 public sealed class WebPushEndpointValidator
 {
     public async Task<bool> IsAllowedAsync(

--- a/src/Harmonie.Infrastructure/Services/Notifications/WebPushEndpointValidator.cs
+++ b/src/Harmonie.Infrastructure/Services/Notifications/WebPushEndpointValidator.cs
@@ -1,0 +1,82 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace Harmonie.Infrastructure.Services.Notifications;
+
+public sealed class WebPushEndpointValidator
+{
+    public async Task<bool> IsAllowedAsync(
+        string endpoint,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var uri))
+            return false;
+
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (string.IsNullOrWhiteSpace(uri.Host))
+            return false;
+
+        if (IPAddress.TryParse(uri.Host, out var literalAddress))
+            return IsPublicAddress(literalAddress);
+
+        IPAddress[] addresses;
+        try
+        {
+            addresses = await Dns.GetHostAddressesAsync(uri.Host, cancellationToken);
+        }
+        catch (SocketException)
+        {
+            return false;
+        }
+
+        return addresses.Length > 0 && addresses.All(IsPublicAddress);
+    }
+
+    private static bool IsPublicAddress(IPAddress address)
+    {
+        if (IPAddress.IsLoopback(address))
+            return false;
+
+        if (address.AddressFamily == AddressFamily.InterNetwork)
+            return IsPublicIpv4(address);
+
+        if (address.AddressFamily == AddressFamily.InterNetworkV6)
+            return IsPublicIpv6(address);
+
+        return false;
+    }
+
+    private static bool IsPublicIpv4(IPAddress address)
+    {
+        var bytes = address.GetAddressBytes();
+
+        if (bytes[0] == 10)
+            return false;
+        if (bytes[0] == 127)
+            return false;
+        if (bytes[0] == 169 && bytes[1] == 254)
+            return false;
+        if (bytes[0] == 172 && bytes[1] is >= 16 and <= 31)
+            return false;
+        if (bytes[0] == 192 && bytes[1] == 168)
+            return false;
+        if (bytes[0] == 0)
+            return false;
+
+        return true;
+    }
+
+    private static bool IsPublicIpv6(IPAddress address)
+    {
+        if (address.IsIPv6LinkLocal || address.IsIPv6SiteLocal || address.IsIPv6Multicast)
+            return false;
+
+        var bytes = address.GetAddressBytes();
+        if ((bytes[0] & 0xfe) == 0xfc)
+            return false;
+
+        return true;
+    }
+}

--- a/src/Harmonie.Infrastructure/Services/Notifications/WebPushNotificationDeliveryAdapter.cs
+++ b/src/Harmonie.Infrastructure/Services/Notifications/WebPushNotificationDeliveryAdapter.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using System.Text.Json;
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Infrastructure.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using WebPush;
+
+namespace Harmonie.Infrastructure.Services.Notifications;
+
+public sealed class WebPushNotificationDeliveryAdapter : INotificationDeliveryAdapter
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly WebPushClient _client;
+    private readonly WebPushEndpointValidator _endpointValidator;
+    private readonly WebPushSettings _settings;
+    private readonly ILogger<WebPushNotificationDeliveryAdapter> _logger;
+
+    public WebPushNotificationDeliveryAdapter(
+        WebPushClient client,
+        WebPushEndpointValidator endpointValidator,
+        IOptions<WebPushSettings> settings,
+        ILogger<WebPushNotificationDeliveryAdapter> logger)
+    {
+        _client = client;
+        _endpointValidator = endpointValidator;
+        _settings = settings.Value;
+        _logger = logger;
+    }
+
+    public string Platform => NotificationDevicePlatforms.WebPush;
+
+    public async Task<IReadOnlyList<NotificationDeliveryResult>> SendAsync(
+        NotificationDeliveryPayload payload,
+        IReadOnlyList<NotificationDevice> devices,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_settings.HasVapidCredentials)
+        {
+            return devices
+                .Select(device => new NotificationDeliveryResult(
+                    device.Id,
+                    NotificationDeliveryResultStatus.TransientFailure,
+                    "Web Push VAPID credentials are not configured"))
+                .ToArray();
+        }
+
+        var serializedPayload = JsonSerializer.Serialize(payload, SerializerOptions);
+        var vapidDetails = new VapidDetails(_settings.Subject, _settings.PublicKey, _settings.PrivateKey);
+        var results = new List<NotificationDeliveryResult>(devices.Count);
+
+        foreach (var device in devices)
+        {
+            var validationResult = await ValidateDeviceAsync(device, cancellationToken);
+            if (validationResult is not null)
+            {
+                results.Add(validationResult);
+                continue;
+            }
+
+            var subscription = new PushSubscription(device.Token, device.WebPushP256dh, device.WebPushAuth);
+            results.Add(await SendToDeviceAsync(device.Id, subscription, serializedPayload, vapidDetails, cancellationToken));
+        }
+
+        return results;
+    }
+
+    private async Task<NotificationDeliveryResult?> ValidateDeviceAsync(
+        NotificationDevice device,
+        CancellationToken cancellationToken)
+    {
+        if (device.WebPushP256dh is null || device.WebPushAuth is null)
+        {
+            return new NotificationDeliveryResult(
+                device.Id,
+                NotificationDeliveryResultStatus.InvalidDevice,
+                "Web Push device is missing encryption keys");
+        }
+
+        var endpointAllowed = await _endpointValidator.IsAllowedAsync(device.Token, cancellationToken);
+        if (!endpointAllowed)
+        {
+            return new NotificationDeliveryResult(
+                device.Id,
+                NotificationDeliveryResultStatus.PermanentFailure,
+                "Web Push endpoint is not allowed");
+        }
+
+        return null;
+    }
+
+    private async Task<NotificationDeliveryResult> SendToDeviceAsync(
+        Guid deviceId,
+        PushSubscription subscription,
+        string payload,
+        VapidDetails vapidDetails,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _client.SendNotificationAsync(subscription, payload, vapidDetails, cancellationToken);
+            return new NotificationDeliveryResult(deviceId, NotificationDeliveryResultStatus.Succeeded);
+        }
+        catch (WebPushException ex) when (ex.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Gone)
+        {
+            return new NotificationDeliveryResult(
+                deviceId,
+                NotificationDeliveryResultStatus.InvalidDevice,
+                $"Web Push subscription is no longer valid ({(int)ex.StatusCode})");
+        }
+        catch (WebPushException ex) when (IsTransient(ex.StatusCode))
+        {
+            return new NotificationDeliveryResult(
+                deviceId,
+                NotificationDeliveryResultStatus.TransientFailure,
+                $"Web Push send failed with transient status {(int)ex.StatusCode}");
+        }
+        catch (WebPushException ex)
+        {
+            return new NotificationDeliveryResult(
+                deviceId,
+                NotificationDeliveryResultStatus.PermanentFailure,
+                $"Web Push send failed with status {(int)ex.StatusCode}");
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Unexpected Web Push send failure for notification device {DeviceId}", deviceId);
+            return new NotificationDeliveryResult(
+                deviceId,
+                NotificationDeliveryResultStatus.TransientFailure,
+                "Unexpected Web Push send failure");
+        }
+    }
+
+    private static bool IsTransient(HttpStatusCode statusCode)
+    {
+        var numericStatusCode = (int)statusCode;
+        return numericStatusCode == 408 || numericStatusCode == 429 || numericStatusCode >= 500;
+    }
+}

--- a/src/Harmonie.Workers/Dockerfile
+++ b/src/Harmonie.Workers/Dockerfile
@@ -23,7 +23,7 @@ FROM build AS publish
 RUN dotnet publish "Harmonie.Workers.csproj" -c Release -o /app/publish /p:UseAppHost=false
 
 # Runtime stage
-FROM mcr.microsoft.com/dotnet/runtime:10.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 WORKDIR /app
 
 # Copy published app

--- a/src/Harmonie.Workers/Program.cs
+++ b/src/Harmonie.Workers/Program.cs
@@ -18,6 +18,7 @@ builder.Services.AddOptions<PushNotificationOptions>()
     .Bind(builder.Configuration.GetSection(PushNotificationOptions.SectionName))
     .ValidateDataAnnotations()
     .ValidateOnStart();
+builder.Services.AddScoped<PushNotificationBatchProcessor>();
 builder.Services.AddHostedService<PushNotificationWorker>();
 
 await builder.Build().RunAsync();

--- a/src/Harmonie.Workers/Program.cs
+++ b/src/Harmonie.Workers/Program.cs
@@ -18,7 +18,7 @@ builder.Services.AddOptions<PushNotificationOptions>()
     .Bind(builder.Configuration.GetSection(PushNotificationOptions.SectionName))
     .ValidateDataAnnotations()
     .ValidateOnStart();
-builder.Services.AddScoped<PushNotificationBatchProcessor>();
+builder.Services.AddScoped<IPushNotificationBatchProcessor, PushNotificationBatchProcessor>();
 builder.Services.AddHostedService<PushNotificationWorker>();
 
 await builder.Build().RunAsync();

--- a/src/Harmonie.Workers/Program.cs
+++ b/src/Harmonie.Workers/Program.cs
@@ -1,3 +1,5 @@
+using Harmonie.Application;
+using Harmonie.Application.Services.Notifications;
 using Harmonie.Infrastructure;
 using Harmonie.Workers.Workers.Notifications;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,7 +11,13 @@ var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
     ContentRootPath = AppContext.BaseDirectory
 });
 
+builder.Services.AddApplication();
 builder.Services.AddPersistence(builder.Configuration);
+builder.Services.AddNotificationDeliveryInfrastructure(builder.Configuration);
+builder.Services.AddOptions<PushNotificationOptions>()
+    .Bind(builder.Configuration.GetSection(PushNotificationOptions.SectionName))
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
 builder.Services.AddHostedService<PushNotificationWorker>();
 
 await builder.Build().RunAsync();

--- a/src/Harmonie.Workers/Workers/Notifications/IPushNotificationBatchProcessor.cs
+++ b/src/Harmonie.Workers/Workers/Notifications/IPushNotificationBatchProcessor.cs
@@ -1,0 +1,6 @@
+namespace Harmonie.Workers.Workers.Notifications;
+
+public interface IPushNotificationBatchProcessor
+{
+    Task ProcessBatchAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Harmonie.Workers/Workers/Notifications/PushNotificationBatchProcessor.cs
+++ b/src/Harmonie.Workers/Workers/Notifications/PushNotificationBatchProcessor.cs
@@ -1,0 +1,57 @@
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Application.Services.Notifications;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Harmonie.Workers.Workers.Notifications;
+
+public sealed class PushNotificationBatchProcessor
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IMessageNotificationOutboxRepository _outboxRepository;
+    private readonly PushNotificationOptions _options;
+    private readonly ILogger<PushNotificationBatchProcessor> _logger;
+
+    public PushNotificationBatchProcessor(
+        IServiceScopeFactory scopeFactory,
+        IMessageNotificationOutboxRepository outboxRepository,
+        IOptions<PushNotificationOptions> options,
+        ILogger<PushNotificationBatchProcessor> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _outboxRepository = outboxRepository;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task ProcessBatchAsync(CancellationToken cancellationToken = default)
+    {
+        var nowUtc = DateTime.UtcNow;
+        var jobs = await _outboxRepository.ClaimPendingAsync(
+            _options.BatchSize,
+            nowUtc,
+            TimeSpan.FromSeconds(_options.LockDurationSeconds),
+            cancellationToken);
+
+        if (jobs.Count == 0)
+            return;
+
+        _logger.LogInformation(
+            "Claimed {JobCount} message notification outbox jobs.",
+            jobs.Count);
+
+        var parallelOptions = new ParallelOptions
+        {
+            MaxDegreeOfParallelism = _options.MaxConcurrentJobs,
+            CancellationToken = cancellationToken
+        };
+
+        await Parallel.ForEachAsync(jobs, parallelOptions, async (job, ct) =>
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var dispatchService = scope.ServiceProvider.GetRequiredService<NotificationDispatchService>();
+            await dispatchService.DispatchAsync(job, DateTime.UtcNow, ct);
+        });
+    }
+}

--- a/src/Harmonie.Workers/Workers/Notifications/PushNotificationBatchProcessor.cs
+++ b/src/Harmonie.Workers/Workers/Notifications/PushNotificationBatchProcessor.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Options;
 
 namespace Harmonie.Workers.Workers.Notifications;
 
-public sealed class PushNotificationBatchProcessor
+public sealed class PushNotificationBatchProcessor : IPushNotificationBatchProcessor
 {
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IMessageNotificationOutboxRepository _outboxRepository;
@@ -50,7 +50,7 @@ public sealed class PushNotificationBatchProcessor
         await Parallel.ForEachAsync(jobs, parallelOptions, async (job, ct) =>
         {
             await using var scope = _scopeFactory.CreateAsyncScope();
-            var dispatchService = scope.ServiceProvider.GetRequiredService<NotificationDispatchService>();
+            var dispatchService = scope.ServiceProvider.GetRequiredService<INotificationDispatchService>();
             await dispatchService.DispatchAsync(job, DateTime.UtcNow, ct);
         });
     }

--- a/src/Harmonie.Workers/Workers/Notifications/PushNotificationWorker.cs
+++ b/src/Harmonie.Workers/Workers/Notifications/PushNotificationWorker.cs
@@ -53,7 +53,7 @@ public sealed class PushNotificationWorker : BackgroundService
         try
         {
             await using var scope = _scopeFactory.CreateAsyncScope();
-            var processor = scope.ServiceProvider.GetRequiredService<PushNotificationBatchProcessor>();
+            var processor = scope.ServiceProvider.GetRequiredService<IPushNotificationBatchProcessor>();
             await processor.ProcessBatchAsync(stoppingToken);
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)

--- a/src/Harmonie.Workers/Workers/Notifications/PushNotificationWorker.cs
+++ b/src/Harmonie.Workers/Workers/Notifications/PushNotificationWorker.cs
@@ -1,28 +1,81 @@
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Application.Services.Notifications;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Harmonie.Workers.Workers.Notifications;
 
 public sealed class PushNotificationWorker : BackgroundService
 {
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly PushNotificationOptions _options;
     private readonly ILogger<PushNotificationWorker> _logger;
 
-    public PushNotificationWorker(ILogger<PushNotificationWorker> logger)
+    public PushNotificationWorker(
+        IServiceScopeFactory scopeFactory,
+        IOptions<PushNotificationOptions> options,
+        ILogger<PushNotificationWorker> logger)
     {
+        _scopeFactory = scopeFactory;
+        _options = options.Value;
         _logger = logger;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _logger.LogInformation("Push notification worker started. Dispatch is not implemented yet.");
+        if (!_options.Enabled)
+        {
+            _logger.LogInformation("Push notification worker is disabled.");
+            return;
+        }
 
+        _logger.LogInformation("Push notification worker started.");
+
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(_options.PollIntervalSeconds));
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await ProcessBatchAsync(stoppingToken);
+
+            try
+            {
+                await timer.WaitForNextTickAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+    }
+
+    private async Task ProcessBatchAsync(CancellationToken stoppingToken)
+    {
         try
         {
-            await Task.Delay(Timeout.InfiniteTimeSpan, stoppingToken);
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var outboxRepository = scope.ServiceProvider.GetRequiredService<IMessageNotificationOutboxRepository>();
+            var dispatchService = scope.ServiceProvider.GetRequiredService<NotificationDispatchService>();
+            var nowUtc = DateTime.UtcNow;
+
+            var jobs = await outboxRepository.ClaimPendingAsync(
+                _options.BatchSize,
+                nowUtc,
+                TimeSpan.FromSeconds(_options.LockDurationSeconds),
+                stoppingToken);
+
+            foreach (var job in jobs)
+            {
+                await dispatchService.DispatchAsync(job, DateTime.UtcNow, stoppingToken);
+            }
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
         {
             // Expected during graceful shutdown.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Push notification worker batch failed.");
         }
     }
 }

--- a/src/Harmonie.Workers/Workers/Notifications/PushNotificationWorker.cs
+++ b/src/Harmonie.Workers/Workers/Notifications/PushNotificationWorker.cs
@@ -1,4 +1,3 @@
-using Harmonie.Application.Interfaces.Notifications;
 using Harmonie.Application.Services.Notifications;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -54,20 +53,8 @@ public sealed class PushNotificationWorker : BackgroundService
         try
         {
             await using var scope = _scopeFactory.CreateAsyncScope();
-            var outboxRepository = scope.ServiceProvider.GetRequiredService<IMessageNotificationOutboxRepository>();
-            var dispatchService = scope.ServiceProvider.GetRequiredService<NotificationDispatchService>();
-            var nowUtc = DateTime.UtcNow;
-
-            var jobs = await outboxRepository.ClaimPendingAsync(
-                _options.BatchSize,
-                nowUtc,
-                TimeSpan.FromSeconds(_options.LockDurationSeconds),
-                stoppingToken);
-
-            foreach (var job in jobs)
-            {
-                await dispatchService.DispatchAsync(job, DateTime.UtcNow, stoppingToken);
-            }
+            var processor = scope.ServiceProvider.GetRequiredService<PushNotificationBatchProcessor>();
+            await processor.ProcessBatchAsync(stoppingToken);
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
         {

--- a/src/Harmonie.Workers/appsettings.json
+++ b/src/Harmonie.Workers/appsettings.json
@@ -1,4 +1,17 @@
 {
+  "PushNotifications": {
+    "Enabled": false,
+    "BatchSize": 25,
+    "PollIntervalSeconds": 5,
+    "LockDurationSeconds": 300,
+    "MaxAttempts": 5,
+    "RetryBaseDelaySeconds": 30
+  },
+  "WebPush": {
+    "PublicKey": "",
+    "PrivateKey": "",
+    "Subject": "mailto:contact@harmonie.app"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/Harmonie.Workers/appsettings.json
+++ b/src/Harmonie.Workers/appsettings.json
@@ -6,9 +6,7 @@
     "LockDurationSeconds": 300,
     "MaxConcurrentJobs": 4,
     "MaxAttempts": 5,
-    "RetryBaseDelaySeconds": 30,
-    "Icon": "/harmonie.png",
-    "Badge": "/pwa-icon-192.png"
+    "RetryBaseDelaySeconds": 30
   },
   "WebPush": {
     "PublicKey": "",

--- a/src/Harmonie.Workers/appsettings.json
+++ b/src/Harmonie.Workers/appsettings.json
@@ -4,8 +4,11 @@
     "BatchSize": 25,
     "PollIntervalSeconds": 5,
     "LockDurationSeconds": 300,
+    "MaxConcurrentJobs": 4,
     "MaxAttempts": 5,
-    "RetryBaseDelaySeconds": 30
+    "RetryBaseDelaySeconds": 30,
+    "Icon": "/harmonie.png",
+    "Badge": "/pwa-icon-192.png"
   },
   "WebPush": {
     "PublicKey": "",

--- a/tests/Harmonie.API.IntegrationTests/Harmonie.API.IntegrationTests.csproj
+++ b/tests/Harmonie.API.IntegrationTests/Harmonie.API.IntegrationTests.csproj
@@ -14,5 +14,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Harmonie.API\Harmonie.API.csproj" />
+    <ProjectReference Include="..\..\src\Harmonie.Workers\Harmonie.Workers.csproj" Aliases="Workers" />
   </ItemGroup>
 </Project>

--- a/tests/Harmonie.API.IntegrationTests/Notifications/MessageNotificationOutboxTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Notifications/MessageNotificationOutboxTests.cs
@@ -90,6 +90,7 @@ public sealed class MessageNotificationOutboxTests : IClassFixture<HarmonieWebAp
             channelId,
             "claim me once",
             user.AccessToken);
+        await DelayOtherPendingOutboxJobsAsync(message.MessageId, DateTime.UtcNow.AddDays(1));
         await SetOutboxNextAttemptAsync(message.MessageId, new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
 
         var firstClaim = await ClaimPendingAsync(batchSize: 1);
@@ -114,6 +115,26 @@ public sealed class MessageNotificationOutboxTests : IClassFixture<HarmonieWebAp
             DateTime.UtcNow.AddMinutes(1),
             TimeSpan.FromMinutes(5),
             TestContext.Current.CancellationToken);
+    }
+
+    private async Task DelayOtherPendingOutboxJobsAsync(Guid messageId, DateTime nextAttemptAtUtc)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var dbSession = scope.ServiceProvider.GetRequiredService<DbSession>();
+        var connection = await dbSession.GetOpenConnectionAsync(TestContext.Current.CancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+                              UPDATE message_notification_outbox
+                              SET next_attempt_at_utc = @NextAttemptAtUtc
+                              WHERE message_id <> @MessageId
+                                AND status = @PendingStatus
+                              """;
+        command.Parameters.AddWithValue("NextAttemptAtUtc", nextAttemptAtUtc);
+        command.Parameters.AddWithValue("MessageId", messageId);
+        command.Parameters.AddWithValue("PendingStatus", MessageNotificationOutboxStatuses.Pending);
+
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
     }
 
     private async Task SetOutboxNextAttemptAsync(Guid messageId, DateTime nextAttemptAtUtc)

--- a/tests/Harmonie.API.IntegrationTests/Notifications/MessageNotificationOutboxTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Notifications/MessageNotificationOutboxTests.cs
@@ -90,7 +90,7 @@ public sealed class MessageNotificationOutboxTests : IClassFixture<HarmonieWebAp
             channelId,
             "claim me once",
             user.AccessToken);
-        await DelayOtherPendingOutboxJobsAsync(message.MessageId, DateTime.UtcNow.AddDays(1));
+        await DelayOtherClaimableOutboxJobsAsync(message.MessageId, DateTime.UtcNow.AddDays(1));
         await SetOutboxNextAttemptAsync(message.MessageId, new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
 
         var firstClaim = await ClaimPendingAsync(batchSize: 1);
@@ -117,7 +117,7 @@ public sealed class MessageNotificationOutboxTests : IClassFixture<HarmonieWebAp
             TestContext.Current.CancellationToken);
     }
 
-    private async Task DelayOtherPendingOutboxJobsAsync(Guid messageId, DateTime nextAttemptAtUtc)
+    private async Task DelayOtherClaimableOutboxJobsAsync(Guid messageId, DateTime nextAttemptAtUtc)
     {
         await using var scope = _factory.Services.CreateAsyncScope();
         var dbSession = scope.ServiceProvider.GetRequiredService<DbSession>();
@@ -126,13 +126,21 @@ public sealed class MessageNotificationOutboxTests : IClassFixture<HarmonieWebAp
         await using var command = connection.CreateCommand();
         command.CommandText = """
                               UPDATE message_notification_outbox
-                              SET next_attempt_at_utc = @NextAttemptAtUtc
+                              SET next_attempt_at_utc = CASE
+                                      WHEN status = @PendingStatus THEN @NextAttemptAtUtc
+                                      ELSE next_attempt_at_utc
+                                  END,
+                                  locked_until_utc = CASE
+                                      WHEN status = @ProcessingStatus THEN @NextAttemptAtUtc
+                                      ELSE locked_until_utc
+                                  END
                               WHERE message_id <> @MessageId
-                                AND status = @PendingStatus
+                                AND status IN (@PendingStatus, @ProcessingStatus)
                               """;
         command.Parameters.AddWithValue("NextAttemptAtUtc", nextAttemptAtUtc);
         command.Parameters.AddWithValue("MessageId", messageId);
         command.Parameters.AddWithValue("PendingStatus", MessageNotificationOutboxStatuses.Pending);
+        command.Parameters.AddWithValue("ProcessingStatus", MessageNotificationOutboxStatuses.Processing);
 
         await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
     }

--- a/tests/Harmonie.API.IntegrationTests/Notifications/PushNotificationDispatchIntegrationTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Notifications/PushNotificationDispatchIntegrationTests.cs
@@ -1,0 +1,171 @@
+extern alias Workers;
+
+using System.Diagnostics;
+using System.Net;
+using FluentAssertions;
+using Harmonie.API.IntegrationTests.Common;
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Application.Services.Notifications;
+using Harmonie.Infrastructure.Persistence.Common;
+using Workers::Harmonie.Workers.Workers.Notifications;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Harmonie.API.IntegrationTests.Notifications;
+
+public sealed class PushNotificationDispatchIntegrationTests : IClassFixture<HarmonieWebApplicationFactory>, IDisposable
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+    private readonly RecordingNotificationDeliveryAdapter _recordingAdapter;
+
+    public PushNotificationDispatchIntegrationTests(HarmonieWebApplicationFactory factory)
+    {
+        _recordingAdapter = new RecordingNotificationDeliveryAdapter();
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.Configure<PushNotificationOptions>(options =>
+                {
+                    options.BatchSize = 500;
+                    options.MaxConcurrentJobs = 2;
+                    options.LockDurationSeconds = 60;
+                    options.MaxAttempts = 3;
+                    options.RetryBaseDelaySeconds = 1;
+                });
+                services.AddSingleton(_recordingAdapter);
+                services.AddScoped<INotificationDeliveryAdapter>(sp => sp.GetRequiredService<RecordingNotificationDeliveryAdapter>());
+                services.AddScoped<IPushNotificationBatchProcessor, PushNotificationBatchProcessor>();
+            });
+        });
+        _client = _factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task WorkerBatch_WhenConversationMessageIsSent_ShouldDispatchWebPushToRecipientDeviceOnly()
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var sender = await AuthTestHelper.RegisterAsync(_client);
+        var recipient = await AuthTestHelper.RegisterAsync(_client);
+        var recipientEndpoint = $"https://push.example/subscriptions/{Guid.NewGuid():N}";
+        var senderEndpoint = $"https://push.example/subscriptions/{Guid.NewGuid():N}";
+        await RegisterWebPushDeviceAsync(recipient.AccessToken, recipientEndpoint);
+        await RegisterWebPushDeviceAsync(sender.AccessToken, senderEndpoint);
+        var conversationId = await ConversationTestHelper.OpenConversationAsync(_client, sender.AccessToken, recipient.UserId);
+        var message = await ConversationTestHelper.SendConversationMessageAsync(
+            _client,
+            conversationId,
+            "this content must not be part of the push payload",
+            sender.AccessToken);
+
+        await ProcessNotificationBatchAsync();
+
+        stopwatch.Stop();
+        Console.WriteLine($"Push notification dispatch integration test elapsed: {stopwatch.ElapsedMilliseconds}ms");
+
+        var delivery = _recordingAdapter.Deliveries.Should().ContainSingle().Subject;
+        delivery.Device.Token.Should().Be(recipientEndpoint);
+        delivery.Device.UserId.Value.Should().Be(recipient.UserId);
+        delivery.Payload.Type.Should().Be(NotificationDeliveryPayloadTypes.MessageCreated);
+        delivery.Payload.Data.Should().BeOfType<MessageCreatedConversationNotificationData>()
+            .Which.Should().Be(new MessageCreatedConversationNotificationData(
+                NotificationMessageScopes.Conversation,
+                message.MessageId,
+                sender.UserId,
+                sender.Username,
+                conversationId,
+                null));
+        delivery.Payload.Should().NotBeEquivalentTo(new { Body = "this content must not be part of the push payload" });
+
+        var storedStatus = await GetOutboxStatusAsync(message.MessageId);
+        storedStatus.Should().Be(MessageNotificationOutboxStatuses.Processed);
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+    }
+
+    private async Task RegisterWebPushDeviceAsync(string accessToken, string endpoint)
+    {
+        var response = await _client.SendAuthorizedPutAsync(
+            "/api/notifications/push-subscriptions",
+            new
+            {
+                endpoint,
+                expirationTime = (long?)null,
+                keys = new
+                {
+                    p256dh = "p256dh-key",
+                    auth = "auth-secret"
+                }
+            },
+            accessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    private async Task ProcessNotificationBatchAsync()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var processor = scope.ServiceProvider.GetRequiredService<IPushNotificationBatchProcessor>();
+        await processor.ProcessBatchAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task<string?> GetOutboxStatusAsync(Guid messageId)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var dbSession = scope.ServiceProvider.GetRequiredService<DbSession>();
+        var connection = await dbSession.GetOpenConnectionAsync(TestContext.Current.CancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+                              SELECT status
+                              FROM message_notification_outbox
+                              WHERE message_id = @MessageId
+                              """;
+        command.Parameters.AddWithValue("MessageId", messageId);
+
+        var result = await command.ExecuteScalarAsync(TestContext.Current.CancellationToken);
+        return result as string;
+    }
+
+    private sealed class RecordingNotificationDeliveryAdapter : INotificationDeliveryAdapter
+    {
+        private readonly List<RecordedDelivery> _deliveries = new();
+        private readonly Lock _lock = new();
+
+        public string Platform => NotificationDevicePlatforms.WebPush;
+
+        public IReadOnlyList<RecordedDelivery> Deliveries
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _deliveries.ToArray();
+                }
+            }
+        }
+
+        public Task<IReadOnlyList<NotificationDeliveryResult>> SendAsync(
+            NotificationDeliveryPayload payload,
+            IReadOnlyList<NotificationDevice> devices,
+            CancellationToken cancellationToken = default)
+        {
+            lock (_lock)
+            {
+                _deliveries.AddRange(devices.Select(device => new RecordedDelivery(payload, device)));
+            }
+
+            return Task.FromResult<IReadOnlyList<NotificationDeliveryResult>>(
+                devices.Select(device => new NotificationDeliveryResult(device.Id, NotificationDeliveryResultStatus.Succeeded)).ToArray());
+        }
+    }
+
+    private sealed record RecordedDelivery(NotificationDeliveryPayload Payload, NotificationDevice Device);
+}

--- a/tests/Harmonie.API.IntegrationTests/Notifications/RegisterWebPushDeviceEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Notifications/RegisterWebPushDeviceEndpointTests.cs
@@ -115,8 +115,6 @@ public sealed class RegisterWebPushDeviceEndpointTests : IClassFixture<HarmonieW
             }
         };
 
-    // TODO: Replace this direct SQL read with production repository methods once the notification
-    // dispatch worker needs query methods for registered devices.
     private async Task<StoredNotificationDevice?> GetStoredDeviceAsync(string endpoint)
     {
         await using var scope = _factory.Services.CreateAsyncScope();
@@ -143,8 +141,6 @@ public sealed class RegisterWebPushDeviceEndpointTests : IClassFixture<HarmonieW
             reader.GetString(4));
     }
 
-    // TODO: Replace this direct SQL read with production repository methods once the notification
-    // dispatch worker needs query methods for registered devices.
     private async Task<long> CountStoredDevicesAsync(string endpoint)
     {
         await using var scope = _factory.Services.CreateAsyncScope();

--- a/tests/Harmonie.Application.Tests/Notifications/MessageNotificationPayloadFactoryTests.cs
+++ b/tests/Harmonie.Application.Tests/Notifications/MessageNotificationPayloadFactoryTests.cs
@@ -6,65 +6,68 @@ using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
-using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Harmonie.Application.Tests.Notifications;
 
 public sealed class MessageNotificationPayloadFactoryTests
 {
-    private readonly MessageNotificationPayloadFactory _factory = new(Options.Create(new PushNotificationOptions
-    {
-        Icon = "/custom-icon.png",
-        Badge = "/custom-badge.png"
-    }));
+    private readonly MessageNotificationPayloadFactory _factory = new();
 
     [Fact]
-    public void Create_ForChannelMessage_ShouldBuildServiceWorkerPayload()
+    public void Create_ForChannelMessage_ShouldBuildMessageCreatedDataPayload()
     {
         var guildId = GuildId.New();
         var channelId = GuildChannelId.New();
         var messageId = MessageId.New();
+        var authorId = UserId.New();
         var context = new MessageNotificationContext(
             messageId,
-            UserId.New(),
+            authorId,
             "alice",
             "Alice",
-            "Salut !",
-            new MessageNotificationTarget.Channel(guildId, channelId, "général"),
+            new MessageNotificationTarget.Channel(guildId, "Harmonie", channelId, "général"),
             new HashSet<UserId>());
 
         var payload = _factory.Create(context);
 
-        payload.Title.Should().Be("Alice | général");
-        payload.Body.Should().Be("Salut !");
-        payload.TargetUrl.Should().Be($"/guilds/{guildId.Value}/channels/{channelId.Value}");
-        payload.Tag.Should().Be($"message-{messageId.Value}");
-        payload.Icon.Should().Be("/custom-icon.png");
-        payload.Badge.Should().Be("/custom-badge.png");
+        payload.Type.Should().Be(NotificationDeliveryPayloadTypes.MessageCreated);
+        payload.Data.Should().BeOfType<MessageCreatedChannelNotificationData>()
+            .Which.Should().Be(new MessageCreatedChannelNotificationData(
+                NotificationMessageScopes.Channel,
+                messageId.Value,
+                authorId.Value,
+                "Alice",
+                guildId.Value,
+                "Harmonie",
+                channelId.Value,
+                "général"));
     }
 
     [Fact]
-    public void Create_ForConversationMessage_ShouldBuildServiceWorkerPayload()
+    public void Create_ForConversationMessage_ShouldBuildMessageCreatedDataPayload()
     {
         var conversationId = ConversationId.New();
         var messageId = MessageId.New();
+        var authorId = UserId.New();
         var context = new MessageNotificationContext(
             messageId,
-            UserId.New(),
+            authorId,
             "alice",
             null,
-            "Salut !",
-            new MessageNotificationTarget.Conversation(conversationId),
+            new MessageNotificationTarget.Conversation(conversationId, null),
             new HashSet<UserId>());
 
         var payload = _factory.Create(context);
 
-        payload.Title.Should().Be("alice");
-        payload.Body.Should().Be("Salut !");
-        payload.TargetUrl.Should().Be($"/conversations/{conversationId.Value}");
-        payload.Tag.Should().Be($"message-{messageId.Value}");
-        payload.Icon.Should().Be("/custom-icon.png");
-        payload.Badge.Should().Be("/custom-badge.png");
+        payload.Type.Should().Be(NotificationDeliveryPayloadTypes.MessageCreated);
+        payload.Data.Should().BeOfType<MessageCreatedConversationNotificationData>()
+            .Which.Should().Be(new MessageCreatedConversationNotificationData(
+                NotificationMessageScopes.Conversation,
+                messageId.Value,
+                authorId.Value,
+                "alice",
+                conversationId.Value,
+                null));
     }
 }

--- a/tests/Harmonie.Application.Tests/Notifications/MessageNotificationPayloadFactoryTests.cs
+++ b/tests/Harmonie.Application.Tests/Notifications/MessageNotificationPayloadFactoryTests.cs
@@ -6,13 +6,18 @@ using Harmonie.Domain.ValueObjects.Conversations;
 using Harmonie.Domain.ValueObjects.Guilds;
 using Harmonie.Domain.ValueObjects.Messages;
 using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Harmonie.Application.Tests.Notifications;
 
 public sealed class MessageNotificationPayloadFactoryTests
 {
-    private readonly MessageNotificationPayloadFactory _factory = new();
+    private readonly MessageNotificationPayloadFactory _factory = new(Options.Create(new PushNotificationOptions
+    {
+        Icon = "/custom-icon.png",
+        Badge = "/custom-badge.png"
+    }));
 
     [Fact]
     public void Create_ForChannelMessage_ShouldBuildServiceWorkerPayload()
@@ -35,8 +40,8 @@ public sealed class MessageNotificationPayloadFactoryTests
         payload.Body.Should().Be("Salut !");
         payload.TargetUrl.Should().Be($"/guilds/{guildId.Value}/channels/{channelId.Value}");
         payload.Tag.Should().Be($"message-{messageId.Value}");
-        payload.Icon.Should().Be("/harmonie.png");
-        payload.Badge.Should().Be("/pwa-icon-192.png");
+        payload.Icon.Should().Be("/custom-icon.png");
+        payload.Badge.Should().Be("/custom-badge.png");
     }
 
     [Fact]
@@ -59,7 +64,7 @@ public sealed class MessageNotificationPayloadFactoryTests
         payload.Body.Should().Be("Salut !");
         payload.TargetUrl.Should().Be($"/conversations/{conversationId.Value}");
         payload.Tag.Should().Be($"message-{messageId.Value}");
-        payload.Icon.Should().Be("/harmonie.png");
-        payload.Badge.Should().Be("/pwa-icon-192.png");
+        payload.Icon.Should().Be("/custom-icon.png");
+        payload.Badge.Should().Be("/custom-badge.png");
     }
 }

--- a/tests/Harmonie.Application.Tests/Notifications/MessageNotificationPayloadFactoryTests.cs
+++ b/tests/Harmonie.Application.Tests/Notifications/MessageNotificationPayloadFactoryTests.cs
@@ -1,0 +1,65 @@
+using FluentAssertions;
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Application.Services.Notifications;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Conversations;
+using Harmonie.Domain.ValueObjects.Guilds;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Notifications;
+
+public sealed class MessageNotificationPayloadFactoryTests
+{
+    private readonly MessageNotificationPayloadFactory _factory = new();
+
+    [Fact]
+    public void Create_ForChannelMessage_ShouldBuildServiceWorkerPayload()
+    {
+        var guildId = GuildId.New();
+        var channelId = GuildChannelId.New();
+        var messageId = MessageId.New();
+        var context = new MessageNotificationContext(
+            messageId,
+            UserId.New(),
+            "alice",
+            "Alice",
+            "Salut !",
+            new MessageNotificationTarget.Channel(guildId, channelId, "général"),
+            new HashSet<UserId>());
+
+        var payload = _factory.Create(context);
+
+        payload.Title.Should().Be("Alice | général");
+        payload.Body.Should().Be("Salut !");
+        payload.TargetUrl.Should().Be($"/guilds/{guildId.Value}/channels/{channelId.Value}");
+        payload.Tag.Should().Be($"message-{messageId.Value}");
+        payload.Icon.Should().Be("/harmonie.png");
+        payload.Badge.Should().Be("/pwa-icon-192.png");
+    }
+
+    [Fact]
+    public void Create_ForConversationMessage_ShouldBuildServiceWorkerPayload()
+    {
+        var conversationId = ConversationId.New();
+        var messageId = MessageId.New();
+        var context = new MessageNotificationContext(
+            messageId,
+            UserId.New(),
+            "alice",
+            null,
+            "Salut !",
+            new MessageNotificationTarget.Conversation(conversationId),
+            new HashSet<UserId>());
+
+        var payload = _factory.Create(context);
+
+        payload.Title.Should().Be("alice");
+        payload.Body.Should().Be("Salut !");
+        payload.TargetUrl.Should().Be($"/conversations/{conversationId.Value}");
+        payload.Tag.Should().Be($"message-{messageId.Value}");
+        payload.Icon.Should().Be("/harmonie.png");
+        payload.Badge.Should().Be("/pwa-icon-192.png");
+    }
+}

--- a/tests/Harmonie.Application.Tests/Notifications/MessageNotificationRecipientResolverTests.cs
+++ b/tests/Harmonie.Application.Tests/Notifications/MessageNotificationRecipientResolverTests.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Application.Services.Notifications;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Guilds;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Notifications;
+
+public sealed class MessageNotificationRecipientResolverTests
+{
+    [Fact]
+    public void Resolve_ShouldExcludeAuthorFromCandidateRecipients()
+    {
+        var authorId = UserId.New();
+        var recipientId = UserId.New();
+        var context = new MessageNotificationContext(
+            MessageId.New(),
+            authorId,
+            "alice",
+            "Alice",
+            "hello",
+            new MessageNotificationTarget.Channel(GuildId.New(), GuildChannelId.New(), "general"),
+            new HashSet<UserId> { authorId, recipientId });
+        var resolver = new MessageNotificationRecipientResolver();
+
+        var recipients = resolver.Resolve(context);
+
+        recipients.Should().ContainSingle().Which.Should().Be(recipientId);
+    }
+}

--- a/tests/Harmonie.Application.Tests/Notifications/MessageNotificationRecipientResolverTests.cs
+++ b/tests/Harmonie.Application.Tests/Notifications/MessageNotificationRecipientResolverTests.cs
@@ -21,8 +21,7 @@ public sealed class MessageNotificationRecipientResolverTests
             authorId,
             "alice",
             "Alice",
-            "hello",
-            new MessageNotificationTarget.Channel(GuildId.New(), GuildChannelId.New(), "general"),
+            new MessageNotificationTarget.Channel(GuildId.New(), "Harmonie", GuildChannelId.New(), "general"),
             new HashSet<UserId> { authorId, recipientId });
         var resolver = new MessageNotificationRecipientResolver();
 

--- a/tests/Harmonie.Application.Tests/Notifications/NotificationDispatchServiceTests.cs
+++ b/tests/Harmonie.Application.Tests/Notifications/NotificationDispatchServiceTests.cs
@@ -1,0 +1,235 @@
+using FluentAssertions;
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Application.Services.Notifications;
+using Harmonie.Domain.ValueObjects.Channels;
+using Harmonie.Domain.ValueObjects.Guilds;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Domain.ValueObjects.Users;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Notifications;
+
+public sealed class NotificationDispatchServiceTests
+{
+    private readonly Mock<IMessageNotificationContextRepository> _contextRepositoryMock = new();
+    private readonly Mock<INotificationDeviceRepository> _deviceRepositoryMock = new();
+    private readonly Mock<IMessageNotificationOutboxRepository> _outboxRepositoryMock = new();
+
+    [Fact]
+    public async Task DispatchAsync_ShouldSendOnlyThroughMatchingPlatformAdapter()
+    {
+        var recipientId = UserId.New();
+        var context = CreateContext(recipientId);
+        var webPushDevice = CreateDevice(recipientId, NotificationDevicePlatforms.WebPush);
+        var fcmDevice = CreateDevice(recipientId, "android_fcm");
+        var webPushAdapter = new StubNotificationDeliveryAdapter(
+            NotificationDevicePlatforms.WebPush,
+            device => new NotificationDeliveryResult(device.Id, NotificationDeliveryResultStatus.Succeeded));
+        var fcmAdapter = new StubNotificationDeliveryAdapter(
+            "android_fcm",
+            device => new NotificationDeliveryResult(device.Id, NotificationDeliveryResultStatus.Succeeded));
+        var service = CreateService(webPushAdapter, fcmAdapter);
+
+        SetupContextAndDevices(context, webPushDevice, fcmDevice);
+
+        await service.DispatchAsync(CreateJob(attempts: 1), DateTime.UtcNow, TestContext.Current.CancellationToken);
+
+        webPushAdapter.SentDeviceIds.Should().ContainSingle().Which.Should().Be(webPushDevice.Id);
+        fcmAdapter.SentDeviceIds.Should().ContainSingle().Which.Should().Be(fcmDevice.Id);
+        _outboxRepositoryMock.Verify(
+            x => x.MarkProcessedAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _outboxRepositoryMock.Verify(
+            x => x.ScheduleRetryAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenWebPushDeviceIsInvalid_ShouldDeleteDeviceAndMarkProcessed()
+    {
+        var recipientId = UserId.New();
+        var invalidDevice = CreateDevice(recipientId, NotificationDevicePlatforms.WebPush);
+        var adapter = new StubNotificationDeliveryAdapter(
+            NotificationDevicePlatforms.WebPush,
+            device => new NotificationDeliveryResult(device.Id, NotificationDeliveryResultStatus.InvalidDevice, "gone"));
+        var service = CreateService(adapter);
+
+        SetupContextAndDevices(CreateContext(recipientId), invalidDevice);
+
+        await service.DispatchAsync(CreateJob(attempts: 1), DateTime.UtcNow, TestContext.Current.CancellationToken);
+
+        _deviceRepositoryMock.Verify(
+            x => x.DeleteAsync(invalidDevice.Id, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _outboxRepositoryMock.Verify(
+            x => x.MarkProcessedAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenTransientFailureBeforeMaxAttempts_ShouldScheduleRetry()
+    {
+        var recipientId = UserId.New();
+        var device = CreateDevice(recipientId, NotificationDevicePlatforms.WebPush);
+        var nowUtc = new DateTime(2026, 6, 13, 12, 0, 0, DateTimeKind.Utc);
+        var adapter = new StubNotificationDeliveryAdapter(
+            NotificationDevicePlatforms.WebPush,
+            device => new NotificationDeliveryResult(device.Id, NotificationDeliveryResultStatus.TransientFailure, "timeout"));
+        var service = CreateService(adapter);
+
+        SetupContextAndDevices(CreateContext(recipientId), device);
+
+        await service.DispatchAsync(CreateJob(attempts: 2), nowUtc, TestContext.Current.CancellationToken);
+
+        _outboxRepositoryMock.Verify(
+            x => x.ScheduleRetryAsync(
+                It.IsAny<Guid>(),
+                nowUtc.AddSeconds(60),
+                It.Is<string>(error => error.Contains("timeout", StringComparison.Ordinal)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _outboxRepositoryMock.Verify(
+            x => x.MarkFailedAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenTransientFailureReachesMaxAttempts_ShouldMarkFailed()
+    {
+        var recipientId = UserId.New();
+        var device = CreateDevice(recipientId, NotificationDevicePlatforms.WebPush);
+        var nowUtc = new DateTime(2026, 6, 13, 12, 0, 0, DateTimeKind.Utc);
+        var adapter = new StubNotificationDeliveryAdapter(
+            NotificationDevicePlatforms.WebPush,
+            device => new NotificationDeliveryResult(device.Id, NotificationDeliveryResultStatus.TransientFailure, "timeout"));
+        var service = CreateService(adapter);
+
+        SetupContextAndDevices(CreateContext(recipientId), device);
+
+        await service.DispatchAsync(CreateJob(attempts: 3), nowUtc, TestContext.Current.CancellationToken);
+
+        _outboxRepositoryMock.Verify(
+            x => x.MarkFailedAsync(
+                It.IsAny<Guid>(),
+                It.Is<string>(error => error.Contains("timeout", StringComparison.Ordinal)),
+                nowUtc,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _outboxRepositoryMock.Verify(
+            x => x.ScheduleRetryAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private NotificationDispatchService CreateService(params INotificationDeliveryAdapter[] adapters)
+    {
+        return new NotificationDispatchService(
+            _contextRepositoryMock.Object,
+            _deviceRepositoryMock.Object,
+            _outboxRepositoryMock.Object,
+            new MessageNotificationRecipientResolver(),
+            new MessageNotificationPayloadFactory(),
+            adapters,
+            Options.Create(new PushNotificationOptions
+            {
+                MaxAttempts = 3,
+                RetryBaseDelaySeconds = 30
+            }),
+            NullLogger<NotificationDispatchService>.Instance);
+    }
+
+    private void SetupContextAndDevices(
+        MessageNotificationContext context,
+        params NotificationDevice[] devices)
+    {
+        _contextRepositoryMock
+            .Setup(x => x.GetAsync(It.IsAny<MessageId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(context);
+        _deviceRepositoryMock
+            .Setup(x => x.GetActiveByUserIdsAsync(
+                It.IsAny<IReadOnlyCollection<UserId>>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(devices);
+        _outboxRepositoryMock
+            .Setup(x => x.MarkProcessedAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _outboxRepositoryMock
+            .Setup(x => x.ScheduleRetryAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _outboxRepositoryMock
+            .Setup(x => x.MarkFailedAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _deviceRepositoryMock
+            .Setup(x => x.DeleteAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+    }
+
+    private static MessageNotificationContext CreateContext(UserId recipientId)
+    {
+        var authorId = UserId.New();
+        return new MessageNotificationContext(
+            MessageId.New(),
+            authorId,
+            "alice",
+            "Alice",
+            "hello",
+            new MessageNotificationTarget.Channel(GuildId.New(), GuildChannelId.New(), "general"),
+            new HashSet<UserId> { authorId, recipientId });
+    }
+
+    private static NotificationDevice CreateDevice(UserId userId, string platform)
+    {
+        return new NotificationDevice(
+            Guid.NewGuid(),
+            userId,
+            platform,
+            $"https://push.example.com/{Guid.NewGuid():N}",
+            "p256dh",
+            "auth",
+            null);
+    }
+
+    private static MessageNotificationOutboxJob CreateJob(int attempts)
+    {
+        return new MessageNotificationOutboxJob(
+            Guid.NewGuid(),
+            MessageId.New(),
+            MessageNotificationOutboxStatuses.Processing,
+            attempts,
+            DateTime.UtcNow,
+            DateTime.UtcNow.AddMinutes(5),
+            null,
+            DateTime.UtcNow,
+            null);
+    }
+
+    private sealed class StubNotificationDeliveryAdapter : INotificationDeliveryAdapter
+    {
+        private readonly Func<NotificationDevice, NotificationDeliveryResult> _resultFactory;
+        private readonly List<Guid> _sentDeviceIds = new();
+
+        public StubNotificationDeliveryAdapter(
+            string platform,
+            Func<NotificationDevice, NotificationDeliveryResult> resultFactory)
+        {
+            Platform = platform;
+            _resultFactory = resultFactory;
+        }
+
+        public string Platform { get; }
+
+        public IReadOnlyList<Guid> SentDeviceIds => _sentDeviceIds;
+
+        public Task<IReadOnlyList<NotificationDeliveryResult>> SendAsync(
+            NotificationDeliveryPayload payload,
+            IReadOnlyList<NotificationDevice> devices,
+            CancellationToken cancellationToken = default)
+        {
+            _sentDeviceIds.AddRange(devices.Select(device => device.Id));
+            return Task.FromResult<IReadOnlyList<NotificationDeliveryResult>>(devices.Select(_resultFactory).ToArray());
+        }
+    }
+}

--- a/tests/Harmonie.Application.Tests/Notifications/NotificationDispatchServiceTests.cs
+++ b/tests/Harmonie.Application.Tests/Notifications/NotificationDispatchServiceTests.cs
@@ -132,7 +132,7 @@ public sealed class NotificationDispatchServiceTests
             _deviceRepositoryMock.Object,
             _outboxRepositoryMock.Object,
             new MessageNotificationRecipientResolver(),
-            new MessageNotificationPayloadFactory(Options.Create(new PushNotificationOptions())),
+            new MessageNotificationPayloadFactory(),
             adapters,
             Options.Create(new PushNotificationOptions
             {
@@ -180,8 +180,7 @@ public sealed class NotificationDispatchServiceTests
             authorId,
             "alice",
             "Alice",
-            "hello",
-            new MessageNotificationTarget.Channel(GuildId.New(), GuildChannelId.New(), "general"),
+            new MessageNotificationTarget.Channel(GuildId.New(), "Harmonie", GuildChannelId.New(), "general"),
             new HashSet<UserId> { authorId, recipientId });
     }
 

--- a/tests/Harmonie.Application.Tests/Notifications/NotificationDispatchServiceTests.cs
+++ b/tests/Harmonie.Application.Tests/Notifications/NotificationDispatchServiceTests.cs
@@ -62,7 +62,9 @@ public sealed class NotificationDispatchServiceTests
         await service.DispatchAsync(CreateJob(attempts: 1), DateTime.UtcNow, TestContext.Current.CancellationToken);
 
         _deviceRepositoryMock.Verify(
-            x => x.DeleteAsync(invalidDevice.Id, It.IsAny<CancellationToken>()),
+            x => x.DeleteManyAsync(
+                It.Is<IReadOnlyCollection<Guid>>(ids => ids.Contains(invalidDevice.Id)),
+                It.IsAny<CancellationToken>()),
             Times.Once);
         _outboxRepositoryMock.Verify(
             x => x.MarkProcessedAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
@@ -130,7 +132,7 @@ public sealed class NotificationDispatchServiceTests
             _deviceRepositoryMock.Object,
             _outboxRepositoryMock.Object,
             new MessageNotificationRecipientResolver(),
-            new MessageNotificationPayloadFactory(),
+            new MessageNotificationPayloadFactory(Options.Create(new PushNotificationOptions())),
             adapters,
             Options.Create(new PushNotificationOptions
             {
@@ -164,6 +166,9 @@ public sealed class NotificationDispatchServiceTests
             .Returns(Task.CompletedTask);
         _deviceRepositoryMock
             .Setup(x => x.DeleteAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _deviceRepositoryMock
+            .Setup(x => x.DeleteManyAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
     }
 

--- a/tests/Harmonie.Infrastructure.Tests/Notifications/WebPushEndpointValidatorTests.cs
+++ b/tests/Harmonie.Infrastructure.Tests/Notifications/WebPushEndpointValidatorTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+using Harmonie.Infrastructure.Services.Notifications;
+using Xunit;
+
+namespace Harmonie.Infrastructure.Tests.Notifications;
+
+public sealed class WebPushEndpointValidatorTests
+{
+    private readonly WebPushEndpointValidator _validator = new();
+
+    [Theory]
+    [InlineData("http://updates.push.services.mozilla.com/subscription")]
+    [InlineData("https://localhost/subscription")]
+    [InlineData("https://127.0.0.1/subscription")]
+    [InlineData("https://10.0.0.1/subscription")]
+    [InlineData("https://192.168.1.10/subscription")]
+    [InlineData("https://169.254.1.1/subscription")]
+    public async Task IsAllowedAsync_WithUnsafeEndpoint_ShouldReturnFalse(string endpoint)
+    {
+        var allowed = await _validator.IsAllowedAsync(endpoint, TestContext.Current.CancellationToken);
+
+        allowed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsAllowedAsync_WithPublicHttpsEndpoint_ShouldReturnTrue()
+    {
+        var allowed = await _validator.IsAllowedAsync(
+            "https://1.1.1.1/subscription",
+            TestContext.Current.CancellationToken);
+
+        allowed.Should().BeTrue();
+    }
+}

--- a/tests/Harmonie.Workers.Tests/Harmonie.Workers.Tests.csproj
+++ b/tests/Harmonie.Workers.Tests/Harmonie.Workers.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Moq" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Harmonie.Workers\Harmonie.Workers.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Harmonie.Workers.Tests/Notifications/PushNotificationBatchProcessorTests.cs
+++ b/tests/Harmonie.Workers.Tests/Notifications/PushNotificationBatchProcessorTests.cs
@@ -1,0 +1,195 @@
+using FluentAssertions;
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Application.Services.Notifications;
+using Harmonie.Domain.ValueObjects.Messages;
+using Harmonie.Workers.Workers.Notifications;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Workers.Tests.Notifications;
+
+public sealed class PushNotificationBatchProcessorTests
+{
+    [Fact]
+    public async Task ProcessBatchAsync_ShouldClaimAndDispatchJobs()
+    {
+        var jobs = new[]
+        {
+            CreateJob(),
+            CreateJob()
+        };
+        var outboxRepositoryMock = CreateOutboxRepository(jobs);
+        var dispatchService = new RecordingNotificationDispatchService();
+        using var serviceProvider = BuildServiceProvider(dispatchService);
+        var processor = CreateProcessor(
+            serviceProvider,
+            outboxRepositoryMock.Object,
+            new PushNotificationOptions { BatchSize = 10, LockDurationSeconds = 60, MaxConcurrentJobs = 2 });
+
+        await processor.ProcessBatchAsync(TestContext.Current.CancellationToken);
+
+        dispatchService.DispatchedJobIds.Should().BeEquivalentTo(jobs.Select(job => job.Id));
+        outboxRepositoryMock.Verify(
+            x => x.ClaimPendingAsync(
+                10,
+                It.IsAny<DateTime>(),
+                TimeSpan.FromSeconds(60),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessBatchAsync_ShouldRespectMaxConcurrentJobs()
+    {
+        var jobs = Enumerable.Range(0, 8).Select(_ => CreateJob()).ToArray();
+        var outboxRepositoryMock = CreateOutboxRepository(jobs);
+        var dispatchService = new RecordingNotificationDispatchService(TimeSpan.FromMilliseconds(50));
+        using var serviceProvider = BuildServiceProvider(dispatchService);
+        var processor = CreateProcessor(
+            serviceProvider,
+            outboxRepositoryMock.Object,
+            new PushNotificationOptions { BatchSize = 10, LockDurationSeconds = 60, MaxConcurrentJobs = 2 });
+
+        await processor.ProcessBatchAsync(TestContext.Current.CancellationToken);
+
+        dispatchService.MaxObservedConcurrency.Should().BeLessThanOrEqualTo(2);
+        dispatchService.MaxObservedConcurrency.Should().BeGreaterThan(1);
+    }
+
+    [Fact]
+    public async Task ProcessBatchAsync_WhenNoJobsClaimed_ShouldNotResolveDispatchService()
+    {
+        var outboxRepositoryMock = CreateOutboxRepository([]);
+        using var serviceProvider = BuildServiceProvider(new ThrowingNotificationDispatchService());
+        var processor = CreateProcessor(
+            serviceProvider,
+            outboxRepositoryMock.Object,
+            new PushNotificationOptions { BatchSize = 10, LockDurationSeconds = 60, MaxConcurrentJobs = 2 });
+
+        await processor.ProcessBatchAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static PushNotificationBatchProcessor CreateProcessor(
+        ServiceProvider serviceProvider,
+        IMessageNotificationOutboxRepository outboxRepository,
+        PushNotificationOptions options)
+    {
+        return new PushNotificationBatchProcessor(
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            outboxRepository,
+            Options.Create(options),
+            NullLogger<PushNotificationBatchProcessor>.Instance);
+    }
+
+    private static ServiceProvider BuildServiceProvider(INotificationDispatchService dispatchService)
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => dispatchService);
+        return services.BuildServiceProvider();
+    }
+
+    private static Mock<IMessageNotificationOutboxRepository> CreateOutboxRepository(
+        IReadOnlyList<MessageNotificationOutboxJob> jobs)
+    {
+        var mock = new Mock<IMessageNotificationOutboxRepository>();
+        mock.Setup(x => x.ClaimPendingAsync(
+                It.IsAny<int>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(jobs);
+        return mock;
+    }
+
+    private static MessageNotificationOutboxJob CreateJob()
+    {
+        return new MessageNotificationOutboxJob(
+            Guid.NewGuid(),
+            MessageId.New(),
+            MessageNotificationOutboxStatuses.Processing,
+            1,
+            DateTime.UtcNow,
+            DateTime.UtcNow.AddMinutes(5),
+            null,
+            DateTime.UtcNow,
+            null);
+    }
+
+    private sealed class RecordingNotificationDispatchService : INotificationDispatchService
+    {
+        private readonly TimeSpan _delay;
+        private readonly List<Guid> _dispatchedJobIds = new();
+        private readonly Lock _lock = new();
+        private int _currentConcurrency;
+        private int _maxObservedConcurrency;
+
+        public RecordingNotificationDispatchService(TimeSpan delay = default)
+        {
+            _delay = delay;
+        }
+
+        public IReadOnlyList<Guid> DispatchedJobIds
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _dispatchedJobIds.ToArray();
+                }
+            }
+        }
+
+        public int MaxObservedConcurrency => Volatile.Read(ref _maxObservedConcurrency);
+
+        public async Task DispatchAsync(
+            MessageNotificationOutboxJob job,
+            DateTime nowUtc,
+            CancellationToken cancellationToken = default)
+        {
+            var concurrency = Interlocked.Increment(ref _currentConcurrency);
+            TrackMaxConcurrency(concurrency);
+
+            try
+            {
+                lock (_lock)
+                {
+                    _dispatchedJobIds.Add(job.Id);
+                }
+
+                if (_delay > TimeSpan.Zero)
+                    await Task.Delay(_delay, cancellationToken);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _currentConcurrency);
+            }
+        }
+
+        private void TrackMaxConcurrency(int concurrency)
+        {
+            while (true)
+            {
+                var currentMax = Volatile.Read(ref _maxObservedConcurrency);
+                if (concurrency <= currentMax)
+                    return;
+
+                if (Interlocked.CompareExchange(ref _maxObservedConcurrency, concurrency, currentMax) == currentMax)
+                    return;
+            }
+        }
+    }
+
+    private sealed class ThrowingNotificationDispatchService : INotificationDispatchService
+    {
+        public Task DispatchAsync(
+            MessageNotificationOutboxJob job,
+            DateTime nowUtc,
+            CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("Dispatch service should not be resolved when no jobs are claimed.");
+        }
+    }
+}

--- a/tests/Harmonie.Workers.Tests/Notifications/PushNotificationWorkerTests.cs
+++ b/tests/Harmonie.Workers.Tests/Notifications/PushNotificationWorkerTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using Harmonie.Application.Services.Notifications;
+using Harmonie.Workers.Workers.Notifications;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Harmonie.Workers.Tests.Notifications;
+
+public sealed class PushNotificationWorkerTests
+{
+    [Fact]
+    public async Task StartAsync_WhenDisabled_ShouldNotCreateScope()
+    {
+        var worker = new PushNotificationWorker(
+            new ThrowingServiceScopeFactory(),
+            Options.Create(new PushNotificationOptions { Enabled = false }),
+            NullLogger<PushNotificationWorker>.Instance);
+
+        await worker.StartAsync(TestContext.Current.CancellationToken);
+
+        await worker.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenEnabled_ShouldProcessAtLeastOneBatch()
+    {
+        var processor = new RecordingPushNotificationBatchProcessor();
+        var services = new ServiceCollection();
+        services.AddScoped<IPushNotificationBatchProcessor>(_ => processor);
+        await using var serviceProvider = services.BuildServiceProvider();
+        var worker = new PushNotificationWorker(
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            Options.Create(new PushNotificationOptions
+            {
+                Enabled = true,
+                PollIntervalSeconds = 3600,
+                BatchSize = 1,
+                LockDurationSeconds = 60,
+                MaxConcurrentJobs = 1
+            }),
+            NullLogger<PushNotificationWorker>.Instance);
+
+        await worker.StartAsync(TestContext.Current.CancellationToken);
+        await processor.WaitForFirstBatchAsync(TestContext.Current.CancellationToken);
+        await worker.StopAsync(TestContext.Current.CancellationToken);
+
+        processor.ProcessedBatchCount.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    private sealed class RecordingPushNotificationBatchProcessor : IPushNotificationBatchProcessor
+    {
+        private readonly TaskCompletionSource _firstBatchProcessed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _processedBatchCount;
+
+        public int ProcessedBatchCount => Volatile.Read(ref _processedBatchCount);
+
+        public Task ProcessBatchAsync(CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _processedBatchCount);
+            _firstBatchProcessed.TrySetResult();
+            return Task.CompletedTask;
+        }
+
+        public async Task WaitForFirstBatchAsync(CancellationToken cancellationToken)
+        {
+            await _firstBatchProcessed.Task.WaitAsync(cancellationToken);
+        }
+    }
+
+    private sealed class ThrowingServiceScopeFactory : IServiceScopeFactory
+    {
+        public IServiceScope CreateScope()
+        {
+            throw new InvalidOperationException("Disabled worker should not create a scope.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Wire the workers host to poll `message_notification_outbox` and dispatch message notifications asynchronously.
- Add the transport-agnostic notification pipeline:
  - `NotificationDispatchService`
  - `MessageNotificationRecipientResolver`
  - `MessageNotificationPayloadFactory`
  - `INotificationDeliveryAdapter`
- Add the first platform adapter, `WebPushNotificationDeliveryAdapter`, backed by VAPID configuration and the WebPush package.
- Resolve message context/recipients for channel and conversation messages, excluding the author.
- Load active notification devices, group by platform, remove invalid Web Push devices, retry transient failures, and fail jobs after max attempts.
- Add outbound Web Push endpoint protection for non-HTTPS/private/local/link-local destinations.
- Add worker config for disabled local mode and VAPID environment variables.

## Tests

- `dotnet build --configuration Release`
- `ConnectionStrings__DefaultConnection='Host=localhost;Port=54321;Database=harmonie;Username=harmonie_user;Password=harmonie_password' dotnet test`

Closes #413
