### PR TITLE
Track notification deliveries per device

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,8 +62,8 @@ Push notifications are asynchronous and transport-agnostic at the Application bo
 1. Message creation writes the message and a `message_notification_outbox` row in the same transaction.
 2. `Harmonie.Workers` claims pending outbox jobs with a lock/retry policy.
 3. `MessageNotificationPolicy` selects users to notify without knowing the delivery platform.
-4. `NotificationDispatchService` loads active notification devices for selected users.
-5. Platform adapters deliver the minimal business payload. Web Push is the first adapter; Android FCM and iOS APNs can be added behind the same device/policy model later.
+4. `NotificationDispatchService` loads active notification devices for selected users and records per-device delivery state in `message_notification_deliveries`.
+5. Platform adapters deliver the minimal business payload only to pending/retryable device deliveries. Succeeded device deliveries are not retried, which prevents duplicate pushes after partial failures. Web Push is the first adapter; Android FCM and iOS APNs can be added behind the same device/policy model later.
 
 Initial message notification policy:
 - Direct conversation messages: notify participants except the author.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -109,7 +109,8 @@ Development Web Push configuration is provided through `VAPID_*` environment var
 Current backend notification behavior:
 - conversation messages notify participants except the author;
 - guild channel messages notify channel candidate members except the author;
-- payloads are minimal `message.created` business data, without message content or UI presentation fields.
+- payloads are minimal `message.created` business data, without message content or UI presentation fields;
+- retries are tracked per device, so a partial Web Push failure does not resend to devices that already succeeded.
 
 ## 6. Run Tests
 

