### PR TITLE
Fix worker host startup DI registration

### DIFF
--- a/src/Harmonie.Application/DependencyInjection.cs
+++ b/src/Harmonie.Application/DependencyInjection.cs
@@ -24,9 +24,7 @@ public static class DependencyInjection
         services.AddScoped<ReadOrchestrator>();
         services.AddScoped<MessageFetchOrchestrator>();
         services.AddScoped<PinnedMessageFetchOrchestrator>();
-        services.AddScoped<IMessageNotificationPolicy, MessageNotificationPolicy>();
-        services.AddScoped<MessageNotificationPayloadFactory>();
-        services.AddScoped<INotificationDispatchService, NotificationDispatchService>();
+        services.AddNotificationApplicationServices();
 
         services.AddAuthHandlers();
         services.AddGuildHandlers();
@@ -36,6 +34,15 @@ public static class DependencyInjection
         services.AddUploadHandlers();
         services.AddVoiceHandlers();
         services.AddNotificationHandlers();
+
+        return services;
+    }
+
+    public static IServiceCollection AddNotificationApplicationServices(this IServiceCollection services)
+    {
+        services.AddScoped<IMessageNotificationPolicy, MessageNotificationPolicy>();
+        services.AddScoped<MessageNotificationPayloadFactory>();
+        services.AddScoped<INotificationDispatchService, NotificationDispatchService>();
 
         return services;
     }

--- a/src/Harmonie.Workers/DependencyInjection.cs
+++ b/src/Harmonie.Workers/DependencyInjection.cs
@@ -1,0 +1,28 @@
+using Harmonie.Application;
+using Harmonie.Application.Services.Notifications;
+using Harmonie.Infrastructure;
+using Harmonie.Workers.Workers.Notifications;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Harmonie.Workers;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddWorkerServices(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.AddNotificationApplicationServices();
+        services.AddPersistence(configuration);
+        services.AddNotificationDeliveryInfrastructure(configuration);
+        services.AddOptions<PushNotificationOptions>()
+            .Bind(configuration.GetSection(PushNotificationOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+        services.AddScoped<IPushNotificationBatchProcessor, PushNotificationBatchProcessor>();
+        services.AddHostedService<PushNotificationWorker>();
+
+        return services;
+    }
+}

--- a/src/Harmonie.Workers/Program.cs
+++ b/src/Harmonie.Workers/Program.cs
@@ -1,8 +1,4 @@
-using Harmonie.Application;
-using Harmonie.Application.Services.Notifications;
-using Harmonie.Infrastructure;
-using Harmonie.Workers.Workers.Notifications;
-using Microsoft.Extensions.DependencyInjection;
+using Harmonie.Workers;
 using Microsoft.Extensions.Hosting;
 
 var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
@@ -11,14 +7,6 @@ var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
     ContentRootPath = AppContext.BaseDirectory
 });
 
-builder.Services.AddApplication();
-builder.Services.AddPersistence(builder.Configuration);
-builder.Services.AddNotificationDeliveryInfrastructure(builder.Configuration);
-builder.Services.AddOptions<PushNotificationOptions>()
-    .Bind(builder.Configuration.GetSection(PushNotificationOptions.SectionName))
-    .ValidateDataAnnotations()
-    .ValidateOnStart();
-builder.Services.AddScoped<IPushNotificationBatchProcessor, PushNotificationBatchProcessor>();
-builder.Services.AddHostedService<PushNotificationWorker>();
+builder.Services.AddWorkerServices(builder.Configuration);
 
 await builder.Build().RunAsync();

--- a/tests/Harmonie.Workers.Tests/WorkerDependencyInjectionTests.cs
+++ b/tests/Harmonie.Workers.Tests/WorkerDependencyInjectionTests.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Application.Interfaces.Uploads;
+using Harmonie.Application.Interfaces.Users;
+using Harmonie.Application.Interfaces.Voice;
+using Harmonie.Application.Services.Notifications;
+using Harmonie.Workers;
+using Harmonie.Workers.Workers.Notifications;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Harmonie.Workers.Tests;
+
+public sealed class WorkerDependencyInjectionTests
+{
+    [Fact]
+    public async Task WorkerServices_ShouldBuildWithoutApiOnlyApplicationHandlers()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "Host=postgres;Port=5432;Database=harmonie;Username=harmonie_user;Password=harmonie_password",
+                ["PushNotifications:Enabled"] = "false",
+                ["PushNotifications:BatchSize"] = "100",
+                ["PushNotifications:PollIntervalSeconds"] = "30",
+                ["PushNotifications:LockDurationSeconds"] = "300",
+                ["PushNotifications:MaxConcurrentJobs"] = "4",
+                ["PushNotifications:MaxAttempts"] = "5",
+                ["PushNotifications:RetryBaseDelaySeconds"] = "30",
+                ["VAPID_PUBLIC_KEY"] = string.Empty,
+                ["VAPID_PRIVATE_KEY"] = string.Empty,
+                ["VAPID_SUBJECT"] = "mailto:contact@harmonie.app"
+            })
+            .Build();
+        var services = new ServiceCollection();
+
+        services.AddLogging();
+        services.AddWorkerServices(configuration);
+
+        await using var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        await using var scope = serviceProvider.CreateAsyncScope();
+        scope.ServiceProvider.GetRequiredService<INotificationDispatchService>().Should().NotBeNull();
+        scope.ServiceProvider.GetRequiredService<IPushNotificationBatchProcessor>().Should().NotBeNull();
+        serviceProvider.GetServices<IHostedService>().Should().ContainSingle(service => service is PushNotificationWorker);
+        scope.ServiceProvider.GetService<IUserPresenceNotifier>().Should().BeNull();
+        scope.ServiceProvider.GetService<IObjectStorageService>().Should().BeNull();
+        scope.ServiceProvider.GetService<ILiveKitWebhookReceiver>().Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary\n- split notification application service registration from full API feature handler registration\n- update Harmonie.Workers to register only the notification application services it needs\n- add a worker DI validation test to ensure API-only services are not required\n- smoke-tested the worker container startup with Podman\n\n## Tests\n- dotnet build --configuration Release\n- ConnectionStrings__DefaultConnection='Host=localhost;Port=54321;Database=harmonie;Username=harmonie_user;Password=harmonie_password' dotnet test\n- podman build -f src/Harmonie.Workers/Dockerfile -t harmonie-workers-issue422 .\n- podman run smoke test with PushNotifications__Enabled=false\n\nCloses #422

Closes #422