### PR TITLE
Document outbound push notification payloads in Scalar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ ScaffoldingReadMe.txt
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*
 
+# Local generated API docs
+openapi.local*.json
+
 # NuGet Packages
 *.nupkg
 *.snupkg

--- a/src/Harmonie.API/Configuration/OpenApiConfiguration.cs
+++ b/src/Harmonie.API/Configuration/OpenApiConfiguration.cs
@@ -1,3 +1,5 @@
+using Microsoft.OpenApi;
+
 namespace Harmonie.API.Configuration;
 
 public static class OpenApiConfiguration
@@ -15,6 +17,24 @@ public static class OpenApiConfiguration
                     Version = "v1",
                     Description = "Open-source, self-hosted communication platform API"
                 };
+
+                document.Tags ??= new HashSet<OpenApiTag>();
+                var notificationTag = document.Tags.FirstOrDefault(tag => tag.Name == "Notifications");
+                var notificationDescription = "Web Push registration plus outbound notification payload contracts. " +
+                    "Push delivery is asynchronous through Harmonie.Workers; clients cannot trigger delivery directly through an HTTP send endpoint.";
+
+                if (notificationTag is null)
+                {
+                    document.Tags.Add(new OpenApiTag
+                    {
+                        Name = "Notifications",
+                        Description = notificationDescription
+                    });
+                }
+                else
+                {
+                    notificationTag.Description = notificationDescription;
+                }
 
                 return Task.CompletedTask;
             });

--- a/src/Harmonie.API/Endpoints/NotificationDocumentationEndpoints.cs
+++ b/src/Harmonie.API/Endpoints/NotificationDocumentationEndpoints.cs
@@ -1,0 +1,77 @@
+using System.Text;
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Application.Services.Notifications;
+
+namespace Harmonie.API.Endpoints;
+
+public static class NotificationDocumentationEndpoints
+{
+    public static void MapNotificationDocumentationEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/docs/notifications/push-payloads", Results.NoContent)
+            .WithName("GetPushNotificationPayloadContracts")
+            .WithTags("Notifications")
+            .WithSummary("Describe outbound push notification payload contracts")
+            .WithDescription(BuildDescription())
+            .Produces(StatusCodes.Status204NoContent);
+    }
+
+    private static string BuildDescription()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("Documentation-only Development endpoint for outbound push notification payloads emitted by Harmonie.Workers. It does not send notifications and should not be used as a production API action.");
+        builder.AppendLine();
+        builder.AppendLine("## Delivery model");
+        builder.AppendLine();
+        builder.AppendLine("Clients register devices through the API. Message sends create outbox jobs. Harmonie.Workers claims jobs and delivers push notifications asynchronously through platform adapters.");
+        builder.AppendLine();
+        builder.AppendLine("## Current policy");
+        builder.AppendLine();
+        builder.AppendLine("- Direct conversation messages notify participants except the author.");
+        builder.AppendLine("- Group conversation messages notify participants except the author.");
+        builder.AppendLine("- Guild channel messages notify channel candidate members except the author by default.");
+        builder.AppendLine("- Mention-only, mute, quiet hours, and per-platform preferences can be added in the policy layer later.");
+        builder.AppendLine();
+        builder.AppendLine("## Payload notes");
+        builder.AppendLine();
+        builder.AppendLine("- Payloads intentionally exclude message content.");
+        builder.AppendLine("- Frontend/service worker owns notification text, routing, i18n, icon, badge, and tag.");
+        builder.AppendLine("- The top-level `type` field identifies the event. The `data.scope` field narrows the message target shape.");
+        builder.AppendLine();
+        builder.AppendLine("## `message.created` channel payload");
+        builder.AppendLine();
+        builder.AppendLine("```json");
+        builder.AppendLine("{");
+        builder.AppendLine($"  \"type\": \"{NotificationDeliveryPayloadTypes.MessageCreated}\",");
+        builder.AppendLine("  \"data\": {");
+        builder.AppendLine($"    \"scope\": \"{NotificationMessageScopes.Channel}\",");
+        builder.AppendLine("    \"messageId\": \"11111111-1111-1111-1111-111111111111\",");
+        builder.AppendLine("    \"authorUserId\": \"22222222-2222-2222-2222-222222222222\",");
+        builder.AppendLine("    \"authorDisplayName\": \"alice\",");
+        builder.AppendLine("    \"guildId\": \"33333333-3333-3333-3333-333333333333\",");
+        builder.AppendLine("    \"guildName\": \"Harmonie\",");
+        builder.AppendLine("    \"channelId\": \"44444444-4444-4444-4444-444444444444\",");
+        builder.AppendLine("    \"channelName\": \"general\"");
+        builder.AppendLine("  }");
+        builder.AppendLine("}");
+        builder.AppendLine("```");
+        builder.AppendLine();
+        builder.AppendLine("## `message.created` conversation payload");
+        builder.AppendLine();
+        builder.AppendLine("```json");
+        builder.AppendLine("{");
+        builder.AppendLine($"  \"type\": \"{NotificationDeliveryPayloadTypes.MessageCreated}\",");
+        builder.AppendLine("  \"data\": {");
+        builder.AppendLine($"    \"scope\": \"{NotificationMessageScopes.Conversation}\",");
+        builder.AppendLine("    \"messageId\": \"55555555-5555-5555-5555-555555555555\",");
+        builder.AppendLine("    \"authorUserId\": \"22222222-2222-2222-2222-222222222222\",");
+        builder.AppendLine("    \"authorDisplayName\": \"alice\",");
+        builder.AppendLine("    \"conversationId\": \"66666666-6666-6666-6666-666666666666\",");
+        builder.AppendLine("    \"conversationName\": null");
+        builder.AppendLine("  }");
+        builder.AppendLine("}");
+        builder.AppendLine("```");
+
+        return builder.ToString();
+    }
+}