--- a/src/Harmonie.Application/Interfaces/Notifications/IMessageNotificationDeliveryRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Notifications/IMessageNotificationDeliveryRepository.cs
@@ -1,0 +1,50 @@
+namespace Harmonie.Application.Interfaces.Notifications;
+
+public static class MessageNotificationDeliveryStatuses
+{
+    public const string Pending = "pending";
+    public const string Succeeded = "succeeded";
+    public const string TransientFailure = "transient_failure";
+    public const string InvalidDevice = "invalid_device";
+    public const string Failed = "failed";
+}
+
+public sealed record MessageNotificationDelivery(
+    Guid Id,
+    Guid OutboxJobId,
+    Guid DeviceId,
+    string Status,
+    int Attempts,
+    string? LastError,
+    DateTime? FirstAttemptedAtUtc,
+    DateTime? LastAttemptedAtUtc,
+    DateTime? SucceededAtUtc,
+    DateTime CreatedAtUtc,
+    DateTime UpdatedAtUtc);
+
+public interface IMessageNotificationDeliveryRepository
+{
+    Task EnsurePendingAsync(
+        Guid outboxJobId,
+        IReadOnlyCollection<Guid> deviceIds,
+        DateTime createdAtUtc,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<MessageNotificationDelivery>> GetByJobAndDeviceIdsAsync(
+        Guid outboxJobId,
+        IReadOnlyCollection<Guid> deviceIds,
+        CancellationToken cancellationToken = default);
+
+    Task MarkResultsAsync(
+        Guid outboxJobId,
+        IReadOnlyCollection<NotificationDeliveryResult> results,
+        DateTime attemptedAtUtc,
+        CancellationToken cancellationToken = default);
+
+    Task MarkDevicesFailedAsync(
+        Guid outboxJobId,
+        IReadOnlyCollection<Guid> deviceIds,
+        string error,
+        DateTime failedAtUtc,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Harmonie.Application/Interfaces/Notifications/IMessageNotificationDeliveryRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Notifications/IMessageNotificationDeliveryRepository.cs
@@ -9,30 +9,12 @@ public static class MessageNotificationDeliveryStatuses
     public const string Failed = "failed";
 }
 
-public sealed record MessageNotificationDelivery(
-    Guid Id,
-    Guid OutboxJobId,
-    Guid DeviceId,
-    string Status,
-    int Attempts,
-    string? LastError,
-    DateTime? FirstAttemptedAtUtc,
-    DateTime? LastAttemptedAtUtc,
-    DateTime? SucceededAtUtc,
-    DateTime CreatedAtUtc,
-    DateTime UpdatedAtUtc);
-
 public interface IMessageNotificationDeliveryRepository
 {
-    Task EnsurePendingAsync(
+    Task<IReadOnlySet<Guid>> GetOrCreateRetryableDeviceIdsAsync(
         Guid outboxJobId,
         IReadOnlyCollection<Guid> deviceIds,
         DateTime createdAtUtc,
-        CancellationToken cancellationToken = default);
-
-    Task<IReadOnlyList<MessageNotificationDelivery>> GetByJobAndDeviceIdsAsync(
-        Guid outboxJobId,
-        IReadOnlyCollection<Guid> deviceIds,
         CancellationToken cancellationToken = default);
 
     Task MarkResultsAsync(

--- a/src/Harmonie.Application/Services/Notifications/NotificationDispatchService.cs
+++ b/src/Harmonie.Application/Services/Notifications/NotificationDispatchService.cs
@@ -9,6 +9,7 @@ public sealed class NotificationDispatchService : INotificationDispatchService
     private readonly IMessageNotificationContextRepository _contextRepository;
     private readonly INotificationDeviceRepository _deviceRepository;
     private readonly IMessageNotificationOutboxRepository _outboxRepository;
+    private readonly IMessageNotificationDeliveryRepository _deliveryRepository;
     private readonly IMessageNotificationPolicy _notificationPolicy;
     private readonly MessageNotificationPayloadFactory _payloadFactory;
     private readonly IReadOnlyDictionary<string, INotificationDeliveryAdapter> _adaptersByPlatform;
@@ -19,6 +20,7 @@ public sealed class NotificationDispatchService : INotificationDispatchService
         IMessageNotificationContextRepository contextRepository,
         INotificationDeviceRepository deviceRepository,
         IMessageNotificationOutboxRepository outboxRepository,
+        IMessageNotificationDeliveryRepository deliveryRepository,
         IMessageNotificationPolicy notificationPolicy,
         MessageNotificationPayloadFactory payloadFactory,
         IEnumerable<INotificationDeliveryAdapter> adapters,
@@ -28,6 +30,7 @@ public sealed class NotificationDispatchService : INotificationDispatchService
         _contextRepository = contextRepository;
         _deviceRepository = deviceRepository;
         _outboxRepository = outboxRepository;
+        _deliveryRepository = deliveryRepository;
         _notificationPolicy = notificationPolicy;
         _payloadFactory = payloadFactory;
         _adaptersByPlatform = adapters
@@ -75,25 +78,75 @@ public sealed class NotificationDispatchService : INotificationDispatchService
             return;
         }
 
+        var deviceIds = devices.Select(device => device.Id).Distinct().ToArray();
+        var deliveries = await _deliveryRepository.GetByJobAndDeviceIdsAsync(job.Id, deviceIds, cancellationToken);
+        if (job.Attempts <= 1 || deliveries.Count == 0)
+        {
+            var existingDeliveryDeviceIds = deliveries.Select(delivery => delivery.DeviceId).ToHashSet();
+            var missingDeviceIds = deviceIds.Where(deviceId => !existingDeliveryDeviceIds.Contains(deviceId)).ToArray();
+            if (missingDeviceIds.Length > 0)
+            {
+                await _deliveryRepository.EnsurePendingAsync(job.Id, missingDeviceIds, nowUtc, cancellationToken);
+                deliveries = await _deliveryRepository.GetByJobAndDeviceIdsAsync(job.Id, deviceIds, cancellationToken);
+            }
+        }
+
+        var retryableDeviceIds = deliveries
+            .Where(delivery => IsRetryableDeliveryStatus(delivery.Status))
+            .Select(delivery => delivery.DeviceId)
+            .ToHashSet();
+        var devicesToAttempt = devices
+            .Where(device => retryableDeviceIds.Contains(device.Id))
+            .ToArray();
+
+        if (devicesToAttempt.Length == 0)
+        {
+            _logger.LogDebug(
+                "Message notification outbox job {JobId} processed because all active notification devices are already in terminal delivery states.",
+                job.Id);
+            await _outboxRepository.MarkProcessedAsync(job.Id, nowUtc, cancellationToken);
+            return;
+        }
+
         var payload = _payloadFactory.Create(context);
         var deliveryResults = new List<NotificationDeliveryResult>();
-        var unsupportedPlatforms = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var unsupportedFailures = new List<(Guid DeviceId, string Error)>();
 
-        foreach (var platformDevices in devices.GroupBy(device => device.Platform, StringComparer.OrdinalIgnoreCase))
+        foreach (var platformDevices in devicesToAttempt.GroupBy(device => device.Platform, StringComparer.OrdinalIgnoreCase))
         {
+            var platformDeviceArray = platformDevices.ToArray();
             if (!_adaptersByPlatform.TryGetValue(platformDevices.Key, out var adapter))
             {
+                var unsupportedError = $"No notification adapter registered for platform '{platformDevices.Key}'";
                 _logger.LogWarning(
                     "Message notification outbox job {JobId} found {DeviceCount} devices for unsupported notification platform {Platform}.",
                     job.Id,
-                    platformDevices.Count(),
+                    platformDeviceArray.Length,
                     platformDevices.Key);
-                unsupportedPlatforms.Add(platformDevices.Key);
+                unsupportedFailures.AddRange(platformDeviceArray.Select(device => (device.Id, unsupportedError)));
                 continue;
             }
 
-            var results = await adapter.SendAsync(payload, platformDevices.ToArray(), cancellationToken);
+            var results = await adapter.SendAsync(payload, platformDeviceArray, cancellationToken);
             deliveryResults.AddRange(results);
+        }
+
+        if (deliveryResults.Count > 0)
+        {
+            await _deliveryRepository.MarkResultsAsync(job.Id, deliveryResults, nowUtc, cancellationToken);
+        }
+
+        if (unsupportedFailures.Count > 0)
+        {
+            foreach (var failureGroup in unsupportedFailures.GroupBy(failure => failure.Error, StringComparer.Ordinal))
+            {
+                await _deliveryRepository.MarkDevicesFailedAsync(
+                    job.Id,
+                    failureGroup.Select(failure => failure.DeviceId).ToArray(),
+                    failureGroup.Key,
+                    nowUtc,
+                    cancellationToken);
+            }
         }
 
         var invalidDeviceIds = deliveryResults
@@ -110,23 +163,26 @@ public sealed class NotificationDispatchService : INotificationDispatchService
             await _deviceRepository.DeleteManyAsync(invalidDeviceIds, cancellationToken);
         }
 
-        var blockingFailures = deliveryResults
-            .Where(result => result.Status is NotificationDeliveryResultStatus.TransientFailure or NotificationDeliveryResultStatus.PermanentFailure)
-            .Select(result => result.Error ?? result.Status.ToString())
-            .Concat(unsupportedPlatforms.Select(platform => $"No notification adapter registered for platform '{platform}'"))
+        var transientFailures = deliveryResults
+            .Where(result => result.Status == NotificationDeliveryResultStatus.TransientFailure)
             .ToArray();
 
-        if (blockingFailures.Length == 0)
+        if (transientFailures.Length == 0)
         {
             _logger.LogDebug(
-                "Message notification outbox job {JobId} processed for {DeviceCount} devices.",
+                "Message notification outbox job {JobId} processed for {AttemptedDeviceCount} attempted devices.",
                 job.Id,
-                devices.Count);
+                devicesToAttempt.Length);
             await _outboxRepository.MarkProcessedAsync(job.Id, nowUtc, cancellationToken);
             return;
         }
 
-        var error = string.Join("; ", blockingFailures.Distinct(StringComparer.Ordinal).Take(5));
+        var error = string.Join(
+            "; ",
+            transientFailures
+                .Select(result => result.Error ?? result.Status.ToString())
+                .Distinct(StringComparer.Ordinal)
+                .Take(5));
         if (job.Attempts >= _options.MaxAttempts)
         {
             _logger.LogWarning(
@@ -134,6 +190,12 @@ public sealed class NotificationDispatchService : INotificationDispatchService
                 job.Id,
                 job.Attempts,
                 error);
+            await _deliveryRepository.MarkDevicesFailedAsync(
+                job.Id,
+                transientFailures.Select(result => result.DeviceId).Distinct().ToArray(),
+                error,
+                nowUtc,
+                cancellationToken);
             await _outboxRepository.MarkFailedAsync(job.Id, error, nowUtc, cancellationToken);
             return;
         }
@@ -146,6 +208,12 @@ public sealed class NotificationDispatchService : INotificationDispatchService
             nextAttemptAtUtc,
             error);
         await _outboxRepository.ScheduleRetryAsync(job.Id, nextAttemptAtUtc, error, cancellationToken);
+    }
+
+    private static bool IsRetryableDeliveryStatus(string status)
+    {
+        return status is MessageNotificationDeliveryStatuses.Pending
+            or MessageNotificationDeliveryStatuses.TransientFailure;
     }
 
     private TimeSpan CalculateRetryDelay(int attempts)

--- a/src/Harmonie.Application/Services/Notifications/NotificationDispatchService.cs
+++ b/src/Harmonie.Application/Services/Notifications/NotificationDispatchService.cs
@@ -79,22 +79,11 @@ public sealed class NotificationDispatchService : INotificationDispatchService
         }
 
         var deviceIds = devices.Select(device => device.Id).Distinct().ToArray();
-        var deliveries = await _deliveryRepository.GetByJobAndDeviceIdsAsync(job.Id, deviceIds, cancellationToken);
-        if (job.Attempts <= 1 || deliveries.Count == 0)
-        {
-            var existingDeliveryDeviceIds = deliveries.Select(delivery => delivery.DeviceId).ToHashSet();
-            var missingDeviceIds = deviceIds.Where(deviceId => !existingDeliveryDeviceIds.Contains(deviceId)).ToArray();
-            if (missingDeviceIds.Length > 0)
-            {
-                await _deliveryRepository.EnsurePendingAsync(job.Id, missingDeviceIds, nowUtc, cancellationToken);
-                deliveries = await _deliveryRepository.GetByJobAndDeviceIdsAsync(job.Id, deviceIds, cancellationToken);
-            }
-        }
-
-        var retryableDeviceIds = deliveries
-            .Where(delivery => IsRetryableDeliveryStatus(delivery.Status))
-            .Select(delivery => delivery.DeviceId)
-            .ToHashSet();
+        var retryableDeviceIds = await _deliveryRepository.GetOrCreateRetryableDeviceIdsAsync(
+            job.Id,
+            deviceIds,
+            nowUtc,
+            cancellationToken);
         var devicesToAttempt = devices
             .Where(device => retryableDeviceIds.Contains(device.Id))
             .ToArray();
