### PR TITLE
feat: store refresh tokens in HttpOnly cookies

### DIFF
--- a/src/Harmonie.Application/Common/Auth/RefreshTokenCookie.cs
+++ b/src/Harmonie.Application/Common/Auth/RefreshTokenCookie.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Harmonie.Application.Common.Auth;
+
+public static class RefreshTokenCookie
+{
+    public const string Name = "__Host-harmonie-refresh";
+
+    public static string? Read(HttpContext httpContext) =>
+        httpContext.Request.Cookies.TryGetValue(Name, out var refreshToken)
+            ? refreshToken
+            : null;
+
+    public static void Write(HttpContext httpContext, string refreshToken, DateTime expiresAtUtc)
+    {
+        httpContext.Response.Cookies.Append(
+            Name,
+            refreshToken,
+            CreateOptions(new DateTimeOffset(EnsureUtc(expiresAtUtc))));
+    }
+
+    public static void Delete(HttpContext httpContext)
+    {
+        httpContext.Response.Cookies.Delete(Name, CreateOptions(expires: null));
+    }
+
+    private static CookieOptions CreateOptions(DateTimeOffset? expires) => new()
+    {
+        HttpOnly = true,
+        Secure = true,
+        SameSite = SameSiteMode.None,
+        Path = "/",
+        IsEssential = true,
+        Expires = expires
+    };
+
+    private static DateTime EnsureUtc(DateTime value) => value.Kind switch
+    {
+        DateTimeKind.Utc => value,
+        DateTimeKind.Local => value.ToUniversalTime(),
+        _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+    };
+}

--- a/src/Harmonie.Application/Features/Auth/Login/LoginEndpoint.cs
+++ b/src/Harmonie.Application/Features/Auth/Login/LoginEndpoint.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Auth;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -42,6 +43,13 @@ public static class LoginEndpoint
             return ApplicationResponse<LoginResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var response = await handler.HandleAsync(request, cancellationToken);
+        if (response.Success)
+        {
+            RefreshTokenCookie.Write(
+                httpContext,
+                response.Data.RefreshToken,
+                response.Data.RefreshTokenExpiresAt);
+        }
 
         return response.ToHttpResult(httpContext);
     }

--- a/src/Harmonie.Application/Features/Auth/Login/LoginHandler.cs
+++ b/src/Harmonie.Application/Features/Auth/Login/LoginHandler.cs
@@ -94,7 +94,8 @@ public sealed class LoginHandler : IHandler<LoginRequest, LoginResponse>
             Username: user.Username,
             AccessToken: accessToken,
             RefreshToken: refreshToken,
-            ExpiresAt: accessTokenExpiresAt
+            ExpiresAt: accessTokenExpiresAt,
+            RefreshTokenExpiresAt: refreshTokenExpiresAt
         );
 
         return ApplicationResponse<LoginResponse>.Ok(payload);

--- a/src/Harmonie.Application/Features/Auth/Login/LoginResponse.cs
+++ b/src/Harmonie.Application/Features/Auth/Login/LoginResponse.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Harmonie.Application.Features.Auth.Login;
 
 /// <summary>
@@ -9,4 +11,5 @@ public sealed record LoginResponse(
     string Username,
     string AccessToken,
     string RefreshToken,
-    DateTime ExpiresAt);
+    DateTime ExpiresAt,
+    [property: JsonIgnore] DateTime RefreshTokenExpiresAt);

--- a/src/Harmonie.Application/Features/Auth/Logout/LogoutEndpoint.cs
+++ b/src/Harmonie.Application/Features/Auth/Logout/LogoutEndpoint.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Auth;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -34,13 +35,21 @@ public static class LogoutEndpoint
         HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        var validationError = await request.ValidateAsync(validator, cancellationToken);
