### PR TITLE
Add notification cleanup worker

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -117,7 +117,7 @@ Notification cleanup is configured in the worker host. It is disabled by default
 ```json
 "NotificationCleanup": {
   "Enabled": true,
-  "PollIntervalHours": 24,
+  "PollIntervalSeconds": 86400,
   "BatchSize": 500,
   "ProcessedOutboxRetentionDays": 7,
   "FailedOutboxRetentionDays": 30,

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -112,6 +112,21 @@ Current backend notification behavior:
 - payloads are minimal `message.created` business data, without message content or UI presentation fields;
 - retries are tracked per device, so a partial Web Push failure does not resend to devices that already succeeded.
 
+Notification cleanup is configured in the worker host. It is disabled by default; enable it explicitly in production after selecting retention periods appropriate for operational debugging:
+
+```json
+"NotificationCleanup": {
+  "Enabled": true,
+  "PollIntervalHours": 24,
+  "BatchSize": 500,
+  "ProcessedOutboxRetentionDays": 7,
+  "FailedOutboxRetentionDays": 30,
+  "ExpiredDeviceRetentionDays": 7
+}
+```
+
+The worker deletes terminal outbox jobs and expired notification devices in small, multi-instance-safe batches. Failed jobs use a longer default retention period for troubleshooting.
+
 ## 6. Run Tests
 
 ```bash

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -112,12 +112,12 @@ Current backend notification behavior:
 - payloads are minimal `message.created` business data, without message content or UI presentation fields;
 - retries are tracked per device, so a partial Web Push failure does not resend to devices that already succeeded.
 
