### PR TITLE
Expose Web Push VAPID public key endpoint

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -73,6 +73,7 @@ services:
       - Uploads__MaxFileSizeBytes=26214400
       - ObjectStorage__LocalBasePath=/app/uploads
       - ObjectStorage__LocalBaseUrl=http://localhost:5001/files
+      - VAPID_PUBLIC_KEY=
     ports:
       - "5001:80"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       - Uploads__MaxFileSizeBytes=26214400
       - ObjectStorage__LocalBasePath=/app/uploads
       - ObjectStorage__LocalBaseUrl=http://192.168.1.67:55401/files
+      - VAPID_PUBLIC_KEY=
     ports:
       - "55401:80"
     volumes:

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -101,9 +101,10 @@ podman compose --profile workers up -d harmonie-workers
 
 Push notification dispatch runs in this worker host. The API only registers Web Push subscriptions and creates notification outbox jobs when messages are sent. The worker claims pending jobs and sends notifications through the configured delivery adapters.
 
-Development Web Push configuration is provided through `VAPID_*` environment variables in compose. For local API docs, Scalar exposes the registration endpoint:
+Development Web Push configuration is provided through `VAPID_*` environment variables in compose. For local API docs, Scalar exposes the Web Push endpoints:
 
-- `PUT /api/notifications/push-subscriptions`
+- `GET /api/notifications/web-push-public-key` returns the VAPID public key clients use with `PushManager.subscribe()`.
+- `PUT /api/notifications/push-subscriptions` registers the resulting browser subscription.
 
 Current backend notification behavior:
 - conversation messages notify participants except the author;

--- a/src/Harmonie.API/Endpoints/NotificationEndpoints.cs
+++ b/src/Harmonie.API/Endpoints/NotificationEndpoints.cs
@@ -1,3 +1,4 @@
+using Harmonie.Application.Features.Notifications.GetWebPushPublicKey;
 using Harmonie.Application.Features.Notifications.RegisterWebPushDevice;
 
 namespace Harmonie.API.Endpoints;
@@ -6,6 +7,7 @@ public static class NotificationEndpoints
 {
     public static void MapNotificationEndpoints(this IEndpointRouteBuilder app)
     {
+        GetWebPushPublicKeyEndpoint.Map(app);
         RegisterWebPushDeviceEndpoint.Map(app);
     }
 }

--- a/src/Harmonie.Application/Common/ApplicationErrorCodes.cs
+++ b/src/Harmonie.Application/Common/ApplicationErrorCodes.cs
@@ -94,6 +94,11 @@ public static class ApplicationErrorCodes
         public const string NotFound = "USER_NOT_FOUND";
     }
 
+    public static class Notification
+    {
+        public const string WebPushNotConfigured = "NOTIFICATION_WEB_PUSH_NOT_CONFIGURED";
+    }
+
     public static class Upload
     {
         public const string StorageUnavailable = "UPLOAD_STORAGE_UNAVAILABLE";

--- a/src/Harmonie.Application/Common/EndpointExtensions.cs
+++ b/src/Harmonie.Application/Common/EndpointExtensions.cs
@@ -328,6 +328,7 @@ public static class EndpointExtensions
             ApplicationErrorCodes.Message.EditForbidden => HttpStatusCode.Forbidden,
             ApplicationErrorCodes.Message.DeleteForbidden => HttpStatusCode.Forbidden,
             ApplicationErrorCodes.User.NotFound => HttpStatusCode.NotFound,
+            ApplicationErrorCodes.Notification.WebPushNotConfigured => HttpStatusCode.ServiceUnavailable,
             ApplicationErrorCodes.Upload.StorageUnavailable => HttpStatusCode.ServiceUnavailable,
             ApplicationErrorCodes.Upload.NotFound => HttpStatusCode.NotFound,
             ApplicationErrorCodes.Upload.AccessDenied => HttpStatusCode.Forbidden,

--- a/src/Harmonie.Application/Features/Notifications/GetWebPushPublicKey/GetWebPushPublicKeyEndpoint.cs
+++ b/src/Harmonie.Application/Features/Notifications/GetWebPushPublicKey/GetWebPushPublicKeyEndpoint.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using Harmonie.Application.Common;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.OpenApi;
+
+namespace Harmonie.Application.Features.Notifications.GetWebPushPublicKey;
+
+public static class GetWebPushPublicKeyEndpoint
+{
+    private static readonly JsonSerializerOptions OpenApiExampleSerializerOptions = new(JsonSerializerDefaults.Web);
+
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/notifications/web-push-public-key", HandleAsync)
+            .WithName("GetWebPushPublicKey")
+            .WithTags("Notifications")
+            .AllowAnonymous()
+            .WithSummary("Get the Web Push VAPID public key")
+            .WithDescription("Returns the public VAPID key used by clients to create browser Web Push subscriptions. The private VAPID key is never exposed.")
+            .Produces<GetWebPushPublicKeyResponse>(StatusCodes.Status200OK)
+            .ProducesErrors(ApplicationErrorCodes.Notification.WebPushNotConfigured)
+            .AddOpenApiOperationTransformer((operation, _, _) =>
+            {
+                if (operation?.Responses is not null
+                    && operation.Responses.TryGetValue("200", out var response)
+                    && response.Content is not null
+                    && response.Content.TryGetValue("application/json", out var mediaType))
+                {
+                    mediaType.Example = JsonSerializer.SerializeToNode(
+                        new GetWebPushPublicKeyResponse("BDp4Base64UrlVapidPublicKeyExample"),
+                        OpenApiExampleSerializerOptions);
+                }
+
+                return Task.CompletedTask;
+            });
+    }
+
+    private static async Task<IResult> HandleAsync(
+        [FromServices] IHandler<Unit, GetWebPushPublicKeyResponse> handler,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var response = await handler.HandleAsync(Unit.Value, cancellationToken);
+        return response.ToHttpResult(httpContext);
+    }
+}