+        var cookieRefreshToken = RefreshTokenCookie.Read(httpContext);
+        var effectiveRequest = string.IsNullOrWhiteSpace(request.RefreshToken)
+            && !string.IsNullOrWhiteSpace(cookieRefreshToken)
+                ? new LogoutRequest(cookieRefreshToken)
+                : request;
+
+        RefreshTokenCookie.Delete(httpContext);
+
+        var validationError = await effectiveRequest.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
             return ApplicationResponse<LogoutResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
 
-        var response = await handler.HandleAsync(request, currentUserId, cancellationToken);
+        var response = await handler.HandleAsync(effectiveRequest, currentUserId, cancellationToken);
         if (!response.Success)
             return response.ToHttpResult(httpContext);
 

--- a/src/Harmonie.Application/Features/Auth/RefreshToken/RefreshTokenEndpoint.cs
+++ b/src/Harmonie.Application/Features/Auth/RefreshToken/RefreshTokenEndpoint.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Auth;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -34,11 +35,32 @@ public static class RefreshTokenEndpoint
         HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        var validationError = await request.ValidateAsync(validator, cancellationToken);
-        if (validationError is not null)
-            return ApplicationResponse<RefreshTokenResponse>.Fail(validationError).ToHttpResult(httpContext);
+        var cookieRefreshToken = RefreshTokenCookie.Read(httpContext);
+        var effectiveRequest = string.IsNullOrWhiteSpace(request.RefreshToken)
+            && !string.IsNullOrWhiteSpace(cookieRefreshToken)
+                ? new RefreshTokenRequest(cookieRefreshToken)
+                : request;
 
-        var response = await handler.HandleAsync(request, cancellationToken);
+        var validationError = await effectiveRequest.ValidateAsync(validator, cancellationToken);
+        if (validationError is not null)
+        {
+            RefreshTokenCookie.Delete(httpContext);
+            return ApplicationResponse<RefreshTokenResponse>.Fail(validationError).ToHttpResult(httpContext);
+        }
+
+        var response = await handler.HandleAsync(effectiveRequest, cancellationToken);
+        if (response.Success)
+        {
+            RefreshTokenCookie.Write(
+                httpContext,
+                response.Data.RefreshToken,
+                response.Data.RefreshTokenExpiresAt);
+        }
+        else
+        {
+            RefreshTokenCookie.Delete(httpContext);
+        }
+
         return response.ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Auth/RefreshToken/RefreshTokenHandler.cs
+++ b/src/Harmonie.Application/Features/Auth/RefreshToken/RefreshTokenHandler.cs
@@ -88,7 +88,8 @@ public sealed class RefreshTokenHandler : IHandler<RefreshTokenRequest, RefreshT
         var payload = new RefreshTokenResponse(
             AccessToken: accessToken,
             RefreshToken: newRefreshToken,
-            ExpiresAt: accessTokenExpiresAt);
+            ExpiresAt: accessTokenExpiresAt,
+            RefreshTokenExpiresAt: refreshTokenExpiresAt);
 
         return ApplicationResponse<RefreshTokenResponse>.Ok(payload);
     }

--- a/src/Harmonie.Application/Features/Auth/RefreshToken/RefreshTokenResponse.cs
+++ b/src/Harmonie.Application/Features/Auth/RefreshToken/RefreshTokenResponse.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Harmonie.Application.Features.Auth.RefreshToken;
 
 /// <summary>
@@ -6,4 +8,5 @@ namespace Harmonie.Application.Features.Auth.RefreshToken;
 public sealed record RefreshTokenResponse(
     string AccessToken,
     string RefreshToken,
-    DateTime ExpiresAt);
+    DateTime ExpiresAt,
+    [property: JsonIgnore] DateTime RefreshTokenExpiresAt);

--- a/src/Harmonie.Application/Features/Auth/Register/RegisterEndpoint.cs
+++ b/src/Harmonie.Application/Features/Auth/Register/RegisterEndpoint.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Auth;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -40,6 +41,13 @@ public static class RegisterEndpoint
             return ApplicationResponse<RegisterResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var response = await handler.HandleAsync(request, cancellationToken);