@@ -208,12 +197,6 @@ public sealed class NotificationDispatchService : INotificationDispatchService
             nextAttemptAtUtc,
             error);
         await _outboxRepository.ScheduleRetryAsync(job.Id, nextAttemptAtUtc, error, cancellationToken);
-    }
-
-    private static bool IsRetryableDeliveryStatus(string status)
-    {
-        return status is MessageNotificationDeliveryStatuses.Pending
-            or MessageNotificationDeliveryStatuses.TransientFailure;
     }
 
     private TimeSpan CalculateRetryDelay(int attempts)

--- a/src/Harmonie.Infrastructure/DependencyInjection.cs
+++ b/src/Harmonie.Infrastructure/DependencyInjection.cs
@@ -78,6 +78,7 @@ public static class DependencyInjection
         services.AddScoped<IUserSubscriptionRepository, UserSubscriptionRepository>();
         services.AddScoped<INotificationDeviceRepository, NotificationDeviceRepository>();
         services.AddScoped<IMessageNotificationOutboxRepository, MessageNotificationOutboxRepository>();
+        services.AddScoped<IMessageNotificationDeliveryRepository, MessageNotificationDeliveryRepository>();
         services.AddScoped<IMessageNotificationContextRepository, MessageNotificationContextRepository>();
 
         return services;

--- a/src/Harmonie.Infrastructure/Persistence/Notifications/MessageNotificationDeliveryRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Notifications/MessageNotificationDeliveryRepository.cs
@@ -1,0 +1,246 @@
+using Dapper;
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Infrastructure.Persistence.Common;
+
+namespace Harmonie.Infrastructure.Persistence.Notifications;
+
+public sealed class MessageNotificationDeliveryRepository : IMessageNotificationDeliveryRepository
+{
+    private readonly DbSession _dbSession;
+
+    public MessageNotificationDeliveryRepository(DbSession dbSession)
+    {
+        _dbSession = dbSession;
+    }
+
+    public async Task EnsurePendingAsync(
+        Guid outboxJobId,
+        IReadOnlyCollection<Guid> deviceIds,
+        DateTime createdAtUtc,
+        CancellationToken cancellationToken = default)
+    {
+        if (deviceIds.Count == 0)
+            return;
+
+        const string sql = """
+                           INSERT INTO message_notification_deliveries (
+                               id,
+                               outbox_job_id,
+                               device_id,
+                               status,
+                               attempts,
+                               last_error,
+                               first_attempted_at_utc,
+                               last_attempted_at_utc,
+                               succeeded_at_utc,
+                               created_at_utc,
+                               updated_at_utc)
+                           VALUES (
+                               @Id,
+                               @OutboxJobId,
+                               @DeviceId,
+                               @Status,
+                               0,
+                               NULL,
+                               NULL,
+                               NULL,
+                               NULL,
+                               @NowUtc,
+                               @NowUtc)
+                           ON CONFLICT (outbox_job_id, device_id) DO NOTHING
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        foreach (var deviceId in deviceIds.Distinct())
+        {
+            var command = new CommandDefinition(
+                sql,
+                new
+                {
+                    Id = Guid.NewGuid(),
+                    OutboxJobId = outboxJobId,
+                    DeviceId = deviceId,
+                    Status = MessageNotificationDeliveryStatuses.Pending,
+                    NowUtc = createdAtUtc
+                },
+                transaction: _dbSession.Transaction,
+                cancellationToken: cancellationToken);
+
+            await connection.ExecuteAsync(command);
+        }
+    }
+
+    public async Task<IReadOnlyList<MessageNotificationDelivery>> GetByJobAndDeviceIdsAsync(
+        Guid outboxJobId,
+        IReadOnlyCollection<Guid> deviceIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (deviceIds.Count == 0)
+            return [];
+
+        const string sql = """
+                           SELECT
+                               id AS "Id",
+                               outbox_job_id AS "OutboxJobId",
+                               device_id AS "DeviceId",
+                               status AS "Status",
+                               attempts AS "Attempts",
+                               last_error AS "LastError",
+                               first_attempted_at_utc AS "FirstAttemptedAtUtc",
+                               last_attempted_at_utc AS "LastAttemptedAtUtc",
+                               succeeded_at_utc AS "SucceededAtUtc",
+                               created_at_utc AS "CreatedAtUtc",
+                               updated_at_utc AS "UpdatedAtUtc"
+                           FROM message_notification_deliveries
+                           WHERE outbox_job_id = @OutboxJobId
+                             AND device_id = ANY(@DeviceIds)
+                           ORDER BY created_at_utc ASC, id ASC
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new
+            {
+                OutboxJobId = outboxJobId,
+                DeviceIds = deviceIds.Distinct().ToArray()
+            },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        var rows = await connection.QueryAsync<MessageNotificationDeliveryRow>(command);
+        return rows
+            .Select(row => new MessageNotificationDelivery(
+                row.Id,
+                row.OutboxJobId,
+                row.DeviceId,
+                row.Status,
+                row.Attempts,
+                row.LastError,
+                row.FirstAttemptedAtUtc,
+                row.LastAttemptedAtUtc,
+                row.SucceededAtUtc,
+                row.CreatedAtUtc,
+                row.UpdatedAtUtc))
+            .ToArray();
+    }
+
+    public async Task MarkResultsAsync(
+        Guid outboxJobId,
+        IReadOnlyCollection<NotificationDeliveryResult> results,
+        DateTime attemptedAtUtc,
+        CancellationToken cancellationToken = default)
+    {
+        if (results.Count == 0)
+            return;
+
+        const string sql = """
+                           UPDATE message_notification_deliveries
+                           SET status = @Status,
+                               attempts = attempts + 1,
+                               last_error = @Error,
+                               first_attempted_at_utc = COALESCE(first_attempted_at_utc, @AttemptedAtUtc),
+                               last_attempted_at_utc = @AttemptedAtUtc,
+                               succeeded_at_utc = CASE
+                                   WHEN @Status = @SucceededStatus THEN @AttemptedAtUtc
+                                   ELSE succeeded_at_utc
+                               END,
+                               updated_at_utc = @AttemptedAtUtc
+                           WHERE outbox_job_id = @OutboxJobId
+                             AND device_id = @DeviceId
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        foreach (var result in results)
+        {
+            var command = new CommandDefinition(
+                sql,
+                new
+                {
+                    OutboxJobId = outboxJobId,
+                    result.DeviceId,
+                    Status = ToDeliveryStatus(result.Status),
+                    result.Error,
+                    AttemptedAtUtc = attemptedAtUtc,
+                    SucceededStatus = MessageNotificationDeliveryStatuses.Succeeded
+                },
+                transaction: _dbSession.Transaction,
+                cancellationToken: cancellationToken);
+
+            await connection.ExecuteAsync(command);
+        }
+    }
+
+    public async Task MarkDevicesFailedAsync(
+        Guid outboxJobId,
+        IReadOnlyCollection<Guid> deviceIds,
+        string error,
+        DateTime failedAtUtc,
+        CancellationToken cancellationToken = default)
+    {
+        if (deviceIds.Count == 0)
+            return;
+
+        const string sql = """
+                           UPDATE message_notification_deliveries
+                           SET status = @Status,
+                               last_error = @Error,
+                               updated_at_utc = @FailedAtUtc
+                           WHERE outbox_job_id = @OutboxJobId
+                             AND device_id = ANY(@DeviceIds)
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new
+            {
+                OutboxJobId = outboxJobId,
+                DeviceIds = deviceIds.Distinct().ToArray(),
+                Status = MessageNotificationDeliveryStatuses.Failed,
+                Error = error,
+                FailedAtUtc = failedAtUtc
+            },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        await connection.ExecuteAsync(command);
+    }
+
+    private static string ToDeliveryStatus(NotificationDeliveryResultStatus status)
+    {
+        return status switch
+        {
+            NotificationDeliveryResultStatus.Succeeded => MessageNotificationDeliveryStatuses.Succeeded,
+            NotificationDeliveryResultStatus.InvalidDevice => MessageNotificationDeliveryStatuses.InvalidDevice,
+            NotificationDeliveryResultStatus.TransientFailure => MessageNotificationDeliveryStatuses.TransientFailure,
+            NotificationDeliveryResultStatus.PermanentFailure => MessageNotificationDeliveryStatuses.Failed,
+            _ => MessageNotificationDeliveryStatuses.Failed
+        };
+    }
+
+    private sealed class MessageNotificationDeliveryRow
+    {
+        public Guid Id { get; init; }
+
+        public Guid OutboxJobId { get; init; }
+
+        public Guid DeviceId { get; init; }
+
+        public string Status { get; init; } = string.Empty;
+
+        public int Attempts { get; init; }
+
+        public string? LastError { get; init; }
+
+        public DateTime? FirstAttemptedAtUtc { get; init; }
+
+        public DateTime? LastAttemptedAtUtc { get; init; }
+
+        public DateTime? SucceededAtUtc { get; init; }
+
+        public DateTime CreatedAtUtc { get; init; }
+
+        public DateTime UpdatedAtUtc { get; init; }
+    }
+}