--- a/src/Harmonie.Application/Features/Notifications/GetWebPushPublicKey/GetWebPushPublicKeyHandler.cs
+++ b/src/Harmonie.Application/Features/Notifications/GetWebPushPublicKey/GetWebPushPublicKeyHandler.cs
@@ -1,0 +1,30 @@
+using Harmonie.Application.Common;
+using Harmonie.Application.Interfaces.Notifications;
+
+namespace Harmonie.Application.Features.Notifications.GetWebPushPublicKey;
+
+public sealed class GetWebPushPublicKeyHandler : IHandler<Unit, GetWebPushPublicKeyResponse>
+{
+    private readonly IWebPushPublicKeyProvider _publicKeyProvider;
+
+    public GetWebPushPublicKeyHandler(IWebPushPublicKeyProvider publicKeyProvider)
+    {
+        _publicKeyProvider = publicKeyProvider;
+    }
+
+    public Task<ApplicationResponse<GetWebPushPublicKeyResponse>> HandleAsync(
+        Unit request,
+        CancellationToken cancellationToken = default)
+    {
+        var publicKey = _publicKeyProvider.GetPublicKey();
+        if (string.IsNullOrWhiteSpace(publicKey))
+        {
+            return Task.FromResult(ApplicationResponse<GetWebPushPublicKeyResponse>.Fail(
+                ApplicationErrorCodes.Notification.WebPushNotConfigured,
+                "Web Push public key is not configured"));
+        }
+
+        return Task.FromResult(ApplicationResponse<GetWebPushPublicKeyResponse>.Ok(
+            new GetWebPushPublicKeyResponse(publicKey)));
+    }
+}

--- a/src/Harmonie.Application/Features/Notifications/GetWebPushPublicKey/GetWebPushPublicKeyResponse.cs
+++ b/src/Harmonie.Application/Features/Notifications/GetWebPushPublicKey/GetWebPushPublicKeyResponse.cs
@@ -1,0 +1,3 @@
+namespace Harmonie.Application.Features.Notifications.GetWebPushPublicKey;
+
+public sealed record GetWebPushPublicKeyResponse(string PublicKey);

--- a/src/Harmonie.Application/Interfaces/Notifications/IWebPushPublicKeyProvider.cs
+++ b/src/Harmonie.Application/Interfaces/Notifications/IWebPushPublicKeyProvider.cs
@@ -1,0 +1,6 @@
+namespace Harmonie.Application.Interfaces.Notifications;
+
+public interface IWebPushPublicKeyProvider
+{
+    string? GetPublicKey();
+}

--- a/src/Harmonie.Application/Registration/NotificationRegistration.cs
+++ b/src/Harmonie.Application/Registration/NotificationRegistration.cs
@@ -1,4 +1,5 @@
 using Harmonie.Application.Common;