+        if (response.Success)
+        {
+            RefreshTokenCookie.Write(
+                httpContext,
+                response.Data.RefreshToken,
+                response.Data.RefreshTokenExpiresAt);
+        }
 
         return response.ToCreatedHttpResult(data => $"/api/users/{data.UserId}", httpContext);
     }

--- a/src/Harmonie.Application/Features/Auth/Register/RegisterHandler.cs
+++ b/src/Harmonie.Application/Features/Auth/Register/RegisterHandler.cs
@@ -173,7 +173,8 @@ public sealed class RegisterHandler : IHandler<RegisterRequest, RegisterResponse
             RefreshToken: refreshToken,
             ExpiresAt: accessTokenExpiresAt,
             Avatar: avatar,
-            Theme: user.Theme
+            Theme: user.Theme,
+            RefreshTokenExpiresAt: refreshTokenExpiresAt
         );
 
         return ApplicationResponse<RegisterResponse>.Ok(payload);

--- a/src/Harmonie.Application/Features/Auth/Register/RegisterResponse.cs
+++ b/src/Harmonie.Application/Features/Auth/Register/RegisterResponse.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Harmonie.Application.Features.Users;
 
 namespace Harmonie.Application.Features.Auth.Register;
@@ -13,4 +14,5 @@ public sealed record RegisterResponse(
     string RefreshToken,
     DateTime ExpiresAt,
     AvatarAppearanceDto? Avatar,
-    string Theme);
+    string Theme,
+    [property: JsonIgnore] DateTime RefreshTokenExpiresAt);

--- a/tests/Harmonie.API.IntegrationTests/Auth/AuthEndpointsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Auth/AuthEndpointsTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using FluentAssertions;
 using Harmonie.API.IntegrationTests.Common;
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Auth;
 using Harmonie.Application.Features.Auth.Login;
 using Harmonie.Application.Features.Auth.Logout;
 using Harmonie.Application.Features.Auth.RefreshToken;