--- a/src/Harmonie.Infrastructure/Persistence/Notifications/MessageNotificationDeliveryRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Notifications/MessageNotificationDeliveryRepository.cs
@@ -13,116 +13,82 @@ public sealed class MessageNotificationDeliveryRepository : IMessageNotification
         _dbSession = dbSession;
     }
 
-    public async Task EnsurePendingAsync(
+    public async Task<IReadOnlySet<Guid>> GetOrCreateRetryableDeviceIdsAsync(
         Guid outboxJobId,
         IReadOnlyCollection<Guid> deviceIds,
         DateTime createdAtUtc,
         CancellationToken cancellationToken = default)
     {
         if (deviceIds.Count == 0)
-            return;
+            return new HashSet<Guid>();
 
         const string sql = """
-                           INSERT INTO message_notification_deliveries (
-                               id,
-                               outbox_job_id,
-                               device_id,
-                               status,
-                               attempts,
-                               last_error,
-                               first_attempted_at_utc,
-                               last_attempted_at_utc,
-                               succeeded_at_utc,
-                               created_at_utc,
-                               updated_at_utc)
-                           VALUES (
-                               @Id,
-                               @OutboxJobId,
-                               @DeviceId,
-                               @Status,
-                               0,
-                               NULL,
-                               NULL,
-                               NULL,
-                               NULL,
-                               @NowUtc,
-                               @NowUtc)
-                           ON CONFLICT (outbox_job_id, device_id) DO NOTHING
+                           WITH input AS (
+                               SELECT *
+                               FROM unnest(@DeviceIds::uuid[], @DeliveryIds::uuid[]) AS input(device_id, delivery_id)
+                           ), existing AS (
+                               SELECT deliveries.device_id
+                               FROM message_notification_deliveries deliveries
+                               JOIN input ON input.device_id = deliveries.device_id
+                               WHERE deliveries.outbox_job_id = @OutboxJobId
+                                 AND deliveries.status = ANY(@RetryableStatuses)
+                           ), inserted AS (
+                               INSERT INTO message_notification_deliveries (
+                                   id,
+                                   outbox_job_id,
+                                   device_id,
+                                   status,
+                                   attempts,
+                                   last_error,
+                                   first_attempted_at_utc,
+                                   last_attempted_at_utc,
+                                   succeeded_at_utc,
+                                   created_at_utc,
+                                   updated_at_utc)
+                               SELECT
+                                   input.delivery_id,
+                                   @OutboxJobId,
+                                   input.device_id,
+                                   @PendingStatus,
+                                   0,
+                                   NULL,
+                                   NULL,
+                                   NULL,
+                                   NULL,
+                                   @NowUtc,
+                                   @NowUtc
+                               FROM input
+                               ON CONFLICT (outbox_job_id, device_id) DO NOTHING
+                               RETURNING device_id
+                           )
+                           SELECT device_id FROM existing
+                           UNION
+                           SELECT device_id FROM inserted
                            """;
 
-        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
-        foreach (var deviceId in deviceIds.Distinct())
-        {
-            var command = new CommandDefinition(
-                sql,
-                new
-                {
-                    Id = Guid.NewGuid(),
-                    OutboxJobId = outboxJobId,
-                    DeviceId = deviceId,
-                    Status = MessageNotificationDeliveryStatuses.Pending,
-                    NowUtc = createdAtUtc
-                },
-                transaction: _dbSession.Transaction,
-                cancellationToken: cancellationToken);
-
-            await connection.ExecuteAsync(command);
-        }
-    }
-
-    public async Task<IReadOnlyList<MessageNotificationDelivery>> GetByJobAndDeviceIdsAsync(
-        Guid outboxJobId,
-        IReadOnlyCollection<Guid> deviceIds,
-        CancellationToken cancellationToken = default)
-    {
-        if (deviceIds.Count == 0)
-            return [];
-
-        const string sql = """
-                           SELECT
-                               id AS "Id",
-                               outbox_job_id AS "OutboxJobId",
-                               device_id AS "DeviceId",
-                               status AS "Status",
-                               attempts AS "Attempts",
-                               last_error AS "LastError",
-                               first_attempted_at_utc AS "FirstAttemptedAtUtc",
-                               last_attempted_at_utc AS "LastAttemptedAtUtc",
-                               succeeded_at_utc AS "SucceededAtUtc",
-                               created_at_utc AS "CreatedAtUtc",
-                               updated_at_utc AS "UpdatedAtUtc"
-                           FROM message_notification_deliveries
-                           WHERE outbox_job_id = @OutboxJobId
-                             AND device_id = ANY(@DeviceIds)
-                           ORDER BY created_at_utc ASC, id ASC
-                           """;
-
+        var distinctDeviceIds = deviceIds.Distinct().ToArray();
+        var deliveryIds = distinctDeviceIds.Select(_ => Guid.NewGuid()).ToArray();
         var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
         var command = new CommandDefinition(
             sql,
             new
             {
                 OutboxJobId = outboxJobId,
-                DeviceIds = deviceIds.Distinct().ToArray()
+                DeviceIds = distinctDeviceIds,
+                DeliveryIds = deliveryIds,
+                PendingStatus = MessageNotificationDeliveryStatuses.Pending,
+                RetryableStatuses = new[]
+                {
+                    MessageNotificationDeliveryStatuses.Pending,
+                    MessageNotificationDeliveryStatuses.TransientFailure
+                },
+                NowUtc = createdAtUtc
             },
             transaction: _dbSession.Transaction,
             cancellationToken: cancellationToken);
 
-        var rows = await connection.QueryAsync<MessageNotificationDeliveryRow>(command);
-        return rows
-            .Select(row => new MessageNotificationDelivery(
-                row.Id,
-                row.OutboxJobId,
-                row.DeviceId,
-                row.Status,
-                row.Attempts,
-                row.LastError,
-                row.FirstAttemptedAtUtc,
-                row.LastAttemptedAtUtc,
-                row.SucceededAtUtc,
-                row.CreatedAtUtc,
-                row.UpdatedAtUtc))
-            .ToArray();
+        var retryableDeviceIds = await connection.QueryAsync<Guid>(command);
+        return retryableDeviceIds.ToHashSet();
     }
 
     public async Task MarkResultsAsync(
@@ -135,40 +101,44 @@ public sealed class MessageNotificationDeliveryRepository : IMessageNotification
             return;
 
         const string sql = """
-                           UPDATE message_notification_deliveries
-                           SET status = @Status,
-                               attempts = attempts + 1,
-                               last_error = @Error,
-                               first_attempted_at_utc = COALESCE(first_attempted_at_utc, @AttemptedAtUtc),
+                           WITH results AS (
+                               SELECT *
+                               FROM unnest(@DeviceIds::uuid[], @Statuses::text[], @Errors::text[])
+                                   AS results(device_id, status, error)
+                           )
+                           UPDATE message_notification_deliveries deliveries
+                           SET status = results.status,
+                               attempts = deliveries.attempts + 1,
+                               last_error = results.error,
+                               first_attempted_at_utc = COALESCE(deliveries.first_attempted_at_utc, @AttemptedAtUtc),
                                last_attempted_at_utc = @AttemptedAtUtc,
                                succeeded_at_utc = CASE
-                                   WHEN @Status = @SucceededStatus THEN @AttemptedAtUtc
-                                   ELSE succeeded_at_utc
+                                   WHEN results.status = @SucceededStatus THEN @AttemptedAtUtc
+                                   ELSE deliveries.succeeded_at_utc
                                END,
                                updated_at_utc = @AttemptedAtUtc
-                           WHERE outbox_job_id = @OutboxJobId
-                             AND device_id = @DeviceId
+                           FROM results
+                           WHERE deliveries.outbox_job_id = @OutboxJobId
+                             AND deliveries.device_id = results.device_id
                            """;
 
+        var resultArray = results.ToArray();
         var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
-        foreach (var result in results)
-        {
-            var command = new CommandDefinition(
-                sql,
-                new
-                {
-                    OutboxJobId = outboxJobId,
-                    result.DeviceId,
-                    Status = ToDeliveryStatus(result.Status),
-                    result.Error,
-                    AttemptedAtUtc = attemptedAtUtc,
-                    SucceededStatus = MessageNotificationDeliveryStatuses.Succeeded
-                },
-                transaction: _dbSession.Transaction,
-                cancellationToken: cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new
+            {
+                OutboxJobId = outboxJobId,
+                DeviceIds = resultArray.Select(result => result.DeviceId).ToArray(),
+                Statuses = resultArray.Select(result => ToDeliveryStatus(result.Status)).ToArray(),
+                Errors = resultArray.Select(result => result.Error).ToArray(),
+                AttemptedAtUtc = attemptedAtUtc,
+                SucceededStatus = MessageNotificationDeliveryStatuses.Succeeded
+            },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
 
-            await connection.ExecuteAsync(command);
-        }
+        await connection.ExecuteAsync(command);
     }
 
     public async Task MarkDevicesFailedAsync(
@@ -217,30 +187,5 @@ public sealed class MessageNotificationDeliveryRepository : IMessageNotification
             NotificationDeliveryResultStatus.PermanentFailure => MessageNotificationDeliveryStatuses.Failed,
             _ => MessageNotificationDeliveryStatuses.Failed
         };
-    }
-
-    private sealed class MessageNotificationDeliveryRow
-    {
-        public Guid Id { get; init; }
-
-        public Guid OutboxJobId { get; init; }
-
-        public Guid DeviceId { get; init; }
-
-        public string Status { get; init; } = string.Empty;
-
-        public int Attempts { get; init; }
-
-        public string? LastError { get; init; }
-
-        public DateTime? FirstAttemptedAtUtc { get; init; }
-
-        public DateTime? LastAttemptedAtUtc { get; init; }
-
-        public DateTime? SucceededAtUtc { get; init; }
-
-        public DateTime CreatedAtUtc { get; init; }
-
-        public DateTime UpdatedAtUtc { get; init; }
     }
 }