-Notification cleanup is configured in the worker host. It is disabled by default; enable it explicitly in production after selecting retention periods appropriate for operational debugging:
+Notification cleanup is configured and enabled by default in the worker host. Adjust the retention periods for operational debugging, or set `Enabled` to `false` to disable it:
 
 ```json
 "NotificationCleanup": {
   "Enabled": true,
-  "PollIntervalSeconds": 86400,
+  "PollIntervalSeconds": 1800,
   "BatchSize": 500,
   "ProcessedOutboxRetentionDays": 7,
   "FailedOutboxRetentionDays": 30,

--- a/src/Harmonie.Application/Interfaces/Notifications/INotificationCleanupRepository.cs
+++ b/src/Harmonie.Application/Interfaces/Notifications/INotificationCleanupRepository.cs
@@ -1,0 +1,15 @@
+namespace Harmonie.Application.Interfaces.Notifications;
+
+public interface INotificationCleanupRepository
+{
+    Task<int> DeleteOutboxBatchAsync(
+        string status,
+        DateTime processedBeforeUtc,
+        int batchSize,
+        CancellationToken cancellationToken = default);
+
+    Task<int> DeleteExpiredDevicesBatchAsync(
+        DateTime expiresBeforeUtc,
+        int batchSize,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Harmonie.Application/Services/Notifications/NotificationCleanupOptions.cs
+++ b/src/Harmonie.Application/Services/Notifications/NotificationCleanupOptions.cs
@@ -8,8 +8,8 @@ public sealed class NotificationCleanupOptions
 
     public bool Enabled { get; set; }
 
-    [Range(1, 168)]
-    public int PollIntervalHours { get; set; } = 24;
+    [Range(1, 86_400)]
+    public int PollIntervalSeconds { get; set; } = 86_400;
 
     [Range(1, 5_000)]
     public int BatchSize { get; set; } = 500;

--- a/src/Harmonie.Application/Services/Notifications/NotificationCleanupOptions.cs
+++ b/src/Harmonie.Application/Services/Notifications/NotificationCleanupOptions.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Harmonie.Application.Services.Notifications;
+
+public sealed class NotificationCleanupOptions
+{
+    public const string SectionName = "NotificationCleanup";
+
+    public bool Enabled { get; set; }
+
+    [Range(1, 168)]
+    public int PollIntervalHours { get; set; } = 24;
+
+    [Range(1, 5_000)]
+    public int BatchSize { get; set; } = 500;
+
+    [Range(1, 3_650)]
+    public int ProcessedOutboxRetentionDays { get; set; } = 7;
+
+    [Range(1, 3_650)]
+    public int FailedOutboxRetentionDays { get; set; } = 30;
+
+    [Range(0, 3_650)]
+    public int ExpiredDeviceRetentionDays { get; set; } = 7;
+}

--- a/src/Harmonie.Application/Services/Notifications/NotificationCleanupOptions.cs
+++ b/src/Harmonie.Application/Services/Notifications/NotificationCleanupOptions.cs
@@ -9,7 +9,7 @@ public sealed class NotificationCleanupOptions
     public bool Enabled { get; set; }
 
     [Range(1, 86_400)]
-    public int PollIntervalSeconds { get; set; } = 86_400;
+    public int PollIntervalSeconds { get; set; } = 1_800;
 
     [Range(1, 5_000)]
     public int BatchSize { get; set; } = 500;

--- a/src/Harmonie.Infrastructure/DependencyInjection.cs
+++ b/src/Harmonie.Infrastructure/DependencyInjection.cs
@@ -77,6 +77,7 @@ public static class DependencyInjection
         services.AddScoped<IConversationReadStateRepository, ConversationReadStateRepository>();
         services.AddScoped<IUserSubscriptionRepository, UserSubscriptionRepository>();
         services.AddScoped<INotificationDeviceRepository, NotificationDeviceRepository>();
+        services.AddScoped<INotificationCleanupRepository, NotificationCleanupRepository>();
         services.AddScoped<IMessageNotificationOutboxRepository, MessageNotificationOutboxRepository>();
         services.AddScoped<IMessageNotificationDeliveryRepository, MessageNotificationDeliveryRepository>();
         services.AddScoped<IMessageNotificationContextRepository, MessageNotificationContextRepository>();

--- a/src/Harmonie.Infrastructure/Persistence/Notifications/NotificationCleanupRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Notifications/NotificationCleanupRepository.cs
@@ -1,0 +1,90 @@
+using Dapper;
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Infrastructure.Persistence.Common;
+
+namespace Harmonie.Infrastructure.Persistence.Notifications;
+
+public sealed class NotificationCleanupRepository : INotificationCleanupRepository
+{
+    private readonly DbSession _dbSession;
+
+    public NotificationCleanupRepository(DbSession dbSession)
+    {
+        _dbSession = dbSession;
+    }
+
+    public async Task<int> DeleteOutboxBatchAsync(
+        string status,
+        DateTime processedBeforeUtc,
+        int batchSize,
+        CancellationToken cancellationToken = default)
+    {
+        if (batchSize <= 0)
+            return 0;
+
+        const string sql = """
+                           WITH deletable AS (
+                               SELECT id
+                               FROM message_notification_outbox
+                               WHERE status = @Status
+                                 AND processed_at_utc < @ProcessedBeforeUtc
+                               ORDER BY processed_at_utc ASC, id ASC
+                               LIMIT @BatchSize
+                               FOR UPDATE SKIP LOCKED
+                           )
+                           DELETE FROM message_notification_outbox outbox
+                           USING deletable
+                           WHERE outbox.id = deletable.id
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new
+            {
+                Status = status,
+                ProcessedBeforeUtc = processedBeforeUtc,
+                BatchSize = batchSize
+            },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        return await connection.ExecuteAsync(command);
+    }
+
+    public async Task<int> DeleteExpiredDevicesBatchAsync(
+        DateTime expiresBeforeUtc,
+        int batchSize,
+        CancellationToken cancellationToken = default)
+    {
+        if (batchSize <= 0)
+            return 0;
+
+        const string sql = """
+                           WITH deletable AS (
+                               SELECT id
+                               FROM notification_devices
+                               WHERE expires_at_utc < @ExpiresBeforeUtc
+                               ORDER BY expires_at_utc ASC, id ASC
+                               LIMIT @BatchSize
+                               FOR UPDATE SKIP LOCKED
+                           )
+                           DELETE FROM notification_devices devices
+                           USING deletable
+                           WHERE devices.id = deletable.id
+                           """;
+
+        var connection = await _dbSession.GetOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(
+            sql,
+            new
+            {
+                ExpiresBeforeUtc = expiresBeforeUtc,
+                BatchSize = batchSize
+            },
+            transaction: _dbSession.Transaction,
+            cancellationToken: cancellationToken);
+
+        return await connection.ExecuteAsync(command);
+    }
+}

--- a/src/Harmonie.Workers/DependencyInjection.cs
+++ b/src/Harmonie.Workers/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Harmonie.Infrastructure;
 using Harmonie.Workers.Workers.Notifications;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Harmonie.Workers;
 
@@ -13,6 +14,7 @@ public static class DependencyInjection
         this IServiceCollection services,
         IConfiguration configuration)
     {
+        services.TryAddSingleton<TimeProvider>(TimeProvider.System);
         services.AddNotificationApplicationServices();
         services.AddPersistence(configuration);
         services.AddNotificationDeliveryInfrastructure(configuration);

--- a/src/Harmonie.Workers/DependencyInjection.cs
+++ b/src/Harmonie.Workers/DependencyInjection.cs
@@ -20,8 +20,14 @@ public static class DependencyInjection
             .Bind(configuration.GetSection(PushNotificationOptions.SectionName))
             .ValidateDataAnnotations()
             .ValidateOnStart();
+        services.AddOptions<NotificationCleanupOptions>()
+            .Bind(configuration.GetSection(NotificationCleanupOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
         services.AddScoped<IPushNotificationBatchProcessor, PushNotificationBatchProcessor>();
+        services.AddScoped<INotificationCleanupProcessor, NotificationCleanupProcessor>();
         services.AddHostedService<PushNotificationWorker>();
+        services.AddHostedService<NotificationCleanupWorker>();
 
         return services;
     }

--- a/src/Harmonie.Workers/Workers/Notifications/INotificationCleanupProcessor.cs
+++ b/src/Harmonie.Workers/Workers/Notifications/INotificationCleanupProcessor.cs
@@ -1,0 +1,6 @@
+namespace Harmonie.Workers.Workers.Notifications;
+
+public interface INotificationCleanupProcessor
+{
+    Task ProcessAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Harmonie.Workers/Workers/Notifications/NotificationCleanupProcessor.cs
+++ b/src/Harmonie.Workers/Workers/Notifications/NotificationCleanupProcessor.cs
@@ -9,21 +9,24 @@ public sealed class NotificationCleanupProcessor : INotificationCleanupProcessor
 {
     private readonly INotificationCleanupRepository _cleanupRepository;
     private readonly NotificationCleanupOptions _options;
+    private readonly TimeProvider _timeProvider;
     private readonly ILogger<NotificationCleanupProcessor> _logger;
 
     public NotificationCleanupProcessor(
         INotificationCleanupRepository cleanupRepository,
         IOptions<NotificationCleanupOptions> options,
+        TimeProvider timeProvider,
         ILogger<NotificationCleanupProcessor> logger)
     {
         _cleanupRepository = cleanupRepository;
         _options = options.Value;
+        _timeProvider = timeProvider;
         _logger = logger;
     }
 
     public async Task ProcessAsync(CancellationToken cancellationToken = default)
     {
-        var nowUtc = DateTime.UtcNow;
+        var nowUtc = _timeProvider.GetUtcNow().UtcDateTime;
         var processedBeforeUtc = nowUtc.AddDays(-_options.ProcessedOutboxRetentionDays);
         var failedBeforeUtc = nowUtc.AddDays(-_options.FailedOutboxRetentionDays);
         var expiresBeforeUtc = nowUtc.AddDays(-_options.ExpiredDeviceRetentionDays);
@@ -32,18 +35,25 @@ public sealed class NotificationCleanupProcessor : INotificationCleanupProcessor
             MessageNotificationOutboxStatuses.Processed,
             processedBeforeUtc,
             cancellationToken);
+        _logger.LogInformation(
+            "Notification cleanup deleted {DeletedRowCount} outbox rows with status {Status}.",
+            processedCount,
+            MessageNotificationOutboxStatuses.Processed);
+
         var failedCount = await DeleteAllBatchesAsync(
             MessageNotificationOutboxStatuses.Failed,
             failedBeforeUtc,
             cancellationToken);
+        _logger.LogInformation(
+            "Notification cleanup deleted {DeletedRowCount} outbox rows with status {Status}.",
+            failedCount,
+            MessageNotificationOutboxStatuses.Failed);
+
         var expiredDeviceCount = await DeleteExpiredDeviceBatchesAsync(
             expiresBeforeUtc,
             cancellationToken);
-
         _logger.LogInformation(
-            "Notification cleanup completed. ProcessedOutboxRows={ProcessedOutboxRows}, FailedOutboxRows={FailedOutboxRows}, ExpiredNotificationDevices={ExpiredNotificationDevices}",
-            processedCount,
-            failedCount,
+            "Notification cleanup deleted {DeletedRowCount} expired notification devices.",
             expiredDeviceCount);
     }
 

--- a/src/Harmonie.Workers/Workers/Notifications/NotificationCleanupProcessor.cs
+++ b/src/Harmonie.Workers/Workers/Notifications/NotificationCleanupProcessor.cs
@@ -1,0 +1,91 @@
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Application.Services.Notifications;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Harmonie.Workers.Workers.Notifications;
+
+public sealed class NotificationCleanupProcessor : INotificationCleanupProcessor
+{
+    private readonly INotificationCleanupRepository _cleanupRepository;
+    private readonly NotificationCleanupOptions _options;
+    private readonly ILogger<NotificationCleanupProcessor> _logger;
+
+    public NotificationCleanupProcessor(
+        INotificationCleanupRepository cleanupRepository,
+        IOptions<NotificationCleanupOptions> options,
+        ILogger<NotificationCleanupProcessor> logger)
+    {
+        _cleanupRepository = cleanupRepository;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task ProcessAsync(CancellationToken cancellationToken = default)
+    {
+        var nowUtc = DateTime.UtcNow;
+        var processedBeforeUtc = nowUtc.AddDays(-_options.ProcessedOutboxRetentionDays);
+        var failedBeforeUtc = nowUtc.AddDays(-_options.FailedOutboxRetentionDays);
+        var expiresBeforeUtc = nowUtc.AddDays(-_options.ExpiredDeviceRetentionDays);
+
+        var processedCount = await DeleteAllBatchesAsync(
+            MessageNotificationOutboxStatuses.Processed,
+            processedBeforeUtc,
+            cancellationToken);
+        var failedCount = await DeleteAllBatchesAsync(
+            MessageNotificationOutboxStatuses.Failed,
+            failedBeforeUtc,
+            cancellationToken);
+        var expiredDeviceCount = await DeleteExpiredDeviceBatchesAsync(
+            expiresBeforeUtc,
+            cancellationToken);
+
+        _logger.LogInformation(
+            "Notification cleanup completed. ProcessedOutboxRows={ProcessedOutboxRows}, FailedOutboxRows={FailedOutboxRows}, ExpiredNotificationDevices={ExpiredNotificationDevices}",
+            processedCount,
+            failedCount,
+            expiredDeviceCount);
+    }
+
+    private async Task<int> DeleteAllBatchesAsync(
+        string status,
+        DateTime processedBeforeUtc,
+        CancellationToken cancellationToken)
+    {
+        var deletedCount = 0;
+        int deletedInBatch;
+
+        do
+        {
+            deletedInBatch = await _cleanupRepository.DeleteOutboxBatchAsync(
+                status,
+                processedBeforeUtc,
+                _options.BatchSize,
+                cancellationToken);
+            deletedCount += deletedInBatch;
+        }
+        while (deletedInBatch > 0);
+
+        return deletedCount;
+    }
+
+    private async Task<int> DeleteExpiredDeviceBatchesAsync(
+        DateTime expiresBeforeUtc,
+        CancellationToken cancellationToken)
+    {
+        var deletedCount = 0;
+        int deletedInBatch;
+
+        do
+        {
+            deletedInBatch = await _cleanupRepository.DeleteExpiredDevicesBatchAsync(
+                expiresBeforeUtc,
+                _options.BatchSize,
+                cancellationToken);
+            deletedCount += deletedInBatch;
+        }
+        while (deletedInBatch > 0);
+
+        return deletedCount;
+    }
+}

--- a/src/Harmonie.Workers/Workers/Notifications/NotificationCleanupWorker.cs
+++ b/src/Harmonie.Workers/Workers/Notifications/NotificationCleanupWorker.cs
@@ -1,0 +1,68 @@
+using Harmonie.Application.Services.Notifications;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Harmonie.Workers.Workers.Notifications;
+
+public sealed class NotificationCleanupWorker : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly NotificationCleanupOptions _options;
+    private readonly ILogger<NotificationCleanupWorker> _logger;
+
+    public NotificationCleanupWorker(
+        IServiceScopeFactory scopeFactory,
+        IOptions<NotificationCleanupOptions> options,
+        ILogger<NotificationCleanupWorker> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_options.Enabled)
+        {
+            _logger.LogInformation("Notification cleanup worker is disabled.");
+            return;
+        }
+
+        _logger.LogInformation("Notification cleanup worker started.");
+
+        using var timer = new PeriodicTimer(TimeSpan.FromHours(_options.PollIntervalHours));
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await ProcessAsync(stoppingToken);
+
+            try
+            {
+                await timer.WaitForNextTickAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+    }
+
+    private async Task ProcessAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var processor = scope.ServiceProvider.GetRequiredService<INotificationCleanupProcessor>();
+            await processor.ProcessAsync(stoppingToken);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Expected during graceful shutdown.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Notification cleanup worker run failed.");
+        }
+    }
+}

--- a/src/Harmonie.Workers/Workers/Notifications/NotificationCleanupWorker.cs
+++ b/src/Harmonie.Workers/Workers/Notifications/NotificationCleanupWorker.cs
@@ -32,7 +32,7 @@ public sealed class NotificationCleanupWorker : BackgroundService
 
         _logger.LogInformation("Notification cleanup worker started.");
 
-        using var timer = new PeriodicTimer(TimeSpan.FromHours(_options.PollIntervalHours));
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(_options.PollIntervalSeconds));
         while (!stoppingToken.IsCancellationRequested)
         {
             await ProcessAsync(stoppingToken);

--- a/src/Harmonie.Workers/appsettings.json
+++ b/src/Harmonie.Workers/appsettings.json
@@ -10,7 +10,7 @@
   },
   "NotificationCleanup": {
     "Enabled": false,
-    "PollIntervalHours": 24,
+    "PollIntervalSeconds": 86400,
     "BatchSize": 500,
     "ProcessedOutboxRetentionDays": 7,
     "FailedOutboxRetentionDays": 30,

--- a/src/Harmonie.Workers/appsettings.json
+++ b/src/Harmonie.Workers/appsettings.json
@@ -8,6 +8,14 @@
     "MaxAttempts": 5,
     "RetryBaseDelaySeconds": 30
   },
+  "NotificationCleanup": {
+    "Enabled": false,
+    "PollIntervalHours": 24,
+    "BatchSize": 500,
+    "ProcessedOutboxRetentionDays": 7,
+    "FailedOutboxRetentionDays": 30,
+    "ExpiredDeviceRetentionDays": 7
+  },
   "WebPush": {
     "PublicKey": "",
     "PrivateKey": "",

--- a/src/Harmonie.Workers/appsettings.json
+++ b/src/Harmonie.Workers/appsettings.json
@@ -9,8 +9,8 @@
     "RetryBaseDelaySeconds": 30
   },
   "NotificationCleanup": {
-    "Enabled": false,
-    "PollIntervalSeconds": 86400,
+    "Enabled": true,
+    "PollIntervalSeconds": 1800,
     "BatchSize": 500,
     "ProcessedOutboxRetentionDays": 7,
     "FailedOutboxRetentionDays": 30,

--- a/tests/Harmonie.API.IntegrationTests/Notifications/NotificationCleanupRepositoryTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Notifications/NotificationCleanupRepositoryTests.cs
@@ -23,16 +23,29 @@ public sealed class NotificationCleanupRepositoryTests : IClassFixture<HarmonieW
     {
         var user = await AuthTestHelper.RegisterAsync(_client);
         var (_, channelId) = await ChannelTestHelper.CreateGuildAndChannelAsync(_client, user.AccessToken);
-        var firstOldProcessedMessage = await ChannelTestHelper.SendChannelMessageAsync(_client, channelId, "first old processed cleanup", user.AccessToken);
-        var secondOldProcessedMessage = await ChannelTestHelper.SendChannelMessageAsync(_client, channelId, "second old processed cleanup", user.AccessToken);
-        var recentProcessedMessage = await ChannelTestHelper.SendChannelMessageAsync(_client, channelId, "recent processed cleanup", user.AccessToken);
-        var oldFailedMessage = await ChannelTestHelper.SendChannelMessageAsync(_client, channelId, "old failed cleanup", user.AccessToken);
+        var message = await ChannelTestHelper.SendChannelMessageAsync(
+            _client,
+            channelId,
+            "notification cleanup repository",
+            user.AccessToken);
+        var firstOldProcessedJobId = Guid.NewGuid();
+        var secondOldProcessedJobId = Guid.NewGuid();
+        var cutoffProcessedJobId = Guid.NewGuid();
+        var recentProcessedJobId = Guid.NewGuid();
+        var oldFailedJobId = Guid.NewGuid();
         var cutoffUtc = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-        await SetOutboxStatusAsync(firstOldProcessedMessage.MessageId, MessageNotificationOutboxStatuses.Processed, cutoffUtc.AddDays(-2));
-        await SetOutboxStatusAsync(secondOldProcessedMessage.MessageId, MessageNotificationOutboxStatuses.Processed, cutoffUtc.AddDays(-1));
-        await SetOutboxStatusAsync(recentProcessedMessage.MessageId, MessageNotificationOutboxStatuses.Processed, cutoffUtc.AddDays(1));
-        await SetOutboxStatusAsync(oldFailedMessage.MessageId, MessageNotificationOutboxStatuses.Failed, cutoffUtc.AddDays(-1));
+        await DeleteOutboxUntilEmptyAsync(MessageNotificationOutboxStatuses.Processed, cutoffUtc);
+        await DeleteOutboxUntilEmptyAsync(MessageNotificationOutboxStatuses.Failed, cutoffUtc);
+        await ReplaceOutboxWithCleanupJobsAsync(
+            message.MessageId,
+            [
+                (firstOldProcessedJobId, MessageNotificationOutboxStatuses.Processed, cutoffUtc.AddDays(-2)),
+                (secondOldProcessedJobId, MessageNotificationOutboxStatuses.Processed, cutoffUtc.AddDays(-1)),
+                (cutoffProcessedJobId, MessageNotificationOutboxStatuses.Processed, cutoffUtc),
+                (recentProcessedJobId, MessageNotificationOutboxStatuses.Processed, cutoffUtc.AddDays(1)),
+                (oldFailedJobId, MessageNotificationOutboxStatuses.Failed, cutoffUtc.AddDays(-1))
+            ]);
 
         var firstProcessedBatch = await DeleteOutboxBatchAsync(
             MessageNotificationOutboxStatuses.Processed,
@@ -55,10 +68,11 @@ public sealed class NotificationCleanupRepositoryTests : IClassFixture<HarmonieW
         secondProcessedBatch.Should().Be(1);
         thirdProcessedBatch.Should().Be(0);
         failedBatch.Should().Be(1);
-        (await OutboxJobExistsAsync(firstOldProcessedMessage.MessageId)).Should().BeFalse();
-        (await OutboxJobExistsAsync(secondOldProcessedMessage.MessageId)).Should().BeFalse();
-        (await OutboxJobExistsAsync(oldFailedMessage.MessageId)).Should().BeFalse();
-        (await OutboxJobExistsAsync(recentProcessedMessage.MessageId)).Should().BeTrue();
+        (await OutboxJobExistsAsync(firstOldProcessedJobId)).Should().BeFalse();
+        (await OutboxJobExistsAsync(secondOldProcessedJobId)).Should().BeFalse();
+        (await OutboxJobExistsAsync(oldFailedJobId)).Should().BeFalse();
+        (await OutboxJobExistsAsync(cutoffProcessedJobId)).Should().BeTrue();
+        (await OutboxJobExistsAsync(recentProcessedJobId)).Should().BeTrue();
     }
 
     [Fact]
@@ -67,11 +81,14 @@ public sealed class NotificationCleanupRepositoryTests : IClassFixture<HarmonieW
         var user = await AuthTestHelper.RegisterAsync(_client);
         var oldFirstDeviceId = Guid.NewGuid();
         var oldSecondDeviceId = Guid.NewGuid();
+        var cutoffDeviceId = Guid.NewGuid();
         var recentDeviceId = Guid.NewGuid();
         var cutoffUtc = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
+        await DeleteExpiredDevicesUntilEmptyAsync(cutoffUtc);
         await InsertDeviceAsync(oldFirstDeviceId, user.UserId, cutoffUtc.AddDays(-2));
         await InsertDeviceAsync(oldSecondDeviceId, user.UserId, cutoffUtc.AddDays(-1));
+        await InsertDeviceAsync(cutoffDeviceId, user.UserId, cutoffUtc);
         await InsertDeviceAsync(recentDeviceId, user.UserId, cutoffUtc.AddDays(1));
 
         var firstBatch = await DeleteExpiredDevicesBatchAsync(cutoffUtc, batchSize: 1);
@@ -83,7 +100,50 @@ public sealed class NotificationCleanupRepositoryTests : IClassFixture<HarmonieW
         thirdBatch.Should().Be(0);
         (await NotificationDeviceExistsAsync(oldFirstDeviceId)).Should().BeFalse();
         (await NotificationDeviceExistsAsync(oldSecondDeviceId)).Should().BeFalse();
+        (await NotificationDeviceExistsAsync(cutoffDeviceId)).Should().BeTrue();
         (await NotificationDeviceExistsAsync(recentDeviceId)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DeleteExpiredDevicesBatchAsync_WhenOldestRowIsLocked_ShouldDeleteAnotherEligibleRow()
+    {
+        var user = await AuthTestHelper.RegisterAsync(_client);
+        var lockedDeviceId = Guid.NewGuid();
+        var unlockedDeviceId = Guid.NewGuid();
+        var cutoffUtc = new DateTime(1800, 1, 3, 0, 0, 0, DateTimeKind.Utc);
+        await DeleteExpiredDevicesUntilEmptyAsync(cutoffUtc);
+        await InsertDeviceAsync(lockedDeviceId, user.UserId, cutoffUtc.AddDays(-2));
+        await InsertDeviceAsync(unlockedDeviceId, user.UserId, cutoffUtc.AddDays(-1));
+
+        await using var lockingScope = _factory.Services.CreateAsyncScope();
+        var lockingSession = lockingScope.ServiceProvider.GetRequiredService<DbSession>();
+        await lockingSession.BeginTransactionAsync(TestContext.Current.CancellationToken);
+        var lockingConnection = await lockingSession.GetOpenConnectionAsync(TestContext.Current.CancellationToken);
+        await using var lockCommand = lockingConnection.CreateCommand();
+        lockCommand.CommandText = "SELECT id FROM notification_devices WHERE id = @DeviceId FOR UPDATE";
+        lockCommand.Parameters.AddWithValue("DeviceId", lockedDeviceId);
+        await lockCommand.ExecuteScalarAsync(TestContext.Current.CancellationToken);
+
+        try
+        {
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            timeout.CancelAfter(TimeSpan.FromSeconds(5));
+
+            await using var cleanupScope = _factory.Services.CreateAsyncScope();
+            var repository = cleanupScope.ServiceProvider.GetRequiredService<INotificationCleanupRepository>();
+            var deletedCount = await repository.DeleteExpiredDevicesBatchAsync(
+                cutoffUtc,
+                batchSize: 1,
+                cancellationToken: timeout.Token);
+
+            deletedCount.Should().Be(1);
+            (await NotificationDeviceExistsAsync(lockedDeviceId)).Should().BeTrue();
+            (await NotificationDeviceExistsAsync(unlockedDeviceId)).Should().BeFalse();
+        }
+        finally
+        {
+            await lockingSession.RollbackAsync(TestContext.Current.CancellationToken);
+        }
     }
 
     private async Task<int> DeleteOutboxBatchAsync(string status, DateTime processedBeforeUtc, int batchSize)
@@ -107,26 +167,77 @@ public sealed class NotificationCleanupRepositoryTests : IClassFixture<HarmonieW
             TestContext.Current.CancellationToken);
     }
 
-    private async Task SetOutboxStatusAsync(Guid messageId, string status, DateTime processedAtUtc)
+    private async Task DeleteOutboxUntilEmptyAsync(string status, DateTime cutoffUtc)
+    {
+        while (await DeleteOutboxBatchAsync(status, cutoffUtc, batchSize: 100) > 0)
+        {
+        }
+    }
+
+    private async Task DeleteExpiredDevicesUntilEmptyAsync(DateTime cutoffUtc)
+    {
+        while (await DeleteExpiredDevicesBatchAsync(cutoffUtc, batchSize: 100) > 0)
+        {
+        }
+    }
+
+    private async Task ReplaceOutboxWithCleanupJobsAsync(
+        Guid messageId,
+        IReadOnlyList<(Guid Id, string Status, DateTime ProcessedAtUtc)> jobs)
     {
         await using var scope = _factory.Services.CreateAsyncScope();
         var dbSession = scope.ServiceProvider.GetRequiredService<DbSession>();
         var connection = await dbSession.GetOpenConnectionAsync(TestContext.Current.CancellationToken);
+        await dbSession.BeginTransactionAsync(TestContext.Current.CancellationToken);
 
-        await using var command = connection.CreateCommand();
-        command.CommandText = """
-                              UPDATE message_notification_outbox
-                              SET status = @Status,
-                                  processed_at_utc = @ProcessedAtUtc,
-                                  locked_until_utc = NULL
-                              WHERE message_id = @MessageId
-                              """;
-        command.Parameters.AddWithValue("Status", status);
-        command.Parameters.AddWithValue("ProcessedAtUtc", processedAtUtc);
-        command.Parameters.AddWithValue("MessageId", messageId);
+        try
+        {
+            await using var deleteCommand = connection.CreateCommand();
+            deleteCommand.Transaction = dbSession.Transaction;
+            deleteCommand.CommandText = "DELETE FROM message_notification_outbox WHERE message_id = @MessageId";
+            deleteCommand.Parameters.AddWithValue("MessageId", messageId);
+            await deleteCommand.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
 
-        var rows = await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
-        rows.Should().Be(1);
+            foreach (var job in jobs)
+            {
+                await using var insertCommand = connection.CreateCommand();
+                insertCommand.Transaction = dbSession.Transaction;
+                insertCommand.CommandText = """
+                                            INSERT INTO message_notification_outbox (
+                                                id,
+                                                message_id,
+                                                status,
+                                                attempts,
+                                                next_attempt_at_utc,
+                                                locked_until_utc,
+                                                last_error,
+                                                created_at_utc,
+                                                processed_at_utc)
+                                            VALUES (
+                                                @Id,
+                                                @MessageId,
+                                                @Status,
+                                                1,
+                                                @ProcessedAtUtc,
+                                                NULL,
+                                                NULL,
+                                                @ProcessedAtUtc,
+                                                @ProcessedAtUtc)
+                                            """;
+                insertCommand.Parameters.AddWithValue("Id", job.Id);
+                insertCommand.Parameters.AddWithValue("MessageId", messageId);
+                insertCommand.Parameters.AddWithValue("Status", job.Status);
+                insertCommand.Parameters.AddWithValue("ProcessedAtUtc", job.ProcessedAtUtc);
+                await insertCommand.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+            }
+
+            await dbSession.CommitAsync(TestContext.Current.CancellationToken);
+        }
+        catch
+        {
+            await dbSession.RollbackAsync(TestContext.Current.CancellationToken);
+            throw;
+        }
     }
 
     private async Task InsertDeviceAsync(Guid deviceId, Guid userId, DateTime expiresAtUtc)
@@ -168,15 +279,15 @@ public sealed class NotificationCleanupRepositoryTests : IClassFixture<HarmonieW
         rows.Should().Be(1);
     }
 
-    private async Task<bool> OutboxJobExistsAsync(Guid messageId)
+    private async Task<bool> OutboxJobExistsAsync(Guid jobId)
     {
         await using var scope = _factory.Services.CreateAsyncScope();
         var dbSession = scope.ServiceProvider.GetRequiredService<DbSession>();
         var connection = await dbSession.GetOpenConnectionAsync(TestContext.Current.CancellationToken);
 
         await using var command = connection.CreateCommand();
-        command.CommandText = "SELECT EXISTS (SELECT 1 FROM message_notification_outbox WHERE message_id = @MessageId)";
-        command.Parameters.AddWithValue("MessageId", messageId);
+        command.CommandText = "SELECT EXISTS (SELECT 1 FROM message_notification_outbox WHERE id = @JobId)";
+        command.Parameters.AddWithValue("JobId", jobId);
 
         var result = await command.ExecuteScalarAsync(TestContext.Current.CancellationToken);
         result.Should().BeOfType<bool>();

--- a/tests/Harmonie.API.IntegrationTests/Notifications/NotificationCleanupRepositoryTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Notifications/NotificationCleanupRepositoryTests.cs
@@ -1,0 +1,200 @@
+using FluentAssertions;
+using Harmonie.API.IntegrationTests.Common;
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Infrastructure.Persistence.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Harmonie.API.IntegrationTests.Notifications;
+
+public sealed class NotificationCleanupRepositoryTests : IClassFixture<HarmonieWebApplicationFactory>
+{
+    private readonly HarmonieWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public NotificationCleanupRepositoryTests(HarmonieWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task DeleteOutboxBatchAsync_ShouldRespectRetentionCutoffAndBatchSize()
+    {
+        var user = await AuthTestHelper.RegisterAsync(_client);
+        var (_, channelId) = await ChannelTestHelper.CreateGuildAndChannelAsync(_client, user.AccessToken);
+        var firstOldProcessedMessage = await ChannelTestHelper.SendChannelMessageAsync(_client, channelId, "first old processed cleanup", user.AccessToken);
+        var secondOldProcessedMessage = await ChannelTestHelper.SendChannelMessageAsync(_client, channelId, "second old processed cleanup", user.AccessToken);
+        var recentProcessedMessage = await ChannelTestHelper.SendChannelMessageAsync(_client, channelId, "recent processed cleanup", user.AccessToken);
+        var oldFailedMessage = await ChannelTestHelper.SendChannelMessageAsync(_client, channelId, "old failed cleanup", user.AccessToken);
+        var cutoffUtc = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        await SetOutboxStatusAsync(firstOldProcessedMessage.MessageId, MessageNotificationOutboxStatuses.Processed, cutoffUtc.AddDays(-2));
+        await SetOutboxStatusAsync(secondOldProcessedMessage.MessageId, MessageNotificationOutboxStatuses.Processed, cutoffUtc.AddDays(-1));
+        await SetOutboxStatusAsync(recentProcessedMessage.MessageId, MessageNotificationOutboxStatuses.Processed, cutoffUtc.AddDays(1));
+        await SetOutboxStatusAsync(oldFailedMessage.MessageId, MessageNotificationOutboxStatuses.Failed, cutoffUtc.AddDays(-1));
+
+        var firstProcessedBatch = await DeleteOutboxBatchAsync(
+            MessageNotificationOutboxStatuses.Processed,
+            cutoffUtc,
+            batchSize: 1);
+        var secondProcessedBatch = await DeleteOutboxBatchAsync(
+            MessageNotificationOutboxStatuses.Processed,
+            cutoffUtc,
+            batchSize: 1);
+        var thirdProcessedBatch = await DeleteOutboxBatchAsync(
+            MessageNotificationOutboxStatuses.Processed,
+            cutoffUtc,
+            batchSize: 1);
+        var failedBatch = await DeleteOutboxBatchAsync(
+            MessageNotificationOutboxStatuses.Failed,
+            cutoffUtc,
+            batchSize: 1);
+
+        firstProcessedBatch.Should().Be(1);
+        secondProcessedBatch.Should().Be(1);
+        thirdProcessedBatch.Should().Be(0);
+        failedBatch.Should().Be(1);
+        (await OutboxJobExistsAsync(firstOldProcessedMessage.MessageId)).Should().BeFalse();
+        (await OutboxJobExistsAsync(secondOldProcessedMessage.MessageId)).Should().BeFalse();
+        (await OutboxJobExistsAsync(oldFailedMessage.MessageId)).Should().BeFalse();
+        (await OutboxJobExistsAsync(recentProcessedMessage.MessageId)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DeleteExpiredDevicesBatchAsync_ShouldRespectGracePeriodAndBatchSize()
+    {
+        var user = await AuthTestHelper.RegisterAsync(_client);
+        var oldFirstDeviceId = Guid.NewGuid();
+        var oldSecondDeviceId = Guid.NewGuid();
+        var recentDeviceId = Guid.NewGuid();
+        var cutoffUtc = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        await InsertDeviceAsync(oldFirstDeviceId, user.UserId, cutoffUtc.AddDays(-2));
+        await InsertDeviceAsync(oldSecondDeviceId, user.UserId, cutoffUtc.AddDays(-1));
+        await InsertDeviceAsync(recentDeviceId, user.UserId, cutoffUtc.AddDays(1));
+
+        var firstBatch = await DeleteExpiredDevicesBatchAsync(cutoffUtc, batchSize: 1);
+        var secondBatch = await DeleteExpiredDevicesBatchAsync(cutoffUtc, batchSize: 1);
+        var thirdBatch = await DeleteExpiredDevicesBatchAsync(cutoffUtc, batchSize: 1);
+
+        firstBatch.Should().Be(1);
+        secondBatch.Should().Be(1);
+        thirdBatch.Should().Be(0);
+        (await NotificationDeviceExistsAsync(oldFirstDeviceId)).Should().BeFalse();
+        (await NotificationDeviceExistsAsync(oldSecondDeviceId)).Should().BeFalse();
+        (await NotificationDeviceExistsAsync(recentDeviceId)).Should().BeTrue();
+    }
+
+    private async Task<int> DeleteOutboxBatchAsync(string status, DateTime processedBeforeUtc, int batchSize)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var repository = scope.ServiceProvider.GetRequiredService<INotificationCleanupRepository>();
+        return await repository.DeleteOutboxBatchAsync(
+            status,
+            processedBeforeUtc,
+            batchSize,
+            TestContext.Current.CancellationToken);
+    }
+
+    private async Task<int> DeleteExpiredDevicesBatchAsync(DateTime expiresBeforeUtc, int batchSize)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var repository = scope.ServiceProvider.GetRequiredService<INotificationCleanupRepository>();
+        return await repository.DeleteExpiredDevicesBatchAsync(
+            expiresBeforeUtc,
+            batchSize,
+            TestContext.Current.CancellationToken);
+    }
+
+    private async Task SetOutboxStatusAsync(Guid messageId, string status, DateTime processedAtUtc)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var dbSession = scope.ServiceProvider.GetRequiredService<DbSession>();
+        var connection = await dbSession.GetOpenConnectionAsync(TestContext.Current.CancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+                              UPDATE message_notification_outbox
+                              SET status = @Status,
+                                  processed_at_utc = @ProcessedAtUtc,
+                                  locked_until_utc = NULL
+                              WHERE message_id = @MessageId
+                              """;
+        command.Parameters.AddWithValue("Status", status);
+        command.Parameters.AddWithValue("ProcessedAtUtc", processedAtUtc);
+        command.Parameters.AddWithValue("MessageId", messageId);
+
+        var rows = await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        rows.Should().Be(1);
+    }
+
+    private async Task InsertDeviceAsync(Guid deviceId, Guid userId, DateTime expiresAtUtc)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var dbSession = scope.ServiceProvider.GetRequiredService<DbSession>();
+        var connection = await dbSession.GetOpenConnectionAsync(TestContext.Current.CancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+                              INSERT INTO notification_devices (
+                                  id,
+                                  user_id,
+                                  platform,
+                                  token,
+                                  web_push_p256dh,
+                                  web_push_auth,
+                                  expires_at_utc,
+                                  created_at_utc,
+                                  updated_at_utc)
+                              VALUES (
+                                  @Id,
+                                  @UserId,
+                                  'web_push',
+                                  @Token,
+                                  'p256dh-key',
+                                  'auth-secret',
+                                  @ExpiresAtUtc,
+                                  @NowUtc,
+                                  @NowUtc)
+                              """;
+        command.Parameters.AddWithValue("Id", deviceId);
+        command.Parameters.AddWithValue("UserId", userId);
+        command.Parameters.AddWithValue("Token", $"https://push.example/subscriptions/{deviceId:N}");
+        command.Parameters.AddWithValue("ExpiresAtUtc", expiresAtUtc);
+        command.Parameters.AddWithValue("NowUtc", DateTime.UtcNow);
+
+        var rows = await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        rows.Should().Be(1);
+    }
+
+    private async Task<bool> OutboxJobExistsAsync(Guid messageId)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var dbSession = scope.ServiceProvider.GetRequiredService<DbSession>();
+        var connection = await dbSession.GetOpenConnectionAsync(TestContext.Current.CancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT EXISTS (SELECT 1 FROM message_notification_outbox WHERE message_id = @MessageId)";
+        command.Parameters.AddWithValue("MessageId", messageId);
+
+        var result = await command.ExecuteScalarAsync(TestContext.Current.CancellationToken);
+        result.Should().BeOfType<bool>();
+        return (bool)result;
+    }
+
+    private async Task<bool> NotificationDeviceExistsAsync(Guid deviceId)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var dbSession = scope.ServiceProvider.GetRequiredService<DbSession>();
+        var connection = await dbSession.GetOpenConnectionAsync(TestContext.Current.CancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT EXISTS (SELECT 1 FROM notification_devices WHERE id = @DeviceId)";
+        command.Parameters.AddWithValue("DeviceId", deviceId);
+
+        var result = await command.ExecuteScalarAsync(TestContext.Current.CancellationToken);
+        result.Should().BeOfType<bool>();
+        return (bool)result;
+    }
+}

--- a/tests/Harmonie.Workers.Tests/Notifications/NotificationCleanupProcessorTests.cs
+++ b/tests/Harmonie.Workers.Tests/Notifications/NotificationCleanupProcessorTests.cs
@@ -1,0 +1,169 @@
+using FluentAssertions;
+using Harmonie.Application.Interfaces.Notifications;
+using Harmonie.Application.Services.Notifications;
+using Harmonie.Workers.Workers.Notifications;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Harmonie.Workers.Tests.Notifications;
+
+public sealed class NotificationCleanupProcessorTests
+{
+    [Fact]
+    public async Task ProcessAsync_ShouldUseConfiguredRetentionCutoffs()
+    {
+        var cleanupRepositoryMock = new Mock<INotificationCleanupRepository>();
+        var outboxCalls = new List<(string Status, DateTime CutoffUtc, int BatchSize)>();
+        var deviceCalls = new List<(DateTime CutoffUtc, int BatchSize)>();
+
+        cleanupRepositoryMock
+            .Setup(repository => repository.DeleteOutboxBatchAsync(
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, DateTime, int, CancellationToken>((status, cutoffUtc, batchSize, _) =>
+                outboxCalls.Add((status, cutoffUtc, batchSize)))
+            .ReturnsAsync(0);
+        cleanupRepositoryMock
+            .Setup(repository => repository.DeleteExpiredDevicesBatchAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<DateTime, int, CancellationToken>((cutoffUtc, batchSize, _) =>
+                deviceCalls.Add((cutoffUtc, batchSize)))
+            .ReturnsAsync(0);
+
+        var processor = CreateProcessor(
+            cleanupRepositoryMock.Object,
+            new NotificationCleanupOptions
+            {
+                BatchSize = 250,
+                ProcessedOutboxRetentionDays = 8,
+                FailedOutboxRetentionDays = 31,
+                ExpiredDeviceRetentionDays = 3
+            });
+        var beforeProcessingUtc = DateTime.UtcNow;
+
+        await processor.ProcessAsync(TestContext.Current.CancellationToken);
+
+        var processedCall = outboxCalls.Should()
+            .ContainSingle(call => call.Status == MessageNotificationOutboxStatuses.Processed)
+            .Which;
+        processedCall.BatchSize.Should().Be(250);
+        processedCall.CutoffUtc.Should().BeCloseTo(beforeProcessingUtc.AddDays(-8), TimeSpan.FromSeconds(1));
+
+        var failedCall = outboxCalls.Should()
+            .ContainSingle(call => call.Status == MessageNotificationOutboxStatuses.Failed)
+            .Which;
+        failedCall.BatchSize.Should().Be(250);
+        failedCall.CutoffUtc.Should().BeCloseTo(beforeProcessingUtc.AddDays(-31), TimeSpan.FromSeconds(1));
+
+        var deviceCall = deviceCalls.Should().ContainSingle().Which;
+        deviceCall.BatchSize.Should().Be(250);
+        deviceCall.CutoffUtc.Should().BeCloseTo(beforeProcessingUtc.AddDays(-3), TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WhenRowsExceedBatchSize_ShouldContinueUntilEachTableIsEmpty()
+    {
+        var cleanupRepositoryMock = new Mock<INotificationCleanupRepository>();
+        cleanupRepositoryMock
+            .SetupSequence(repository => repository.DeleteOutboxBatchAsync(
+                MessageNotificationOutboxStatuses.Processed,
+                It.IsAny<DateTime>(),
+                2,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2)
+            .ReturnsAsync(1)
+            .ReturnsAsync(0);
+        cleanupRepositoryMock
+            .SetupSequence(repository => repository.DeleteOutboxBatchAsync(
+                MessageNotificationOutboxStatuses.Failed,
+                It.IsAny<DateTime>(),
+                2,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2)
+            .ReturnsAsync(0);
+        cleanupRepositoryMock
+            .SetupSequence(repository => repository.DeleteExpiredDevicesBatchAsync(
+                It.IsAny<DateTime>(),
+                2,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2)
+            .ReturnsAsync(1)
+            .ReturnsAsync(0);
+        var processor = CreateProcessor(cleanupRepositoryMock.Object, new NotificationCleanupOptions { BatchSize = 2 });
+
+        await processor.ProcessAsync(TestContext.Current.CancellationToken);
+
+        cleanupRepositoryMock.Verify(
+            repository => repository.DeleteOutboxBatchAsync(
+                MessageNotificationOutboxStatuses.Processed,
+                It.IsAny<DateTime>(),
+                2,
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(3));
+        cleanupRepositoryMock.Verify(
+            repository => repository.DeleteOutboxBatchAsync(
+                MessageNotificationOutboxStatuses.Failed,
+                It.IsAny<DateTime>(),
+                2,
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+        cleanupRepositoryMock.Verify(
+            repository => repository.DeleteExpiredDevicesBatchAsync(
+                It.IsAny<DateTime>(),
+                2,
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(3));
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WhenNoRowsAreEligible_ShouldPerformOneNoOpBatchPerCleanupTarget()
+    {
+        var cleanupRepositoryMock = new Mock<INotificationCleanupRepository>();
+        cleanupRepositoryMock
+            .Setup(repository => repository.DeleteOutboxBatchAsync(
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+        cleanupRepositoryMock
+            .Setup(repository => repository.DeleteExpiredDevicesBatchAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+        var processor = CreateProcessor(cleanupRepositoryMock.Object, new NotificationCleanupOptions());
+
+        await processor.ProcessAsync(TestContext.Current.CancellationToken);
+
+        cleanupRepositoryMock.Verify(
+            repository => repository.DeleteOutboxBatchAsync(
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+        cleanupRepositoryMock.Verify(
+            repository => repository.DeleteExpiredDevicesBatchAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private static NotificationCleanupProcessor CreateProcessor(
+        INotificationCleanupRepository cleanupRepository,
+        NotificationCleanupOptions options)
+    {
+        return new NotificationCleanupProcessor(
+            cleanupRepository,
+            Options.Create(options),
+            NullLogger<NotificationCleanupProcessor>.Instance);
+    }
+}

--- a/tests/Harmonie.Workers.Tests/Notifications/NotificationCleanupProcessorTests.cs
+++ b/tests/Harmonie.Workers.Tests/Notifications/NotificationCleanupProcessorTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Harmonie.Application.Interfaces.Notifications;
 using Harmonie.Application.Services.Notifications;
 using Harmonie.Workers.Workers.Notifications;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -36,6 +37,7 @@ public sealed class NotificationCleanupProcessorTests
                 deviceCalls.Add((cutoffUtc, batchSize)))
             .ReturnsAsync(0);
 
+        var nowUtc = new DateTimeOffset(2026, 7, 14, 12, 0, 0, TimeSpan.Zero);
         var processor = CreateProcessor(
             cleanupRepositoryMock.Object,
             new NotificationCleanupOptions
@@ -44,8 +46,8 @@ public sealed class NotificationCleanupProcessorTests
                 ProcessedOutboxRetentionDays = 8,
                 FailedOutboxRetentionDays = 31,
                 ExpiredDeviceRetentionDays = 3
-            });
-        var beforeProcessingUtc = DateTime.UtcNow;
+            },
+            nowUtc);
 
         await processor.ProcessAsync(TestContext.Current.CancellationToken);
 
@@ -53,17 +55,17 @@ public sealed class NotificationCleanupProcessorTests
             .ContainSingle(call => call.Status == MessageNotificationOutboxStatuses.Processed)
             .Which;
         processedCall.BatchSize.Should().Be(250);
-        processedCall.CutoffUtc.Should().BeCloseTo(beforeProcessingUtc.AddDays(-8), TimeSpan.FromSeconds(1));
+        processedCall.CutoffUtc.Should().Be(nowUtc.UtcDateTime.AddDays(-8));
 
         var failedCall = outboxCalls.Should()
             .ContainSingle(call => call.Status == MessageNotificationOutboxStatuses.Failed)
             .Which;
         failedCall.BatchSize.Should().Be(250);
-        failedCall.CutoffUtc.Should().BeCloseTo(beforeProcessingUtc.AddDays(-31), TimeSpan.FromSeconds(1));
+        failedCall.CutoffUtc.Should().Be(nowUtc.UtcDateTime.AddDays(-31));
 
         var deviceCall = deviceCalls.Should().ContainSingle().Which;
         deviceCall.BatchSize.Should().Be(250);
-        deviceCall.CutoffUtc.Should().BeCloseTo(beforeProcessingUtc.AddDays(-3), TimeSpan.FromSeconds(1));
+        deviceCall.CutoffUtc.Should().Be(nowUtc.UtcDateTime.AddDays(-3));
     }
 
     [Fact]
@@ -122,6 +124,38 @@ public sealed class NotificationCleanupProcessorTests
     }
 
     [Fact]
+    public async Task ProcessAsync_WhenLaterCleanupFails_ShouldRetainCompletedStatusLog()
+    {
+        var cleanupRepositoryMock = new Mock<INotificationCleanupRepository>();
+        cleanupRepositoryMock
+            .SetupSequence(repository => repository.DeleteOutboxBatchAsync(
+                MessageNotificationOutboxStatuses.Processed,
+                It.IsAny<DateTime>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2)
+            .ReturnsAsync(0);
+        cleanupRepositoryMock
+            .Setup(repository => repository.DeleteOutboxBatchAsync(
+                MessageNotificationOutboxStatuses.Failed,
+                It.IsAny<DateTime>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Failed cleanup unavailable."));
+        var logger = new RecordingLogger<NotificationCleanupProcessor>();
+        var processor = CreateProcessor(
+            cleanupRepositoryMock.Object,
+            new NotificationCleanupOptions(),
+            logger: logger);
+
+        Func<Task> act = () => processor.ProcessAsync(TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        logger.Messages.Should().ContainSingle(message =>
+            message.Contains("deleted 2 outbox rows with status processed", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task ProcessAsync_WhenNoRowsAreEligible_ShouldPerformOneNoOpBatchPerCleanupTarget()
     {
         var cleanupRepositoryMock = new Mock<INotificationCleanupRepository>();
@@ -159,11 +193,38 @@ public sealed class NotificationCleanupProcessorTests
 
     private static NotificationCleanupProcessor CreateProcessor(
         INotificationCleanupRepository cleanupRepository,
-        NotificationCleanupOptions options)
+        NotificationCleanupOptions options,
+        DateTimeOffset? nowUtc = null,
+        ILogger<NotificationCleanupProcessor>? logger = null)
     {
         return new NotificationCleanupProcessor(
             cleanupRepository,
             Options.Create(options),
-            NullLogger<NotificationCleanupProcessor>.Instance);
+            new FixedTimeProvider(nowUtc ?? new DateTimeOffset(2026, 7, 14, 12, 0, 0, TimeSpan.Zero)),
+            logger ?? NullLogger<NotificationCleanupProcessor>.Instance);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add(formatter(state, exception));
+        }
     }
 }

--- a/tests/Harmonie.Workers.Tests/Notifications/NotificationCleanupWorkerTests.cs
+++ b/tests/Harmonie.Workers.Tests/Notifications/NotificationCleanupWorkerTests.cs
@@ -35,7 +35,7 @@ public sealed class NotificationCleanupWorkerTests
             Options.Create(new NotificationCleanupOptions
             {
                 Enabled = true,
-                PollIntervalHours = 24,
+                PollIntervalSeconds = 86_400,
                 BatchSize = 1,
                 ProcessedOutboxRetentionDays = 1,
                 FailedOutboxRetentionDays = 1,

--- a/tests/Harmonie.Workers.Tests/Notifications/NotificationCleanupWorkerTests.cs
+++ b/tests/Harmonie.Workers.Tests/Notifications/NotificationCleanupWorkerTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Harmonie.Application.Services.Notifications;
+using Harmonie.Workers.Workers.Notifications;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Harmonie.Workers.Tests.Notifications;
+
+public sealed class NotificationCleanupWorkerTests
+{
+    [Fact]
+    public async Task StartAsync_WhenDisabled_ShouldNotCreateScope()
+    {
+        var worker = new NotificationCleanupWorker(
+            new ThrowingServiceScopeFactory(),
+            Options.Create(new NotificationCleanupOptions { Enabled = false }),
+            NullLogger<NotificationCleanupWorker>.Instance);
+
+        await worker.StartAsync(TestContext.Current.CancellationToken);
+
+        await worker.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenEnabled_ShouldProcessAtLeastOnce()
+    {
+        var processor = new RecordingNotificationCleanupProcessor();
+        var services = new ServiceCollection();
+        services.AddScoped<INotificationCleanupProcessor>(_ => processor);
+        await using var serviceProvider = services.BuildServiceProvider();
+        var worker = new NotificationCleanupWorker(
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            Options.Create(new NotificationCleanupOptions
+            {
+                Enabled = true,
+                PollIntervalHours = 24,
+                BatchSize = 1,
+                ProcessedOutboxRetentionDays = 1,
+                FailedOutboxRetentionDays = 1,
+                ExpiredDeviceRetentionDays = 0
+            }),
+            NullLogger<NotificationCleanupWorker>.Instance);
+
+        await worker.StartAsync(TestContext.Current.CancellationToken);
+        await processor.WaitForFirstRunAsync(TestContext.Current.CancellationToken);
+        await worker.StopAsync(TestContext.Current.CancellationToken);
+
+        processor.RunCount.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    private sealed class RecordingNotificationCleanupProcessor : INotificationCleanupProcessor
+    {
+        private readonly TaskCompletionSource _firstRun = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _runCount;
+
+        public int RunCount => Volatile.Read(ref _runCount);
+
+        public Task ProcessAsync(CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _runCount);
+            _firstRun.TrySetResult();
+            return Task.CompletedTask;
+        }
+
+        public async Task WaitForFirstRunAsync(CancellationToken cancellationToken)
+        {
+            await _firstRun.Task.WaitAsync(cancellationToken);
+        }
+    }
+
+    private sealed class ThrowingServiceScopeFactory : IServiceScopeFactory
+    {
+        public IServiceScope CreateScope()
+        {
+            throw new InvalidOperationException("Disabled worker should not create a scope.");
+        }
+    }
+}

--- a/tests/Harmonie.Workers.Tests/WorkerDependencyInjectionTests.cs
+++ b/tests/Harmonie.Workers.Tests/WorkerDependencyInjectionTests.cs
@@ -29,6 +29,12 @@ public sealed class WorkerDependencyInjectionTests
                 ["PushNotifications:MaxConcurrentJobs"] = "4",
                 ["PushNotifications:MaxAttempts"] = "5",
                 ["PushNotifications:RetryBaseDelaySeconds"] = "30",
+                ["NotificationCleanup:Enabled"] = "false",
+                ["NotificationCleanup:PollIntervalHours"] = "24",
+                ["NotificationCleanup:BatchSize"] = "500",
+                ["NotificationCleanup:ProcessedOutboxRetentionDays"] = "7",
+                ["NotificationCleanup:FailedOutboxRetentionDays"] = "30",
+                ["NotificationCleanup:ExpiredDeviceRetentionDays"] = "7",
                 ["VAPID_PUBLIC_KEY"] = string.Empty,
                 ["VAPID_PRIVATE_KEY"] = string.Empty,
                 ["VAPID_SUBJECT"] = "mailto:contact@harmonie.app"
@@ -48,7 +54,9 @@ public sealed class WorkerDependencyInjectionTests
         await using var scope = serviceProvider.CreateAsyncScope();
         scope.ServiceProvider.GetRequiredService<INotificationDispatchService>().Should().NotBeNull();
         scope.ServiceProvider.GetRequiredService<IPushNotificationBatchProcessor>().Should().NotBeNull();
+        scope.ServiceProvider.GetRequiredService<INotificationCleanupProcessor>().Should().NotBeNull();
         serviceProvider.GetServices<IHostedService>().Should().ContainSingle(service => service is PushNotificationWorker);
+        serviceProvider.GetServices<IHostedService>().Should().ContainSingle(service => service is NotificationCleanupWorker);
         scope.ServiceProvider.GetService<IUserPresenceNotifier>().Should().BeNull();
         scope.ServiceProvider.GetService<IObjectStorageService>().Should().BeNull();
         scope.ServiceProvider.GetService<ILiveKitWebhookReceiver>().Should().BeNull();

--- a/tests/Harmonie.Workers.Tests/WorkerDependencyInjectionTests.cs
+++ b/tests/Harmonie.Workers.Tests/WorkerDependencyInjectionTests.cs
@@ -30,7 +30,7 @@ public sealed class WorkerDependencyInjectionTests
                 ["PushNotifications:MaxAttempts"] = "5",
                 ["PushNotifications:RetryBaseDelaySeconds"] = "30",
                 ["NotificationCleanup:Enabled"] = "false",
-                ["NotificationCleanup:PollIntervalHours"] = "24",
+                ["NotificationCleanup:PollIntervalSeconds"] = "86400",
                 ["NotificationCleanup:BatchSize"] = "500",
                 ["NotificationCleanup:ProcessedOutboxRetentionDays"] = "7",
                 ["NotificationCleanup:FailedOutboxRetentionDays"] = "30",

--- a/tools/Harmonie.Migrations/Program.cs
+++ b/tools/Harmonie.Migrations/Program.cs
@@ -23,6 +23,7 @@ Console.WriteLine("Starting database migration...");
 var upgrader = DeployChanges.To
     .PostgresqlDatabase(connectionString)
     .WithScriptsEmbeddedInAssembly(Assembly.GetExecutingAssembly())
+    .WithoutTransaction()
     .LogToConsole()
     .Build();
 

--- a/tools/Harmonie.Migrations/Scripts/20260714_1_AddNotificationCleanupIndexes.sql
+++ b/tools/Harmonie.Migrations/Scripts/20260714_1_AddNotificationCleanupIndexes.sql
@@ -1,12 +1,13 @@
 -- Migration: Add indexes for notification cleanup worker
 -- Date: 2026-07-14
 -- Description: Supports batched retention cleanup of terminal outbox jobs and expired devices.
+-- These indexes are built concurrently; the migration runner is explicitly configured without transactions.
 
-CREATE INDEX IF NOT EXISTS idx_message_notification_outbox_terminal_cleanup
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_message_notification_outbox_terminal_cleanup
     ON message_notification_outbox(status, processed_at_utc, id)
     WHERE status IN ('processed', 'failed')
       AND processed_at_utc IS NOT NULL;
 
-CREATE INDEX IF NOT EXISTS idx_notification_devices_expiration_cleanup
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_notification_devices_expiration_cleanup
     ON notification_devices(expires_at_utc, id)
     WHERE expires_at_utc IS NOT NULL;

--- a/tools/Harmonie.Migrations/Scripts/20260714_1_AddNotificationCleanupIndexes.sql
+++ b/tools/Harmonie.Migrations/Scripts/20260714_1_AddNotificationCleanupIndexes.sql
@@ -1,0 +1,12 @@
+-- Migration: Add indexes for notification cleanup worker
+-- Date: 2026-07-14
+-- Description: Supports batched retention cleanup of terminal outbox jobs and expired devices.
+
+CREATE INDEX IF NOT EXISTS idx_message_notification_outbox_terminal_cleanup
+    ON message_notification_outbox(status, processed_at_utc, id)
+    WHERE status IN ('processed', 'failed')
+      AND processed_at_utc IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_notification_devices_expiration_cleanup
+    ON notification_devices(expires_at_utc, id)
+    WHERE expires_at_utc IS NOT NULL;


### PR DESCRIPTION
## Summary
- add configurable notification cleanup worker with batched, multi-instance-safe deletes
- retain terminal outbox jobs and expired devices according to configured cutoffs
- add cleanup indexes, tests, and configuration documentation

Closes #424

## Tests
- `dotnet test --no-restore`