@@ -39,6 +40,7 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
+        GetIssuedRefreshCookie(response).Should().NotBeEmpty();
 
         var result = await response.Content.ReadFromJsonAsync<RegisterResponse>(TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
@@ -90,6 +92,7 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        GetIssuedRefreshCookie(response).Should().NotBeEmpty();
 
         var result = await response.Content.ReadFromJsonAsync<LoginResponse>(TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
@@ -155,6 +158,36 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
         result!.AccessToken.Should().NotBeNullOrEmpty();
         result.RefreshToken.Should().NotBeNullOrEmpty();
         result.RefreshToken.Should().NotBe(registerPayload.RefreshToken);
+    }
+
+    [Fact]
+    public async Task RefreshToken_WithCookie_RotatesRefreshCookie()
+    {
+        var registerRequest = new RegisterRequest(
+            Email: $"test{Guid.NewGuid()}@harmonie.chat",
+            Username: $"testuser{Guid.NewGuid():N}"[..20],
+            Password: "Test123!@#");
+
+        var registerResponse = await _client.PostAsJsonAsync(
+            "/api/auth/register",
+            registerRequest,
+            TestContext.Current.CancellationToken);
+        registerResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var initialCookie = GetIssuedRefreshCookie(registerResponse);
+
+        using var refreshRequest = new HttpRequestMessage(HttpMethod.Post, "/api/auth/refresh")
+        {
+            Content = JsonContent.Create(new RefreshTokenRequest(string.Empty))
+        };
+        refreshRequest.Headers.Add("Cookie", $"{RefreshTokenCookie.Name}={initialCookie}");
+
+        var refreshResponse = await _client.SendAsync(
+            refreshRequest,
+            TestContext.Current.CancellationToken);
+
+        refreshResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var rotatedCookie = GetIssuedRefreshCookie(refreshResponse);
+        rotatedCookie.Should().NotBe(initialCookie);
     }
 
     [Fact]
@@ -271,6 +304,40 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
         var refreshError = await refreshResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         refreshError.Should().NotBeNull();
         refreshError!.Code.Should().Be(ApplicationErrorCodes.Auth.RefreshTokenReuseDetected);
+    }
+
+    [Fact]
+    public async Task Logout_WithCookie_DeletesRefreshCookie()
+    {
+        var registerRequest = new RegisterRequest(
+            Email: $"test{Guid.NewGuid()}@harmonie.chat",
+            Username: $"testuser{Guid.NewGuid():N}"[..20],
+            Password: "Test123!@#");
+
+        var registerResponse = await _client.PostAsJsonAsync(
+            "/api/auth/register",
+            registerRequest,
+            TestContext.Current.CancellationToken);
+        registerResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var registerPayload = await registerResponse.Content.ReadFromJsonAsync<RegisterResponse>(
+            TestContext.Current.CancellationToken);
+        registerPayload.Should().NotBeNull();
+
+        using var logoutRequest = new HttpRequestMessage(HttpMethod.Post, "/api/auth/logout")
+        {
+            Content = JsonContent.Create(new LogoutRequest(string.Empty))
+        };
+        logoutRequest.Headers.Authorization = new("Bearer", registerPayload!.AccessToken);
+        logoutRequest.Headers.Add("Cookie", $"{RefreshTokenCookie.Name}={GetIssuedRefreshCookie(registerResponse)}");
+
+        var logoutResponse = await _client.SendAsync(
+            logoutRequest,
+            TestContext.Current.CancellationToken);
+
+        logoutResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        var deletedCookie = GetRefreshCookieHeader(logoutResponse);
+        deletedCookie.Should().Contain($"{RefreshTokenCookie.Name}=");
+        deletedCookie.ToLowerInvariant().Should().Contain("expires=thu, 01 jan 1970 00:00:00 gmt");
     }
 
     [Fact]
@@ -417,6 +484,22 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
     }
+
+    private static string GetIssuedRefreshCookie(HttpResponseMessage response)
+    {
+        var header = GetRefreshCookieHeader(response);
+        var normalizedHeader = header.ToLowerInvariant();
+        normalizedHeader.Should().Contain("httponly");
+        normalizedHeader.Should().Contain("secure");
+        normalizedHeader.Should().Contain("samesite=none");
+        normalizedHeader.Should().Contain("path=/");
+
+        return header.Split(';', 2)[0].Split('=', 2)[1];
+    }
+
+    private static string GetRefreshCookieHeader(HttpResponseMessage response) =>
+        response.Headers.GetValues("Set-Cookie")
+            .Single(value => value.StartsWith($"{RefreshTokenCookie.Name}=", StringComparison.Ordinal));
 
     [Fact]
     public async Task Register_WithoutAvatarAndTheme_ReturnsNullAvatarAndDefaultTheme()


### PR DESCRIPTION
## Summary

- issue refresh tokens as `Secure`, `HttpOnly`, `SameSite=None`, host-only cookies after register, login, and refresh
- rotate the cookie with every refresh and clear it on logout or refresh failure
- allow refresh and logout to consume the cookie when the compatibility request body contains no token
- keep the existing body token contract temporarily so currently deployed clients continue to work during rollout
- derive cookie expiration from the server-side refresh token lifetime
- add integration coverage for cookie attributes, rotation, and deletion

## Rollout

This server change must be deployed before the client change in Harmonie-chat/harmonie-client#108. Existing clients remain compatible; the new client will stop storing refresh tokens in JavaScript-accessible storage. The temporary body compatibility contract will be removed in #436 after the rollout window.

## Validation

- Release build: 0 warnings, 0 errors
- Full test suite: 1,412 tests passed
- Auth integration suite: 19 tests passed

Closes #434