--- a/src/Harmonie.Infrastructure/Services/Notifications/WebPushNotificationDeliveryAdapter.cs
+++ b/src/Harmonie.Infrastructure/Services/Notifications/WebPushNotificationDeliveryAdapter.cs
@@ -102,12 +102,12 @@ public sealed class WebPushNotificationDeliveryAdapter : INotificationDeliveryAd
             await _client.SendNotificationAsync(subscription, payload, vapidDetails, cancellationToken);
             return new NotificationDeliveryResult(deviceId, NotificationDeliveryResultStatus.Succeeded);
         }
-        catch (WebPushException ex) when (ex.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Gone)
+        catch (WebPushException ex) when (IsInvalidDeviceStatus(ex.StatusCode))
         {
             return new NotificationDeliveryResult(
                 deviceId,
                 NotificationDeliveryResultStatus.InvalidDevice,
-                $"Web Push subscription is no longer valid ({(int)ex.StatusCode})");
+                $"Web Push subscription is no longer valid or no longer accepts this VAPID identity ({(int)ex.StatusCode})");
         }
         catch (WebPushException ex) when (IsTransient(ex.StatusCode))
         {
@@ -135,6 +135,15 @@ public sealed class WebPushNotificationDeliveryAdapter : INotificationDeliveryAd
                 NotificationDeliveryResultStatus.TransientFailure,
                 "Unexpected Web Push send failure");
         }
+    }
+
+    private static bool IsInvalidDeviceStatus(HttpStatusCode statusCode)
+    {
+        return statusCode is HttpStatusCode.BadRequest
+            or HttpStatusCode.Unauthorized
+            or HttpStatusCode.Forbidden
+            or HttpStatusCode.NotFound
+            or HttpStatusCode.Gone;
     }
 
     private static bool IsTransient(HttpStatusCode statusCode)