+using Harmonie.Application.Features.Notifications.GetWebPushPublicKey;
 using Harmonie.Application.Features.Notifications.RegisterWebPushDevice;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,6 +9,7 @@ public static class NotificationRegistration
 {
     public static IServiceCollection AddNotificationHandlers(this IServiceCollection services)
     {
+        services.AddHandler<Unit, GetWebPushPublicKeyResponse, GetWebPushPublicKeyHandler>();
         services.AddAuthenticatedHandler<RegisterWebPushDeviceRequest, bool, RegisterWebPushDeviceHandler>();
 
         return services;

--- a/src/Harmonie.Infrastructure/DependencyInjection.cs
+++ b/src/Harmonie.Infrastructure/DependencyInjection.cs
@@ -39,6 +39,7 @@ public static class DependencyInjection
         services.AddLiveKitInfrastructure(configuration);
         services.AddObjectStorageInfrastructure(configuration);
         services.AddLinkPreviewInfrastructure();
+        services.AddWebPushConfiguration(configuration);
 
         return services;
     }
@@ -141,7 +142,7 @@ public static class DependencyInjection
         return services;
     }
 
-    public static IServiceCollection AddNotificationDeliveryInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    public static IServiceCollection AddWebPushConfiguration(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddOptions<WebPushSettings>()
             .Configure(options =>
@@ -157,6 +158,15 @@ public static class DependencyInjection
                             || settings.Subject.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase),
                 "WebPush:Subject must be an absolute URI or mailto URI when VAPID credentials are configured.")
             .ValidateOnStart();
+
+        services.AddSingleton<IWebPushPublicKeyProvider, WebPushPublicKeyProvider>();
+
+        return services;
+    }
+
+    public static IServiceCollection AddNotificationDeliveryInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddWebPushConfiguration(configuration);
 
         services.AddSingleton<WebPushClient>();
         services.AddSingleton<WebPushEndpointValidator>();

--- a/src/Harmonie.Infrastructure/Services/Notifications/WebPushPublicKeyProvider.cs
+++ b/src/Harmonie.Infrastructure/Services/Notifications/WebPushPublicKeyProvider.cs
@@ -1,0 +1,22 @@
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Infrastructure.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Harmonie.Infrastructure.Services.Notifications;
+
+public sealed class WebPushPublicKeyProvider : IWebPushPublicKeyProvider
+{
+    private readonly WebPushSettings _settings;
+
+    public WebPushPublicKeyProvider(IOptions<WebPushSettings> settings)
+    {
+        _settings = settings.Value;
+    }
+
+    public string? GetPublicKey()
+    {
+        return string.IsNullOrWhiteSpace(_settings.PublicKey)
+            ? null
+            : _settings.PublicKey;
+    }
+}

--- a/tests/Harmonie.API.IntegrationTests/Notifications/GetWebPushPublicKeyEndpointTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Notifications/GetWebPushPublicKeyEndpointTests.cs
@@ -1,0 +1,77 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Harmonie.API.IntegrationTests.Common;
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Notifications.GetWebPushPublicKey;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Harmonie.API.IntegrationTests.Notifications;
+
+public sealed class GetWebPushPublicKeyEndpointTests : IClassFixture<HarmonieWebApplicationFactory>
+{
+    private readonly HarmonieWebApplicationFactory _factory;
+
+    public GetWebPushPublicKeyEndpointTests(HarmonieWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetWebPushPublicKey_WhenConfigured_ShouldReturnPublicKeyWithoutAuthentication()
+    {
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, configuration) =>
+            {
+                configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["VAPID_PUBLIC_KEY"] = "public-vapid-key",
+                    ["VAPID_PRIVATE_KEY"] = "private-vapid-key",
+                    ["VAPID_SUBJECT"] = "mailto:contact@harmonie.app"
+                });
+            });
+        });
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(
+            "/api/notifications/web-push-public-key",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<GetWebPushPublicKeyResponse>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        payload.Should().Be(new GetWebPushPublicKeyResponse("public-vapid-key"));
+        var rawJson = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        rawJson.Should().NotContain("private-vapid-key");
+    }
+
+    [Fact]
+    public async Task GetWebPushPublicKey_WhenPublicKeyIsMissing_ShouldReturnServiceUnavailable()
+    {
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, configuration) =>
+            {
+                configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["WebPush:PublicKey"] = string.Empty,
+                    ["VAPID_PUBLIC_KEY"] = string.Empty
+                });
+            });
+        });
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(
+            "/api/notifications/web-push-public-key",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        var error = await response.Content.ReadFromJsonAsync<ApplicationError>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        error.Should().NotBeNull();
+        error!.Code.Should().Be(ApplicationErrorCodes.Notification.WebPushNotConfigured);
+    }
+}