--- a/src/Harmonie.API/Endpoints/NotificationDocumentationEndpoints.cs
+++ b/src/Harmonie.API/Endpoints/NotificationDocumentationEndpoints.cs
@@ -19,22 +19,7 @@ public static class NotificationDocumentationEndpoints
     private static string BuildDescription()
     {
         var builder = new StringBuilder();
-        builder.AppendLine("Documentation-only Development endpoint. It documents push payloads emitted by Harmonie.Workers; it does not send notifications.");
-        builder.AppendLine();
-        builder.AppendLine("## Client delivery flow");
-        builder.AppendLine();
-        builder.AppendLine("1. The client registers a browser Web Push subscription with `PUT /api/notifications/push-subscriptions`.");
-        builder.AppendLine("2. Harmonie.Workers sends encrypted payloads to the browser push service endpoint from that subscription.");
-        builder.AppendLine("3. The browser wakes the frontend service worker and raises a `push` event.");
-        builder.AppendLine("4. The service worker reads `event.data.json()`, renders the visible notification, and handles `notificationclick` for routing.");
-        builder.AppendLine();
-        builder.AppendLine("No client `GET`/`PUT` receives the push itself. The app may optionally call the API after a push or click to fetch fresh message/channel/conversation details.");
-        builder.AppendLine();
-        builder.AppendLine("## Payload notes");
-        builder.AppendLine();
-        builder.AppendLine("- Payloads intentionally exclude message content.");
-        builder.AppendLine("- Frontend/service worker owns notification text, routing, i18n, icon, badge, and tag.");
-        builder.AppendLine("- `type` identifies the event; `data.scope` narrows the message target shape.");
+        builder.AppendLine("Documentation-only Development endpoint. It documents outbound push payload shapes emitted by Harmonie.Workers; it does not send notifications.");
         builder.AppendLine();
         builder.AppendLine("## `message.created` channel payload");
         builder.AppendLine();

--- a/src/Harmonie.API/Endpoints/NotificationDocumentationEndpoints.cs
+++ b/src/Harmonie.API/Endpoints/NotificationDocumentationEndpoints.cs
@@ -19,24 +19,22 @@ public static class NotificationDocumentationEndpoints
     private static string BuildDescription()
     {
         var builder = new StringBuilder();
-        builder.AppendLine("Documentation-only Development endpoint for outbound push notification payloads emitted by Harmonie.Workers. It does not send notifications and should not be used as a production API action.");
+        builder.AppendLine("Documentation-only Development endpoint. It documents push payloads emitted by Harmonie.Workers; it does not send notifications.");
         builder.AppendLine();
-        builder.AppendLine("## Delivery model");
+        builder.AppendLine("## Client delivery flow");
         builder.AppendLine();
-        builder.AppendLine("Clients register devices through the API. Message sends create outbox jobs. Harmonie.Workers claims jobs and delivers push notifications asynchronously through platform adapters.");
+        builder.AppendLine("1. The client registers a browser Web Push subscription with `PUT /api/notifications/push-subscriptions`.");
+        builder.AppendLine("2. Harmonie.Workers sends encrypted payloads to the browser push service endpoint from that subscription.");
+        builder.AppendLine("3. The browser wakes the frontend service worker and raises a `push` event.");
+        builder.AppendLine("4. The service worker reads `event.data.json()`, renders the visible notification, and handles `notificationclick` for routing.");
         builder.AppendLine();
-        builder.AppendLine("## Current policy");
-        builder.AppendLine();
-        builder.AppendLine("- Direct conversation messages notify participants except the author.");
-        builder.AppendLine("- Group conversation messages notify participants except the author.");
-        builder.AppendLine("- Guild channel messages notify channel candidate members except the author by default.");
-        builder.AppendLine("- Mention-only, mute, quiet hours, and per-platform preferences can be added in the policy layer later.");
+        builder.AppendLine("No client `GET`/`PUT` receives the push itself. The app may optionally call the API after a push or click to fetch fresh message/channel/conversation details.");
         builder.AppendLine();
         builder.AppendLine("## Payload notes");
         builder.AppendLine();
         builder.AppendLine("- Payloads intentionally exclude message content.");
         builder.AppendLine("- Frontend/service worker owns notification text, routing, i18n, icon, badge, and tag.");
-        builder.AppendLine("- The top-level `type` field identifies the event. The `data.scope` field narrows the message target shape.");
+        builder.AppendLine("- `type` identifies the event; `data.scope` narrows the message target shape.");
         builder.AppendLine();
         builder.AppendLine("## `message.created` channel payload");
         builder.AppendLine();

--- a/src/Harmonie.API/Program.cs
+++ b/src/Harmonie.API/Program.cs
@@ -43,6 +43,7 @@ var app = builder.Build();
 // Middleware
 if (app.Environment.IsDevelopment())
 {
+    app.MapNotificationDocumentationEndpoints();
     app.MapOpenApi();
     app.MapScalarApiReference();
     app.MapSignalRAsyncApiDoc();

--- a/tests/Harmonie.API.IntegrationTests/OpenApiDocumentTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/OpenApiDocumentTests.cs
@@ -90,8 +90,9 @@ public sealed class OpenApiDocumentTests : IClassFixture<HarmonieWebApplicationF
         var description = operation["description"]?.GetValue<string>();
         description.Should().NotBeNull();
         description.Should().Contain("does not send notifications");
-        description.Should().Contain("## Delivery model");
-        description.Should().Contain("## Current policy");
+        description.Should().Contain("## Client delivery flow");
+        description.Should().Contain("service worker");
+        description.Should().Contain("No client `GET`/`PUT` receives the push itself");
         description.Should().Contain("## `message.created` channel payload");
         description.Should().Contain("\"type\": \"message.created\"");
         description.Should().Contain("\"scope\": \"channel\"");

--- a/tests/Harmonie.API.IntegrationTests/OpenApiDocumentTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/OpenApiDocumentTests.cs
@@ -90,9 +90,6 @@ public sealed class OpenApiDocumentTests : IClassFixture<HarmonieWebApplicationF
         var description = operation["description"]?.GetValue<string>();
         description.Should().NotBeNull();
         description.Should().Contain("does not send notifications");
-        description.Should().Contain("## Client delivery flow");
-        description.Should().Contain("service worker");
-        description.Should().Contain("No client `GET`/`PUT` receives the push itself");
         description.Should().Contain("## `message.created` channel payload");
         description.Should().Contain("\"type\": \"message.created\"");
         description.Should().Contain("\"scope\": \"channel\"");

--- a/tests/Harmonie.API.IntegrationTests/OpenApiDocumentTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/OpenApiDocumentTests.cs
@@ -66,6 +66,44 @@ public sealed class OpenApiDocumentTests : IClassFixture<HarmonieWebApplicationF
     }
 
     [Fact]
+    public async Task OpenApiDocument_ShouldDocumentOutboundPushPayloadContracts()
+    {
+        using var factory = _factory.WithWebHostBuilder(builder => builder.UseEnvironment("Development"));
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/openapi/v1.json", TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var document = JsonNode.Parse(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+        document.Should().NotBeNull();
+
+        var notificationsTag = document!["tags"]?.AsArray()
+            .FirstOrDefault(tag => tag?["name"]?.GetValue<string>() == "Notifications");
+        notificationsTag.Should().NotBeNull();
+        notificationsTag!["description"]?.GetValue<string>().Should().Contain("Harmonie.Workers");
+        notificationsTag["description"]?.GetValue<string>().Should().Contain("cannot trigger delivery directly");
+
+        var operation = document["paths"]?["/api/docs/notifications/push-payloads"]?["get"];
+        operation.Should().NotBeNull();
+        operation!["summary"]?.GetValue<string>().Should().Contain("outbound push notification payload contracts");
+        var description = operation["description"]?.GetValue<string>();
+        description.Should().NotBeNull();
+        description.Should().Contain("does not send notifications");
+        description.Should().Contain("## Delivery model");
+        description.Should().Contain("## Current policy");
+        description.Should().Contain("## `message.created` channel payload");
+        description.Should().Contain("\"type\": \"message.created\"");
+        description.Should().Contain("\"scope\": \"channel\"");
+        description.Should().Contain("## `message.created` conversation payload");
+        description.Should().Contain("\"scope\": \"conversation\"");
+
+        operation["responses"]?["204"].Should().NotBeNull();
+        operation["responses"]?["200"].Should().BeNull();
+        description.Should().NotContain("\"content\"");
+    }
+
+    [Fact]
     public async Task OpenApiDocument_ShouldListAllRegisterConflictCodesInResponseDescription()
     {
         using var factory = _factory.WithWebHostBuilder(builder => builder.UseEnvironment("Development"));


### PR DESCRIPTION
## Summary
- add a Development-only Scalar/OpenAPI documentation endpoint for outbound push payload contracts
- keep delivery model, policy, and payload notes in the operation description instead of the 204 response body
- document the two current `message.created` payload shapes as markdown JSON examples in OpenAPI
- enrich the Notifications tag with the worker/outbox delivery model
- cover the generated OpenAPI content in integration tests

## Tests
- dotnet build --configuration Release
- ConnectionStrings__DefaultConnection='Host=localhost;Port=54321;Database=harmonie;Username=harmonie_user;Password=harmonie_password' dotnet test

Closes #420