--- a/tests/Harmonie.API.IntegrationTests/Notifications/PushNotificationDispatchIntegrationTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Notifications/PushNotificationDispatchIntegrationTests.cs
@@ -66,7 +66,7 @@ public sealed class PushNotificationDispatchIntegrationTests : IClassFixture<Har
             new[] { mentionedRecipient.UserId },
             sender.AccessToken);
 
-        await ProcessNotificationBatchAsync();
+        await ProcessNotificationBatchAsync(message.MessageId);
 
         var deliveries = _recordingAdapter.Deliveries;
         deliveries.Should().HaveCount(2);
@@ -104,7 +104,7 @@ public sealed class PushNotificationDispatchIntegrationTests : IClassFixture<Har
             "this content must not be part of the push payload",
             sender.AccessToken);
 
-        await ProcessNotificationBatchAsync();
+        await ProcessNotificationBatchAsync(message.MessageId);
 
         stopwatch.Stop();
         Console.WriteLine($"Push notification dispatch integration test elapsed: {stopwatch.ElapsedMilliseconds}ms");
@@ -173,11 +173,61 @@ public sealed class PushNotificationDispatchIntegrationTests : IClassFixture<Har
         return payload!;
     }
 
-    private async Task ProcessNotificationBatchAsync()
+    private async Task ProcessNotificationBatchAsync(Guid messageId)
     {
+        await DelayOtherClaimableOutboxJobsAsync(messageId, DateTime.UtcNow.AddDays(1));
+        await SetOutboxNextAttemptAsync(messageId, new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
         await using var scope = _factory.Services.CreateAsyncScope();
         var processor = scope.ServiceProvider.GetRequiredService<IPushNotificationBatchProcessor>();
         await processor.ProcessBatchAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task DelayOtherClaimableOutboxJobsAsync(Guid messageId, DateTime nextAttemptAtUtc)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var dbSession = scope.ServiceProvider.GetRequiredService<DbSession>();
+        var connection = await dbSession.GetOpenConnectionAsync(TestContext.Current.CancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+                              UPDATE message_notification_outbox
+                              SET next_attempt_at_utc = CASE
+                                      WHEN status = @PendingStatus THEN @NextAttemptAtUtc
+                                      ELSE next_attempt_at_utc
+                                  END,
+                                  locked_until_utc = CASE
+                                      WHEN status = @ProcessingStatus THEN @NextAttemptAtUtc
+                                      ELSE locked_until_utc
+                                  END
+                              WHERE message_id <> @MessageId
+                                AND status IN (@PendingStatus, @ProcessingStatus)
+                              """;
+        command.Parameters.AddWithValue("NextAttemptAtUtc", nextAttemptAtUtc);
+        command.Parameters.AddWithValue("MessageId", messageId);
+        command.Parameters.AddWithValue("PendingStatus", MessageNotificationOutboxStatuses.Pending);
+        command.Parameters.AddWithValue("ProcessingStatus", MessageNotificationOutboxStatuses.Processing);
+
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task SetOutboxNextAttemptAsync(Guid messageId, DateTime nextAttemptAtUtc)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var dbSession = scope.ServiceProvider.GetRequiredService<DbSession>();
+        var connection = await dbSession.GetOpenConnectionAsync(TestContext.Current.CancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+                              UPDATE message_notification_outbox
+                              SET next_attempt_at_utc = @NextAttemptAtUtc
+                              WHERE message_id = @MessageId
+                              """;
+        command.Parameters.AddWithValue("NextAttemptAtUtc", nextAttemptAtUtc);
+        command.Parameters.AddWithValue("MessageId", messageId);
+
+        var rows = await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        rows.Should().Be(1);
     }
 
     private async Task<string?> GetOutboxStatusAsync(Guid messageId)

--- a/tests/Harmonie.Application.Tests/Notifications/NotificationDispatchServiceTests.cs
+++ b/tests/Harmonie.Application.Tests/Notifications/NotificationDispatchServiceTests.cs
@@ -17,6 +17,7 @@ public sealed class NotificationDispatchServiceTests
     private readonly Mock<IMessageNotificationContextRepository> _contextRepositoryMock = new();
     private readonly Mock<INotificationDeviceRepository> _deviceRepositoryMock = new();
     private readonly Mock<IMessageNotificationOutboxRepository> _outboxRepositoryMock = new();
+    private readonly InMemoryMessageNotificationDeliveryRepository _deliveryRepository = new();
 
     [Fact]
     public async Task DispatchAsync_ShouldSendOnlyThroughMatchingPlatformAdapter()
@@ -125,12 +126,61 @@ public sealed class NotificationDispatchServiceTests
             Times.Never);
     }
 