--- a/tests/Harmonie.API.IntegrationTests/OpenApiDocumentTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/OpenApiDocumentTests.cs
@@ -102,6 +102,29 @@ public sealed class OpenApiDocumentTests : IClassFixture<HarmonieWebApplicationF
     }
 
     [Fact]
+    public async Task OpenApiDocument_ShouldDocumentWebPushPublicKeyEndpoint()
+    {
+        using var factory = _factory.WithWebHostBuilder(builder => builder.UseEnvironment("Development"));
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/openapi/v1.json", TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var document = JsonNode.Parse(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+        document.Should().NotBeNull();
+
+        var operation = document!["paths"]?["/api/notifications/web-push-public-key"]?["get"];
+        operation.Should().NotBeNull();
+        operation!["summary"]?.GetValue<string>().Should().Contain("Web Push VAPID public key");
+        operation["description"]?.GetValue<string>().Should().Contain("private VAPID key is never exposed");
+        operation["responses"]?["200"]?["content"]?["application/json"]?["example"]?["publicKey"]?
+            .GetValue<string>().Should().Be("BDp4Base64UrlVapidPublicKeyExample");
+        operation["responses"]?["503"]?["description"]?.GetValue<string>()
+            .Should().Contain(ApplicationErrorCodes.Notification.WebPushNotConfigured);
+    }
+
+    [Fact]
     public async Task OpenApiDocument_ShouldListAllRegisterConflictCodesInResponseDescription()
     {
         using var factory = _factory.WithWebHostBuilder(builder => builder.UseEnvironment("Development"));

--- a/tests/Harmonie.Application.Tests/Notifications/GetWebPushPublicKeyHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Notifications/GetWebPushPublicKeyHandlerTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using Harmonie.Application.Common;
+using Harmonie.Application.Features.Notifications.GetWebPushPublicKey;
+using Harmonie.Application.Interfaces.Notifications;
+using Xunit;
+
+namespace Harmonie.Application.Tests.Notifications;
+
+public sealed class GetWebPushPublicKeyHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_WhenPublicKeyIsConfigured_ShouldReturnPublicKey()
+    {
+        var handler = new GetWebPushPublicKeyHandler(new StubWebPushPublicKeyProvider("public-key"));
+
+        var response = await handler.HandleAsync(Unit.Value, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeTrue();
+        response.Data!.PublicKey.Should().Be("public-key");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task HandleAsync_WhenPublicKeyIsMissing_ShouldReturnConfigurationFailure(string? publicKey)
+    {
+        var handler = new GetWebPushPublicKeyHandler(new StubWebPushPublicKeyProvider(publicKey));
+
+        var response = await handler.HandleAsync(Unit.Value, TestContext.Current.CancellationToken);
+
+        response.Success.Should().BeFalse();
+        response.Error!.Code.Should().Be(ApplicationErrorCodes.Notification.WebPushNotConfigured);
+    }
+
+    private sealed class StubWebPushPublicKeyProvider : IWebPushPublicKeyProvider
+    {
+        private readonly string? _publicKey;
+
+        public StubWebPushPublicKeyProvider(string? publicKey)
+        {
+            _publicKey = publicKey;
+        }
+
+        public string? GetPublicKey() => _publicKey;
+    }
+}


### PR DESCRIPTION
## Summary\n- add anonymous GET /api/notifications/web-push-public-key for frontend runtime Web Push setup\n- share WebPushSettings binding through Infrastructure so API and worker read the same WebPush/VAPID config sources\n- expose only the VAPID public key; private key remains worker/server-only\n- document the endpoint in Scalar and Getting Started\n- add handler, endpoint, and OpenAPI integration tests\n\n## Config sharing\n- API uses AddWebPushConfiguration via AddInfrastructure to bind WebPush:PublicKey and VAPID_PUBLIC_KEY.\n- Worker uses AddNotificationDeliveryInfrastructure, which reuses AddWebPushConfiguration and additionally registers Web Push delivery services.\n- Compose now includes VAPID_PUBLIC_KEY for the API service and the full VAPID key set for the worker service.\n\n## Tests\n- dotnet build --configuration Release\n- ConnectionStrings__DefaultConnection='Host=localhost;Port=54321;Database=harmonie;Username=harmonie_user;Password=harmonie_password' dotnet test\n\nCloses #425

Closes #425