### PR TITLE
Fix vulnerable OpenAPI package dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,8 @@
   </ItemGroup>
   <!-- API / Docs -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.10.0" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.14.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
   </ItemGroup>

--- a/src/Harmonie.API/Harmonie.API.csproj
+++ b/src/Harmonie.API/Harmonie.API.csproj
@@ -20,7 +20,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
-<PackageReference Include="Scalar.AspNetCore" />
+    <PackageReference Include="Microsoft.OpenApi" />
+    <PackageReference Include="Scalar.AspNetCore" />
     <PackageReference Include="Serilog.AspNetCore" />
   </ItemGroup>
 </Project>

--- a/src/Harmonie.Application/Harmonie.Application.csproj
+++ b/src/Harmonie.Application/Harmonie.Application.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.OpenApi" />
     <PackageReference Include="SixLabors.ImageSharp" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Pins Microsoft.OpenApi to 2.10.0 so NuGet resolves a non-vulnerable version instead of the vulnerable 2.0.0 transitive dependency.
- Updates Microsoft.AspNetCore.OpenApi from 10.0.6 to 10.0.9.
- Adds explicit Microsoft.OpenApi references where OpenAPI types are used.

Closes #429

## Validation

- `dotnet clean Harmonie.sln`
- `dotnet restore Harmonie.sln`
- `dotnet build Harmonie.sln --no-restore`
- `dotnet list Harmonie.sln package --vulnerable --include-transitive`

Note: `dotnet test Harmonie.sln --no-build` was also run locally, but failed because local external services were unavailable:
- LiveKit on `localhost:7880`
- PostgreSQL on `127.0.0.1:5432`