+    [Fact]
+    public async Task DispatchAsync_WhenRetryingPartialFailure_ShouldNotResendToSucceededDevice()
+    {
+        var recipientId = UserId.New();
+        var succeededDevice = CreateDevice(recipientId, NotificationDevicePlatforms.WebPush);
+        var retryingDevice = CreateDevice(recipientId, NotificationDevicePlatforms.WebPush);
+        var jobId = Guid.NewGuid();
+        var resultsByDeviceId = new Dictionary<Guid, NotificationDeliveryResultStatus>
+        {
+            [succeededDevice.Id] = NotificationDeliveryResultStatus.Succeeded,
+            [retryingDevice.Id] = NotificationDeliveryResultStatus.TransientFailure
+        };
+        var adapter = new StubNotificationDeliveryAdapter(
+            NotificationDevicePlatforms.WebPush,
+            device => new NotificationDeliveryResult(device.Id, resultsByDeviceId[device.Id], "timeout"));
+        var service = CreateService(adapter);
+
+        SetupContextAndDevices(CreateContext(recipientId), succeededDevice, retryingDevice);
+
+        await service.DispatchAsync(CreateJob(jobId, attempts: 1), DateTime.UtcNow, TestContext.Current.CancellationToken);
+        await service.DispatchAsync(CreateJob(jobId, attempts: 2), DateTime.UtcNow, TestContext.Current.CancellationToken);
+
+        adapter.SentDeviceIds.Count(deviceId => deviceId == succeededDevice.Id).Should().Be(1);
+        adapter.SentDeviceIds.Count(deviceId => deviceId == retryingDevice.Id).Should().Be(2);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenOnlyPermanentFailuresOccur_ShouldMarkProcessedWithoutRetry()
+    {
+        var recipientId = UserId.New();
+        var device = CreateDevice(recipientId, NotificationDevicePlatforms.WebPush);
+        var adapter = new StubNotificationDeliveryAdapter(
+            NotificationDevicePlatforms.WebPush,
+            device => new NotificationDeliveryResult(device.Id, NotificationDeliveryResultStatus.PermanentFailure, "forbidden"));
+        var service = CreateService(adapter);
+
+        SetupContextAndDevices(CreateContext(recipientId), device);
+
+        await service.DispatchAsync(CreateJob(attempts: 1), DateTime.UtcNow, TestContext.Current.CancellationToken);
+
+        _outboxRepositoryMock.Verify(
+            x => x.MarkProcessedAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _outboxRepositoryMock.Verify(
+            x => x.ScheduleRetryAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     private NotificationDispatchService CreateService(params INotificationDeliveryAdapter[] adapters)
     {
         return new NotificationDispatchService(
             _contextRepositoryMock.Object,
             _deviceRepositoryMock.Object,
             _outboxRepositoryMock.Object,
+            _deliveryRepository,
             new MessageNotificationPolicy(),
             new MessageNotificationPayloadFactory(),
             adapters,
@@ -199,8 +249,13 @@ public sealed class NotificationDispatchServiceTests
 
     private static MessageNotificationOutboxJob CreateJob(int attempts)
     {
+        return CreateJob(Guid.NewGuid(), attempts);
+    }
+
+    private static MessageNotificationOutboxJob CreateJob(Guid jobId, int attempts)
+    {
         return new MessageNotificationOutboxJob(
-            Guid.NewGuid(),
+            jobId,
             MessageId.New(),
             MessageNotificationOutboxStatuses.Processing,
             attempts,
@@ -235,6 +290,132 @@ public sealed class NotificationDispatchServiceTests
         {
             _sentDeviceIds.AddRange(devices.Select(device => device.Id));
             return Task.FromResult<IReadOnlyList<NotificationDeliveryResult>>(devices.Select(_resultFactory).ToArray());
+        }
+    }
+
+    private sealed class InMemoryMessageNotificationDeliveryRepository : IMessageNotificationDeliveryRepository
+    {
+        private readonly Dictionary<(Guid OutboxJobId, Guid DeviceId), MessageNotificationDelivery> _deliveries = new();
+
+        public Task EnsurePendingAsync(
+            Guid outboxJobId,
+            IReadOnlyCollection<Guid> deviceIds,
+            DateTime createdAtUtc,
+            CancellationToken cancellationToken = default)
+        {
+            foreach (var deviceId in deviceIds.Distinct())
+            {
+                var key = (outboxJobId, deviceId);
+                if (_deliveries.ContainsKey(key))
+                    continue;
+
+                _deliveries[key] = new MessageNotificationDelivery(
+                    Guid.NewGuid(),
+                    outboxJobId,
+                    deviceId,
+                    MessageNotificationDeliveryStatuses.Pending,
+                    0,
+                    null,
+                    null,
+                    null,
+                    null,
+                    createdAtUtc,
+                    createdAtUtc);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<MessageNotificationDelivery>> GetByJobAndDeviceIdsAsync(
+            Guid outboxJobId,
+            IReadOnlyCollection<Guid> deviceIds,
+            CancellationToken cancellationToken = default)
+        {
+            var deviceIdSet = deviceIds.ToHashSet();
+            var deliveries = _deliveries.Values
+                .Where(delivery => delivery.OutboxJobId == outboxJobId && deviceIdSet.Contains(delivery.DeviceId))
+                .ToArray();
+            return Task.FromResult<IReadOnlyList<MessageNotificationDelivery>>(deliveries);
+        }
+
+        public Task MarkResultsAsync(
+            Guid outboxJobId,
+            IReadOnlyCollection<NotificationDeliveryResult> results,
+            DateTime attemptedAtUtc,
+            CancellationToken cancellationToken = default)
+        {
+            foreach (var result in results)
+            {
+                UpdateDelivery(
+                    outboxJobId,
+                    result.DeviceId,
+                    ToDeliveryStatus(result.Status),
+                    delivery => delivery.Attempts + 1,
+                    result.Error,
+                    attemptedAtUtc,
+                    result.Status == NotificationDeliveryResultStatus.Succeeded ? attemptedAtUtc : null);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task MarkDevicesFailedAsync(
+            Guid outboxJobId,
+            IReadOnlyCollection<Guid> deviceIds,
+            string error,
+            DateTime failedAtUtc,
+            CancellationToken cancellationToken = default)
+        {
+            foreach (var deviceId in deviceIds)
+            {
+                UpdateDelivery(
+                    outboxJobId,
+                    deviceId,
+                    MessageNotificationDeliveryStatuses.Failed,
+                    delivery => delivery.Attempts,
+                    error,
+                    failedAtUtc,
+                    null);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private void UpdateDelivery(
+            Guid outboxJobId,
+            Guid deviceId,
+            string status,
+            Func<MessageNotificationDelivery, int> attemptsFactory,
+            string? error,
+            DateTime updatedAtUtc,
+            DateTime? succeededAtUtc)
+        {
+            var key = (outboxJobId, deviceId);
+            if (!_deliveries.TryGetValue(key, out var delivery))
+                return;
+
+            _deliveries[key] = delivery with
+            {
+                Status = status,
+                Attempts = attemptsFactory(delivery),
+                LastError = error,
+                FirstAttemptedAtUtc = delivery.FirstAttemptedAtUtc ?? updatedAtUtc,
+                LastAttemptedAtUtc = updatedAtUtc,
+                SucceededAtUtc = succeededAtUtc ?? delivery.SucceededAtUtc,
+                UpdatedAtUtc = updatedAtUtc
+            };
+        }
+
+        private static string ToDeliveryStatus(NotificationDeliveryResultStatus status)
+        {
+            return status switch
+            {
+                NotificationDeliveryResultStatus.Succeeded => MessageNotificationDeliveryStatuses.Succeeded,
+                NotificationDeliveryResultStatus.InvalidDevice => MessageNotificationDeliveryStatuses.InvalidDevice,
+                NotificationDeliveryResultStatus.TransientFailure => MessageNotificationDeliveryStatuses.TransientFailure,
+                NotificationDeliveryResultStatus.PermanentFailure => MessageNotificationDeliveryStatuses.Failed,
+                _ => MessageNotificationDeliveryStatuses.Failed
+            };
         }
     }
 }

--- a/tests/Harmonie.Application.Tests/Notifications/NotificationDispatchServiceTests.cs
+++ b/tests/Harmonie.Application.Tests/Notifications/NotificationDispatchServiceTests.cs
@@ -295,9 +295,9 @@ public sealed class NotificationDispatchServiceTests
 
     private sealed class InMemoryMessageNotificationDeliveryRepository : IMessageNotificationDeliveryRepository
     {
-        private readonly Dictionary<(Guid OutboxJobId, Guid DeviceId), MessageNotificationDelivery> _deliveries = new();
+        private readonly Dictionary<(Guid OutboxJobId, Guid DeviceId), StoredDelivery> _deliveries = new();
 
-        public Task EnsurePendingAsync(
+        public Task<IReadOnlySet<Guid>> GetOrCreateRetryableDeviceIdsAsync(
             Guid outboxJobId,
             IReadOnlyCollection<Guid> deviceIds,
             DateTime createdAtUtc,
@@ -306,36 +306,25 @@ public sealed class NotificationDispatchServiceTests
             foreach (var deviceId in deviceIds.Distinct())
             {
                 var key = (outboxJobId, deviceId);
-                if (_deliveries.ContainsKey(key))
-                    continue;
-
-                _deliveries[key] = new MessageNotificationDelivery(
-                    Guid.NewGuid(),
-                    outboxJobId,
-                    deviceId,
-                    MessageNotificationDeliveryStatuses.Pending,
-                    0,
-                    null,
-                    null,
-                    null,
-                    null,
-                    createdAtUtc,
-                    createdAtUtc);
+                if (!_deliveries.ContainsKey(key))
+                {
+                    _deliveries[key] = new StoredDelivery(
+                        MessageNotificationDeliveryStatuses.Pending,
+                        Attempts: 0,
+                        LastError: null,
+                        UpdatedAtUtc: createdAtUtc);
+                }
             }
 
-            return Task.CompletedTask;
-        }
+            var retryableDeviceIds = _deliveries
+                .Where(pair => pair.Key.OutboxJobId == outboxJobId
+                               && deviceIds.Contains(pair.Key.DeviceId)
+                               && pair.Value.Status is MessageNotificationDeliveryStatuses.Pending
+                                   or MessageNotificationDeliveryStatuses.TransientFailure)
+                .Select(pair => pair.Key.DeviceId)
+                .ToHashSet();
 
-        public Task<IReadOnlyList<MessageNotificationDelivery>> GetByJobAndDeviceIdsAsync(
-            Guid outboxJobId,
-            IReadOnlyCollection<Guid> deviceIds,
-            CancellationToken cancellationToken = default)
-        {
-            var deviceIdSet = deviceIds.ToHashSet();
-            var deliveries = _deliveries.Values
-                .Where(delivery => delivery.OutboxJobId == outboxJobId && deviceIdSet.Contains(delivery.DeviceId))
-                .ToArray();
-            return Task.FromResult<IReadOnlyList<MessageNotificationDelivery>>(deliveries);
+            return Task.FromResult<IReadOnlySet<Guid>>(retryableDeviceIds);
         }
 
         public Task MarkResultsAsync(
@@ -352,8 +341,7 @@ public sealed class NotificationDispatchServiceTests
                     ToDeliveryStatus(result.Status),
                     delivery => delivery.Attempts + 1,
                     result.Error,
-                    attemptedAtUtc,
-                    result.Status == NotificationDeliveryResultStatus.Succeeded ? attemptedAtUtc : null);
+                    attemptedAtUtc);
             }
 
             return Task.CompletedTask;
@@ -374,8 +362,7 @@ public sealed class NotificationDispatchServiceTests
                     MessageNotificationDeliveryStatuses.Failed,
                     delivery => delivery.Attempts,
                     error,
-                    failedAtUtc,
-                    null);
+                    failedAtUtc);
             }
 
             return Task.CompletedTask;
@@ -385,10 +372,9 @@ public sealed class NotificationDispatchServiceTests
             Guid outboxJobId,
             Guid deviceId,
             string status,
-            Func<MessageNotificationDelivery, int> attemptsFactory,
+            Func<StoredDelivery, int> attemptsFactory,
             string? error,
-            DateTime updatedAtUtc,
-            DateTime? succeededAtUtc)
+            DateTime updatedAtUtc)
         {
             var key = (outboxJobId, deviceId);
             if (!_deliveries.TryGetValue(key, out var delivery))
@@ -399,9 +385,6 @@ public sealed class NotificationDispatchServiceTests
                 Status = status,
                 Attempts = attemptsFactory(delivery),
                 LastError = error,
-                FirstAttemptedAtUtc = delivery.FirstAttemptedAtUtc ?? updatedAtUtc,
-                LastAttemptedAtUtc = updatedAtUtc,
-                SucceededAtUtc = succeededAtUtc ?? delivery.SucceededAtUtc,
                 UpdatedAtUtc = updatedAtUtc
             };
         }
@@ -417,5 +400,11 @@ public sealed class NotificationDispatchServiceTests
                 _ => MessageNotificationDeliveryStatuses.Failed
             };
         }
+
+        private sealed record StoredDelivery(
+            string Status,
+            int Attempts,
+            string? LastError,
+            DateTime UpdatedAtUtc);
     }
 }

--- a/tools/Harmonie.Migrations/Scripts/20260615_1_CreateMessageNotificationDeliveriesTable.sql
+++ b/tools/Harmonie.Migrations/Scripts/20260615_1_CreateMessageNotificationDeliveriesTable.sql
@@ -1,0 +1,39 @@
+-- Migration: Create message_notification_deliveries table
+-- Date: 2026-06-15
+-- Description: Tracks message notification delivery state per device so retries do not re-send to devices that already succeeded.
+-- Backfill strategy: existing pending/processing outbox rows create delivery rows lazily on their next dispatch attempt from currently active devices. Historical processed/failed rows are terminal and do not need per-device delivery rows.
+
+CREATE TABLE IF NOT EXISTS message_notification_deliveries (
+    id UUID PRIMARY KEY,
+    outbox_job_id UUID NOT NULL REFERENCES message_notification_outbox(id) ON DELETE CASCADE,
+    device_id UUID NOT NULL REFERENCES notification_devices(id) ON DELETE CASCADE,
+    status TEXT NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT NULL,
+    first_attempted_at_utc TIMESTAMPTZ NULL,
+    last_attempted_at_utc TIMESTAMPTZ NULL,
+    succeeded_at_utc TIMESTAMPTZ NULL,
+    created_at_utc TIMESTAMPTZ NOT NULL,
+    updated_at_utc TIMESTAMPTZ NOT NULL,
+    CONSTRAINT chk_message_notification_deliveries_attempts_non_negative
+        CHECK (attempts >= 0),
+    CONSTRAINT chk_message_notification_deliveries_status
+        CHECK (status IN ('pending', 'succeeded', 'transient_failure', 'invalid_device', 'failed')),
+    CONSTRAINT chk_message_notification_deliveries_succeeded_at
+        CHECK (
+            (status = 'succeeded' AND succeeded_at_utc IS NOT NULL)
+            OR (status <> 'succeeded')
+        )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_message_notification_deliveries_job_device
+    ON message_notification_deliveries(outbox_job_id, device_id);
+
+CREATE INDEX IF NOT EXISTS idx_message_notification_deliveries_job_status
+    ON message_notification_deliveries(outbox_job_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_message_notification_deliveries_device_id
+    ON message_notification_deliveries(device_id);
+
+COMMENT ON TABLE message_notification_deliveries IS 'Tracks per-device delivery state for message notification outbox jobs.';
+COMMENT ON COLUMN message_notification_deliveries.status IS 'Delivery status: pending, succeeded, transient_failure, invalid_device, failed.';


### PR DESCRIPTION
## Summary
- add `message_notification_deliveries` to track message notification delivery state per device
- retry only pending/transient device deliveries, so devices that already succeeded are not sent duplicates
- mark permanent/unsupported device failures as terminal for the job, while transient failures still retry
- treat Web Push 400/401/403/404/410 as invalid subscriptions and remove those devices
- update notification docs and tests for partial retry behavior

## Migration/backfill
- adds `20260615_1_CreateMessageNotificationDeliveriesTable.sql`
- existing pending/processing outbox rows lazily create delivery rows on their next dispatch attempt
- historical processed/failed jobs are terminal and do not need backfill rows

## Tests
- `dotnet build --configuration Release`
- `ConnectionStrings__DefaultConnection='Host=localhost;Port=54321;Database=harmonie;Username=harmonie_user;Password=harmonie_password' dotnet run --project tools/Harmonie.Migrations/Harmonie.Migrations.csproj`
- `ConnectionStrings__DefaultConnection='Host=localhost;Port=54321;Database=harmonie;Username=harmonie_user;Password=harmonie_password' dotnet test`

Closes #427