### PR TITLE
refactor: make refresh tokens cookie-only

### DIFF
--- a/src/Harmonie.Application/Common/Auth/AuthSessionResult.cs
+++ b/src/Harmonie.Application/Common/Auth/AuthSessionResult.cs
@@ -1,0 +1,9 @@
+namespace Harmonie.Application.Common.Auth;
+
+/// <summary>
+/// Internal authentication result containing the public response and the refresh cookie value.
+/// </summary>
+public sealed record AuthSessionResult<TResponse>(
+    TResponse Response,
+    string RefreshToken,
+    DateTime RefreshTokenExpiresAt);

--- a/src/Harmonie.Application/Features/Auth/Login/LoginEndpoint.cs
+++ b/src/Harmonie.Application/Features/Auth/Login/LoginEndpoint.cs
@@ -18,12 +18,6 @@ public static class LoginEndpoint
         app.MapPost("/api/auth/login", HandleAsync)
             .WithName("Login")
             .WithTags("Auth")
-            /*.WithOpenApi(operation =>
-            {
-                operation.Summary = "Login to user account";
-                operation.Description = "Authenticates user with email/username and password. Returns JWT tokens.";
-                return operation;
-            })*/
             .Produces<LoginResponse>(StatusCodes.Status200OK)
             .ProducesErrors(
                 ApplicationErrorCodes.Common.ValidationFailed,
@@ -33,7 +27,7 @@ public static class LoginEndpoint
 
     private static async Task<IResult> HandleAsync(
         [FromBody] LoginRequest request,
-        [FromServices] IHandler<LoginRequest, LoginResponse> handler,
+        [FromServices] IHandler<LoginRequest, AuthSessionResult<LoginResponse>> handler,
         [FromServices] IValidator<LoginRequest> validator,
         HttpContext httpContext,
         CancellationToken cancellationToken)
@@ -42,15 +36,15 @@ public static class LoginEndpoint
         if (validationError is not null)
             return ApplicationResponse<LoginResponse>.Fail(validationError).ToHttpResult(httpContext);
 
-        var response = await handler.HandleAsync(request, cancellationToken);
-        if (response.Success)
-        {
-            RefreshTokenCookie.Write(
-                httpContext,
-                response.Data.RefreshToken,
-                response.Data.RefreshTokenExpiresAt);
-        }
+        var result = await handler.HandleAsync(request, cancellationToken);
+        if (!result.Success)
+            return ApplicationResponse<LoginResponse>.Fail(result.Error).ToHttpResult(httpContext);
 
-        return response.ToHttpResult(httpContext);
+        RefreshTokenCookie.Write(
+            httpContext,
+            result.Data.RefreshToken,
+            result.Data.RefreshTokenExpiresAt);
+
+        return ApplicationResponse<LoginResponse>.Ok(result.Data.Response).ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Auth/Login/LoginHandler.cs
+++ b/src/Harmonie.Application/Features/Auth/Login/LoginHandler.cs
@@ -1,4 +1,5 @@
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Auth;
 using Harmonie.Application.Interfaces.Auth;
 using Harmonie.Application.Interfaces.Common;
 using Harmonie.Application.Interfaces.Users;
@@ -10,7 +11,7 @@ namespace Harmonie.Application.Features.Auth.Login;
 /// <summary>
 /// Handler for user login business logic
 /// </summary>
-public sealed class LoginHandler : IHandler<LoginRequest, LoginResponse>
+public sealed class LoginHandler : IHandler<LoginRequest, AuthSessionResult<LoginResponse>>
 {
     private readonly IUserRepository _userRepository;
     private readonly IRefreshTokenRepository _refreshTokenRepository;
@@ -35,7 +36,7 @@ public sealed class LoginHandler : IHandler<LoginRequest, LoginResponse>
         _timeProvider = timeProvider;
     }
 
-    public async Task<ApplicationResponse<LoginResponse>> HandleAsync(
+    public async Task<ApplicationResponse<AuthSessionResult<LoginResponse>>> HandleAsync(
         LoginRequest request,
         CancellationToken cancellationToken = default)
     {
@@ -50,18 +51,18 @@ public sealed class LoginHandler : IHandler<LoginRequest, LoginResponse>
             user = await _userRepository.GetByUsernameAsync(usernameResult.Value, cancellationToken);
 
         if (user is null)
-            return ApplicationResponse<LoginResponse>.Fail(
+            return ApplicationResponse<AuthSessionResult<LoginResponse>>.Fail(
                 ApplicationErrorCodes.Auth.InvalidCredentials,
                 "Invalid email/username or password");
 
         if (!user.IsActive)
-            return ApplicationResponse<LoginResponse>.Fail(
+            return ApplicationResponse<AuthSessionResult<LoginResponse>>.Fail(
                 ApplicationErrorCodes.Auth.UserInactive,
                 $"User with ID '{user.Id}' is inactive and cannot perform this operation");
 
         // Verify password
         if (!_passwordHasher.VerifyPassword(user.Email, user.PasswordHash, request.Password))
-            return ApplicationResponse<LoginResponse>.Fail(
+            return ApplicationResponse<AuthSessionResult<LoginResponse>>.Fail(
                 ApplicationErrorCodes.Auth.InvalidCredentials,
                 "Invalid email/username or password");
 
@@ -88,16 +89,18 @@ public sealed class LoginHandler : IHandler<LoginRequest, LoginResponse>
             cancellationToken);
         await transaction.CommitAsync(cancellationToken);
 
-        var payload = new LoginResponse(
+        var response = new LoginResponse(
             UserId: user.Id.Value,
             Email: user.Email,
             Username: user.Username,
             AccessToken: accessToken,
-            RefreshToken: refreshToken,
-            ExpiresAt: accessTokenExpiresAt,
-            RefreshTokenExpiresAt: refreshTokenExpiresAt
-        );
+            ExpiresAt: accessTokenExpiresAt);
 
-        return ApplicationResponse<LoginResponse>.Ok(payload);
+        var result = new AuthSessionResult<LoginResponse>(
+            response,
+            refreshToken,
+            refreshTokenExpiresAt);
+
+        return ApplicationResponse<AuthSessionResult<LoginResponse>>.Ok(result);
     }
 }

--- a/src/Harmonie.Application/Features/Auth/Login/LoginResponse.cs
+++ b/src/Harmonie.Application/Features/Auth/Login/LoginResponse.cs
@@ -1,15 +1,11 @@
-using System.Text.Json.Serialization;
-
 namespace Harmonie.Application.Features.Auth.Login;
 
 /// <summary>
-/// Response for successful login with authentication tokens
+/// Response for successful login with an access token.
 /// </summary>
 public sealed record LoginResponse(
     Guid UserId,
     string Email,
     string Username,
     string AccessToken,
-    string RefreshToken,
-    DateTime ExpiresAt,
-    [property: JsonIgnore] DateTime RefreshTokenExpiresAt);
+    DateTime ExpiresAt);

--- a/src/Harmonie.Application/Features/Auth/Logout/LogoutEndpoint.cs
+++ b/src/Harmonie.Application/Features/Auth/Logout/LogoutEndpoint.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Routing;
 namespace Harmonie.Application.Features.Auth.Logout;
 
 /// <summary>
-/// Endpoint for logging out current authenticated session.
+/// Endpoint for logging out the current authenticated session.
 /// </summary>
 public static class LogoutEndpoint
 {
@@ -20,7 +20,7 @@ public static class LogoutEndpoint
             .WithTags("Auth")
             .RequireAuthorization()
             .WithSummary("Logout current session")
-            .WithDescription("Revokes the provided refresh token for the authenticated user.")
+            .WithDescription("Revokes the refresh token from the HttpOnly cookie for the authenticated user.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesErrors(
                 ApplicationErrorCodes.Common.ValidationFailed,
@@ -29,27 +29,20 @@ public static class LogoutEndpoint
     }
 
     private static async Task<IResult> HandleAsync(
-        [FromBody] LogoutRequest request,
         [FromServices] IAuthenticatedHandler<LogoutRequest, LogoutResponse> handler,
         [FromServices] IValidator<LogoutRequest> validator,
         HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        var cookieRefreshToken = RefreshTokenCookie.Read(httpContext);
-        var effectiveRequest = string.IsNullOrWhiteSpace(request.RefreshToken)
-            && !string.IsNullOrWhiteSpace(cookieRefreshToken)
-                ? new LogoutRequest(cookieRefreshToken)
-                : request;
-
+        var request = new LogoutRequest(RefreshTokenCookie.Read(httpContext) ?? string.Empty);
         RefreshTokenCookie.Delete(httpContext);
 
-        var validationError = await effectiveRequest.ValidateAsync(validator, cancellationToken);
+        var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
             return ApplicationResponse<LogoutResponse>.Fail(validationError).ToHttpResult(httpContext);
 
         var currentUserId = httpContext.GetRequiredAuthenticatedUserId();
-
-        var response = await handler.HandleAsync(effectiveRequest, currentUserId, cancellationToken);
+        var response = await handler.HandleAsync(request, currentUserId, cancellationToken);
         if (!response.Success)
             return response.ToHttpResult(httpContext);
 

--- a/src/Harmonie.Application/Features/Auth/RefreshToken/RefreshTokenEndpoint.cs
+++ b/src/Harmonie.Application/Features/Auth/RefreshToken/RefreshTokenEndpoint.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Routing;
 namespace Harmonie.Application.Features.Auth.RefreshToken;
 
 /// <summary>
-/// Endpoint for refreshing JWT access tokens.
+/// Endpoint for refreshing an access token from the HttpOnly refresh cookie.
 /// </summary>
 public static class RefreshTokenEndpoint
 {
@@ -19,7 +19,7 @@ public static class RefreshTokenEndpoint
             .WithName("RefreshToken")
             .WithTags("Auth")
             .WithSummary("Refresh access token")
-            .WithDescription("Rotates refresh token and returns a new access token without requiring a new login.")
+            .WithDescription("Rotates the HttpOnly refresh cookie and returns a new access token.")
             .Produces<RefreshTokenResponse>(StatusCodes.Status200OK)
             .ProducesErrors(
                 ApplicationErrorCodes.Common.ValidationFailed,
@@ -29,38 +29,31 @@ public static class RefreshTokenEndpoint
     }
 
     private static async Task<IResult> HandleAsync(
-        [FromBody] RefreshTokenRequest request,
-        [FromServices] IHandler<RefreshTokenRequest, RefreshTokenResponse> handler,
+        [FromServices] IHandler<RefreshTokenRequest, AuthSessionResult<RefreshTokenResponse>> handler,
         [FromServices] IValidator<RefreshTokenRequest> validator,
         HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        var cookieRefreshToken = RefreshTokenCookie.Read(httpContext);
-        var effectiveRequest = string.IsNullOrWhiteSpace(request.RefreshToken)
-            && !string.IsNullOrWhiteSpace(cookieRefreshToken)
-                ? new RefreshTokenRequest(cookieRefreshToken)
-                : request;
-
-        var validationError = await effectiveRequest.ValidateAsync(validator, cancellationToken);
+        var request = new RefreshTokenRequest(RefreshTokenCookie.Read(httpContext) ?? string.Empty);
+        var validationError = await request.ValidateAsync(validator, cancellationToken);
         if (validationError is not null)
         {
             RefreshTokenCookie.Delete(httpContext);
             return ApplicationResponse<RefreshTokenResponse>.Fail(validationError).ToHttpResult(httpContext);
         }
 
-        var response = await handler.HandleAsync(effectiveRequest, cancellationToken);
-        if (response.Success)
-        {
-            RefreshTokenCookie.Write(
-                httpContext,
-                response.Data.RefreshToken,
-                response.Data.RefreshTokenExpiresAt);
-        }
-        else
+        var result = await handler.HandleAsync(request, cancellationToken);
+        if (!result.Success)
         {
             RefreshTokenCookie.Delete(httpContext);
+            return ApplicationResponse<RefreshTokenResponse>.Fail(result.Error).ToHttpResult(httpContext);
         }
 
-        return response.ToHttpResult(httpContext);
+        RefreshTokenCookie.Write(
+            httpContext,
+            result.Data.RefreshToken,
+            result.Data.RefreshTokenExpiresAt);
+
+        return ApplicationResponse<RefreshTokenResponse>.Ok(result.Data.Response).ToHttpResult(httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Auth/RefreshToken/RefreshTokenHandler.cs
+++ b/src/Harmonie.Application/Features/Auth/RefreshToken/RefreshTokenHandler.cs
@@ -8,7 +8,7 @@ namespace Harmonie.Application.Features.Auth.RefreshToken;
 /// <summary>
 /// Handler for refresh token flow with token rotation.
 /// </summary>
-public sealed class RefreshTokenHandler : IHandler<RefreshTokenRequest, RefreshTokenResponse>
+public sealed class RefreshTokenHandler : IHandler<RefreshTokenRequest, AuthSessionResult<RefreshTokenResponse>>
 {
     private readonly IUserRepository _userRepository;
     private readonly IRefreshTokenRepository _refreshTokenRepository;
@@ -27,7 +27,7 @@ public sealed class RefreshTokenHandler : IHandler<RefreshTokenRequest, RefreshT
         _timeProvider = timeProvider;
     }
 
-    public async Task<ApplicationResponse<RefreshTokenResponse>> HandleAsync(
+    public async Task<ApplicationResponse<AuthSessionResult<RefreshTokenResponse>>> HandleAsync(
         RefreshTokenRequest request,
         CancellationToken cancellationToken = default)
     {
@@ -36,7 +36,7 @@ public sealed class RefreshTokenHandler : IHandler<RefreshTokenRequest, RefreshT
         var session = await _refreshTokenRepository.GetByTokenHashAsync(refreshTokenHash, cancellationToken);
 
         if (session is null)
-            return ApplicationResponse<RefreshTokenResponse>.Fail(
+            return ApplicationResponse<AuthSessionResult<RefreshTokenResponse>>.Fail(
                 ApplicationErrorCodes.Auth.InvalidRefreshToken,
                 "Refresh token is invalid or expired");
 
@@ -44,18 +44,18 @@ public sealed class RefreshTokenHandler : IHandler<RefreshTokenRequest, RefreshT
             return await HandleReuseDetectedAsync(session, nowUtc, cancellationToken);
 
         if (session.ExpiresAtUtc <= nowUtc)
-            return ApplicationResponse<RefreshTokenResponse>.Fail(
+            return ApplicationResponse<AuthSessionResult<RefreshTokenResponse>>.Fail(
                 ApplicationErrorCodes.Auth.InvalidRefreshToken,
                 "Refresh token is invalid or expired");
 
         var user = await _userRepository.GetByIdAsync(session.UserId, cancellationToken);
         if (user is null)
-            return ApplicationResponse<RefreshTokenResponse>.Fail(
+            return ApplicationResponse<AuthSessionResult<RefreshTokenResponse>>.Fail(
                 ApplicationErrorCodes.Auth.InvalidRefreshToken,
                 "Refresh token is invalid or expired");
 
         if (!user.IsActive)
-            return ApplicationResponse<RefreshTokenResponse>.Fail(
+            return ApplicationResponse<AuthSessionResult<RefreshTokenResponse>>.Fail(
                 ApplicationErrorCodes.Auth.UserInactive,
                 $"User with ID '{user.Id}' is inactive and cannot perform this operation");
 
@@ -80,21 +80,24 @@ public sealed class RefreshTokenHandler : IHandler<RefreshTokenRequest, RefreshT
             if (latestSession?.RevokedAtUtc is not null)
                 return await HandleReuseDetectedAsync(latestSession, nowUtc, cancellationToken);
 
-            return ApplicationResponse<RefreshTokenResponse>.Fail(
+            return ApplicationResponse<AuthSessionResult<RefreshTokenResponse>>.Fail(
                 ApplicationErrorCodes.Auth.InvalidRefreshToken,
                 "Refresh token is invalid or expired");
         }
 
-        var payload = new RefreshTokenResponse(
+        var response = new RefreshTokenResponse(
             AccessToken: accessToken,
-            RefreshToken: newRefreshToken,
-            ExpiresAt: accessTokenExpiresAt,
-            RefreshTokenExpiresAt: refreshTokenExpiresAt);
+            ExpiresAt: accessTokenExpiresAt);
 
-        return ApplicationResponse<RefreshTokenResponse>.Ok(payload);
+        var result = new AuthSessionResult<RefreshTokenResponse>(
+            response,
+            newRefreshToken,
+            refreshTokenExpiresAt);
+
+        return ApplicationResponse<AuthSessionResult<RefreshTokenResponse>>.Ok(result);
     }
 
-    private async Task<ApplicationResponse<RefreshTokenResponse>> HandleReuseDetectedAsync(
+    private async Task<ApplicationResponse<AuthSessionResult<RefreshTokenResponse>>> HandleReuseDetectedAsync(
         RefreshTokenSession reusedSession,
         DateTime revokedAtUtc,
         CancellationToken cancellationToken)
@@ -120,7 +123,7 @@ public sealed class RefreshTokenHandler : IHandler<RefreshTokenRequest, RefreshT
                 cancellationToken);
         }
 
-        return ApplicationResponse<RefreshTokenResponse>.Fail(
+        return ApplicationResponse<AuthSessionResult<RefreshTokenResponse>>.Fail(
             ApplicationErrorCodes.Auth.RefreshTokenReuseDetected,
             "Refresh token reuse detected; associated sessions were revoked");
     }

--- a/src/Harmonie.Application/Features/Auth/RefreshToken/RefreshTokenResponse.cs
+++ b/src/Harmonie.Application/Features/Auth/RefreshToken/RefreshTokenResponse.cs
@@ -1,12 +1,8 @@
-using System.Text.Json.Serialization;
-
 namespace Harmonie.Application.Features.Auth.RefreshToken;
 
 /// <summary>
-/// Response with new tokens
+/// Response with a refreshed access token.
 /// </summary>
 public sealed record RefreshTokenResponse(
     string AccessToken,
-    string RefreshToken,
-    DateTime ExpiresAt,
-    [property: JsonIgnore] DateTime RefreshTokenExpiresAt);
+    DateTime ExpiresAt);

--- a/src/Harmonie.Application/Features/Auth/Register/RegisterEndpoint.cs
+++ b/src/Harmonie.Application/Features/Auth/Register/RegisterEndpoint.cs
@@ -20,7 +20,7 @@ public static class RegisterEndpoint
             .WithName("Register")
             .WithTags("Auth")
             .WithSummary("Register a new user account")
-            .WithDescription("Creates a new user with email, username, and password. Returns JWT tokens for authentication.")
+            .WithDescription("Creates a user and returns an access token. The refresh token is issued as an HttpOnly cookie.")
             .Produces<RegisterResponse>(StatusCodes.Status201Created)
             .ProducesErrors(
                 ApplicationErrorCodes.Common.ValidationFailed,
@@ -31,7 +31,7 @@ public static class RegisterEndpoint
 
     private static async Task<IResult> HandleAsync(
         [FromBody] RegisterRequest request,
-        [FromServices] IHandler<RegisterRequest, RegisterResponse> handler,
+        [FromServices] IHandler<RegisterRequest, AuthSessionResult<RegisterResponse>> handler,
         [FromServices] IValidator<RegisterRequest> validator,
         HttpContext httpContext,
         CancellationToken cancellationToken)
@@ -40,15 +40,17 @@ public static class RegisterEndpoint
         if (validationError is not null)
             return ApplicationResponse<RegisterResponse>.Fail(validationError).ToHttpResult(httpContext);
 
-        var response = await handler.HandleAsync(request, cancellationToken);
-        if (response.Success)
-        {
-            RefreshTokenCookie.Write(
-                httpContext,
-                response.Data.RefreshToken,
-                response.Data.RefreshTokenExpiresAt);
-        }
+        var result = await handler.HandleAsync(request, cancellationToken);
+        if (!result.Success)
+            return ApplicationResponse<RegisterResponse>.Fail(result.Error).ToHttpResult(httpContext);
 
-        return response.ToCreatedHttpResult(data => $"/api/users/{data.UserId}", httpContext);
+        RefreshTokenCookie.Write(
+            httpContext,
+            result.Data.RefreshToken,
+            result.Data.RefreshTokenExpiresAt);
+
+        return ApplicationResponse<RegisterResponse>
+            .Ok(result.Data.Response)
+            .ToCreatedHttpResult(data => $"/api/users/{data.UserId}", httpContext);
     }
 }

--- a/src/Harmonie.Application/Features/Auth/Register/RegisterHandler.cs
+++ b/src/Harmonie.Application/Features/Auth/Register/RegisterHandler.cs
@@ -1,4 +1,5 @@
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Auth;
 using Harmonie.Application.Features.Users;
 using Harmonie.Application.Interfaces.Auth;
 using Harmonie.Application.Interfaces.Common;
@@ -12,7 +13,7 @@ namespace Harmonie.Application.Features.Auth.Register;
 /// <summary>
 /// Handler for user registration business logic
 /// </summary>
-public sealed class RegisterHandler : IHandler<RegisterRequest, RegisterResponse>
+public sealed class RegisterHandler : IHandler<RegisterRequest, AuthSessionResult<RegisterResponse>>
 {
     private readonly IUserRepository _userRepository;
     private readonly IRefreshTokenRepository _refreshTokenRepository;
@@ -37,7 +38,7 @@ public sealed class RegisterHandler : IHandler<RegisterRequest, RegisterResponse
         _timeProvider = timeProvider;
     }
 
-    public async Task<ApplicationResponse<RegisterResponse>> HandleAsync(
+    public async Task<ApplicationResponse<AuthSessionResult<RegisterResponse>>> HandleAsync(
         RegisterRequest request,
         CancellationToken cancellationToken = default)
     {
@@ -45,7 +46,7 @@ public sealed class RegisterHandler : IHandler<RegisterRequest, RegisterResponse
         var emailResult = Email.Create(request.Email);
         if (emailResult.IsFailure || emailResult.Value is null)
         {
-            return ApplicationResponse<RegisterResponse>.Fail(
+            return ApplicationResponse<AuthSessionResult<RegisterResponse>>.Fail(
                 ApplicationErrorCodes.Common.ValidationFailed,
                 "Request validation failed",
                 EndpointExtensions.SingleValidationError(
@@ -57,7 +58,7 @@ public sealed class RegisterHandler : IHandler<RegisterRequest, RegisterResponse
         var usernameResult = Username.Create(request.Username);
         if (usernameResult.IsFailure || usernameResult.Value is null)
         {
-            return ApplicationResponse<RegisterResponse>.Fail(
+            return ApplicationResponse<AuthSessionResult<RegisterResponse>>.Fail(
                 ApplicationErrorCodes.Common.ValidationFailed,
                 "Request validation failed",
                 EndpointExtensions.SingleValidationError(
@@ -70,12 +71,12 @@ public sealed class RegisterHandler : IHandler<RegisterRequest, RegisterResponse
         var duplicates = await _userRepository.CheckDuplicatesAsync(emailResult.Value, usernameResult.Value, cancellationToken);
 
         if (duplicates.EmailExists)
-            return ApplicationResponse<RegisterResponse>.Fail(
+            return ApplicationResponse<AuthSessionResult<RegisterResponse>>.Fail(
                 ApplicationErrorCodes.Auth.DuplicateEmail,
                 $"A user with email '{emailResult.Value}' already exists");
 
         if (duplicates.UsernameExists)
-            return ApplicationResponse<RegisterResponse>.Fail(
+            return ApplicationResponse<AuthSessionResult<RegisterResponse>>.Fail(
                 ApplicationErrorCodes.Auth.DuplicateUsername,
                 $"A user with username '{usernameResult.Value}' already exists");
 
@@ -91,7 +92,7 @@ public sealed class RegisterHandler : IHandler<RegisterRequest, RegisterResponse
             nowUtc);
 
         if (userResult.IsFailure || userResult.Value is null)
-            return ApplicationResponse<RegisterResponse>.Fail(
+            return ApplicationResponse<AuthSessionResult<RegisterResponse>>.Fail(
                 ApplicationErrorCodes.Common.DomainRuleViolation,
                 userResult.Error ?? "Unable to create user");
 
@@ -102,7 +103,7 @@ public sealed class RegisterHandler : IHandler<RegisterRequest, RegisterResponse
         {
             var appearanceResult = Appearance.Create(request.Avatar.Color, request.Avatar.Icon, request.Avatar.Bg);
             if (appearanceResult.IsFailure || appearanceResult.Value is null)
-                return ApplicationResponse<RegisterResponse>.Fail(
+                return ApplicationResponse<AuthSessionResult<RegisterResponse>>.Fail(
                     ApplicationErrorCodes.Common.ValidationFailed,
                     "Request validation failed",
                     EndpointExtensions.SingleValidationError(
@@ -118,7 +119,7 @@ public sealed class RegisterHandler : IHandler<RegisterRequest, RegisterResponse
         {
             var themeResult = user.UpdateTheme(request.Theme, nowUtc);
             if (themeResult.IsFailure)
-                return ApplicationResponse<RegisterResponse>.Fail(
+                return ApplicationResponse<AuthSessionResult<RegisterResponse>>.Fail(
                     ApplicationErrorCodes.Common.ValidationFailed,
                     "Request validation failed",
                     EndpointExtensions.SingleValidationError(
@@ -145,12 +146,12 @@ public sealed class RegisterHandler : IHandler<RegisterRequest, RegisterResponse
         var addResult = await _userRepository.TryAddAsync(user, cancellationToken);
 
         if (addResult == UserAddResult.DuplicateEmail)
-            return ApplicationResponse<RegisterResponse>.Fail(
+            return ApplicationResponse<AuthSessionResult<RegisterResponse>>.Fail(
                 ApplicationErrorCodes.Auth.DuplicateEmail,
                 $"A user with email '{emailResult.Value}' already exists");
 
         if (addResult == UserAddResult.DuplicateUsername)
-            return ApplicationResponse<RegisterResponse>.Fail(
+            return ApplicationResponse<AuthSessionResult<RegisterResponse>>.Fail(
                 ApplicationErrorCodes.Auth.DuplicateUsername,
                 $"A user with username '{usernameResult.Value}' already exists");
 
@@ -165,18 +166,20 @@ public sealed class RegisterHandler : IHandler<RegisterRequest, RegisterResponse
             ? new AvatarAppearanceDto(user.Avatar.Color, user.Avatar.Glyph, user.Avatar.Bg)
             : null;
 
-        var payload = new RegisterResponse(
+        var response = new RegisterResponse(
             UserId: user.Id.Value,
             Email: user.Email,
             Username: user.Username,
             AccessToken: accessToken,
-            RefreshToken: refreshToken,
             ExpiresAt: accessTokenExpiresAt,
             Avatar: avatar,
-            Theme: user.Theme,
-            RefreshTokenExpiresAt: refreshTokenExpiresAt
-        );
+            Theme: user.Theme);
 
-        return ApplicationResponse<RegisterResponse>.Ok(payload);
+        var result = new AuthSessionResult<RegisterResponse>(
+            response,
+            refreshToken,
+            refreshTokenExpiresAt);
+
+        return ApplicationResponse<AuthSessionResult<RegisterResponse>>.Ok(result);
     }
 }

--- a/src/Harmonie.Application/Features/Auth/Register/RegisterResponse.cs
+++ b/src/Harmonie.Application/Features/Auth/Register/RegisterResponse.cs
@@ -1,18 +1,15 @@
-using System.Text.Json.Serialization;
 using Harmonie.Application.Features.Users;
 
 namespace Harmonie.Application.Features.Auth.Register;
 
 /// <summary>
-/// Response for successful user registration with authentication tokens
+/// Response for successful user registration with an access token.
 /// </summary>
 public sealed record RegisterResponse(
     Guid UserId,
     string Email,
     string Username,
     string AccessToken,
-    string RefreshToken,
     DateTime ExpiresAt,
     AvatarAppearanceDto? Avatar,
-    string Theme,
-    [property: JsonIgnore] DateTime RefreshTokenExpiresAt);
+    string Theme);

--- a/src/Harmonie.Application/Registration/AuthRegistration.cs
+++ b/src/Harmonie.Application/Registration/AuthRegistration.cs
@@ -1,4 +1,5 @@
 using Harmonie.Application.Common;
+using Harmonie.Application.Common.Auth;
 using Harmonie.Application.Features.Auth.Login;
 using Harmonie.Application.Features.Auth.Logout;
 using Harmonie.Application.Features.Auth.LogoutAll;
@@ -12,9 +13,9 @@ public static class AuthRegistration
 {
     public static IServiceCollection AddAuthHandlers(this IServiceCollection services)
     {
-        services.AddHandler<LoginRequest, LoginResponse, LoginHandler>();
-        services.AddHandler<RegisterRequest, RegisterResponse, RegisterHandler>();
-        services.AddHandler<RefreshTokenRequest, RefreshTokenResponse, RefreshTokenHandler>();
+        services.AddHandler<LoginRequest, AuthSessionResult<LoginResponse>, LoginHandler>();
+        services.AddHandler<RegisterRequest, AuthSessionResult<RegisterResponse>, RegisterHandler>();
+        services.AddHandler<RefreshTokenRequest, AuthSessionResult<RefreshTokenResponse>, RefreshTokenHandler>();
         services.AddAuthenticatedHandler<LogoutRequest, LogoutResponse, LogoutHandler>();
         services.AddAuthenticatedHandler<Unit, LogoutAllResponse, LogoutAllHandler>();
 

--- a/tests/Harmonie.API.IntegrationTests/Auth/AuthEndpointsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Auth/AuthEndpointsTests.cs
@@ -5,7 +5,6 @@ using Harmonie.API.IntegrationTests.Common;
 using Harmonie.Application.Common;
 using Harmonie.Application.Common.Auth;
 using Harmonie.Application.Features.Auth.Login;
-using Harmonie.Application.Features.Auth.Logout;
 using Harmonie.Application.Features.Auth.RefreshToken;
 using Harmonie.Application.Features.Auth.Register;
 using Harmonie.Application.Features.Users;
@@ -48,7 +47,8 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
         result!.Email.Should().Be(request.Email);
         result.Username.Should().Be(request.Username);
         result.AccessToken.Should().NotBeNullOrEmpty();
-        result.RefreshToken.Should().NotBeNullOrEmpty();
+        (await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))
+            .Should().NotContain("\"refreshToken\"");
     }
 
     [Fact]
@@ -99,6 +99,8 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
 
         result!.Email.Should().Be(registerRequest.Email);
         result.AccessToken.Should().NotBeNullOrEmpty();
+        (await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))
+            .Should().NotContain("\"refreshToken\"");
     }
 
     [Fact]
@@ -130,34 +132,27 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
     }
 
     [Fact]
-    public async Task RefreshToken_WithValidToken_ReturnsNewTokens()
+    public async Task RefreshToken_WithCookie_ReturnsNewAccessToken()
     {
-        // Arrange - First register a user to get initial tokens
         var registerRequest = new RegisterRequest(
             Email: $"test{Guid.NewGuid()}@harmonie.chat",
             Username: $"testuser{Guid.NewGuid():N}"[..20],
             Password: "Test123!@#");
 
-        var registerResponse = await _client.PostAsJsonAsync("/api/auth/register", registerRequest, TestContext.Current.CancellationToken);
+        var registerResponse = await _client.PostAsJsonAsync(
+            "/api/auth/register",
+            registerRequest,
+            TestContext.Current.CancellationToken);
         registerResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var registerPayload = await registerResponse.Content.ReadFromJsonAsync<RegisterResponse>(TestContext.Current.CancellationToken);
-        registerPayload.Should().NotBeNull();
+        var response = await SendRefreshAsync(GetIssuedRefreshCookie(registerResponse));
 
-        var refreshRequest = new RefreshTokenRequest(registerPayload!.RefreshToken);
-
-        // Act
-        var response = await _client.PostAsJsonAsync("/api/auth/refresh", refreshRequest, TestContext.Current.CancellationToken);
-
-        // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-
         var result = await response.Content.ReadFromJsonAsync<RefreshTokenResponse>(TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
-
         result!.AccessToken.Should().NotBeNullOrEmpty();
-        result.RefreshToken.Should().NotBeNullOrEmpty();
-        result.RefreshToken.Should().NotBe(registerPayload.RefreshToken);
+        (await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))
+            .Should().NotContain("\"refreshToken\"");
     }
 
     [Fact]
@@ -175,10 +170,7 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
         registerResponse.StatusCode.Should().Be(HttpStatusCode.Created);
         var initialCookie = GetIssuedRefreshCookie(registerResponse);
 
-        using var refreshRequest = new HttpRequestMessage(HttpMethod.Post, "/api/auth/refresh")
-        {
-            Content = JsonContent.Create(new RefreshTokenRequest(string.Empty))
-        };
+        using var refreshRequest = new HttpRequestMessage(HttpMethod.Post, "/api/auth/refresh");
         refreshRequest.Headers.Add("Cookie", $"{RefreshTokenCookie.Name}={initialCookie}");
 
         var refreshResponse = await _client.SendAsync(
@@ -201,30 +193,21 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
 
         var registerResponse = await _client.PostAsJsonAsync("/api/auth/register", registerRequest, TestContext.Current.CancellationToken);
         registerResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-        var registerPayload = await registerResponse.Content.ReadFromJsonAsync<RegisterResponse>(TestContext.Current.CancellationToken);
-        registerPayload.Should().NotBeNull();
+        var registerCookie = GetIssuedRefreshCookie(registerResponse);
 
         var loginResponse = await _client.PostAsJsonAsync(
             "/api/auth/login",
             new LoginRequest(registerRequest.Email, registerRequest.Password),
             TestContext.Current.CancellationToken);
         loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        var loginPayload = await loginResponse.Content.ReadFromJsonAsync<LoginResponse>(TestContext.Current.CancellationToken);
-        loginPayload.Should().NotBeNull();
+        var loginCookie = GetIssuedRefreshCookie(loginResponse);
 
-        var firstRefreshResponse = await _client.PostAsJsonAsync(
-            "/api/auth/refresh",
-            new RefreshTokenRequest(registerPayload!.RefreshToken),
-            TestContext.Current.CancellationToken);
+        var firstRefreshResponse = await SendRefreshAsync(registerCookie);
         firstRefreshResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        var firstRefreshPayload = await firstRefreshResponse.Content.ReadFromJsonAsync<RefreshTokenResponse>(TestContext.Current.CancellationToken);
-        firstRefreshPayload.Should().NotBeNull();
+        var firstRefreshCookie = GetIssuedRefreshCookie(firstRefreshResponse);
 
         // Act - reuse rotated token
-        var reuseResponse = await _client.PostAsJsonAsync(
-            "/api/auth/refresh",
-            new RefreshTokenRequest(registerPayload.RefreshToken),
-            TestContext.Current.CancellationToken);
+        var reuseResponse = await SendRefreshAsync(registerCookie);
 
         // Assert - reuse is treated as security incident
         reuseResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
@@ -233,20 +216,14 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
         reuseError!.Code.Should().Be(ApplicationErrorCodes.Auth.RefreshTokenReuseDetected);
 
         // The associated active descendant session is revoked
-        var descendantResponse = await _client.PostAsJsonAsync(
-            "/api/auth/refresh",
-            new RefreshTokenRequest(firstRefreshPayload!.RefreshToken),
-            TestContext.Current.CancellationToken);
+        var descendantResponse = await SendRefreshAsync(firstRefreshCookie);
         descendantResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
         var descendantError = await descendantResponse.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         descendantError.Should().NotBeNull();
         descendantError!.Code.Should().Be(ApplicationErrorCodes.Auth.RefreshTokenReuseDetected);
 
         // Unrelated active session remains valid
-        var unrelatedResponse = await _client.PostAsJsonAsync(
-            "/api/auth/refresh",
-            new RefreshTokenRequest(loginPayload!.RefreshToken),
-            TestContext.Current.CancellationToken);
+        var unrelatedResponse = await SendRefreshAsync(loginCookie);
         unrelatedResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -284,20 +261,15 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
 
         var registerPayload = await registerResponse.Content.ReadFromJsonAsync<RegisterResponse>(TestContext.Current.CancellationToken);
         registerPayload.Should().NotBeNull();
+        var refreshCookie = GetIssuedRefreshCookie(registerResponse);
 
         // Act - Logout current session
-        var logoutResponse = await _client.SendAuthorizedPostAsync(
-            "/api/auth/logout",
-            new LogoutRequest(registerPayload!.RefreshToken),
-            registerPayload.AccessToken);
+        var logoutResponse = await SendLogoutAsync(refreshCookie, registerPayload!.AccessToken);
 
         // Assert
         logoutResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
-        var refreshResponse = await _client.PostAsJsonAsync(
-            "/api/auth/refresh",
-            new RefreshTokenRequest(registerPayload.RefreshToken),
-            TestContext.Current.CancellationToken);
+        var refreshResponse = await SendRefreshAsync(refreshCookie);
 
         refreshResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
 
@@ -323,10 +295,7 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
             TestContext.Current.CancellationToken);
         registerPayload.Should().NotBeNull();
 
-        using var logoutRequest = new HttpRequestMessage(HttpMethod.Post, "/api/auth/logout")
-        {
-            Content = JsonContent.Create(new LogoutRequest(string.Empty))
-        };
+        using var logoutRequest = new HttpRequestMessage(HttpMethod.Post, "/api/auth/logout");
         logoutRequest.Headers.Authorization = new("Bearer", registerPayload!.AccessToken);
         logoutRequest.Headers.Add("Cookie", $"{RefreshTokenCookie.Name}={GetIssuedRefreshCookie(registerResponse)}");
 
@@ -360,14 +329,11 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
         userBResponse.StatusCode.Should().Be(HttpStatusCode.Created);
 
         var userAPayload = await userAResponse.Content.ReadFromJsonAsync<RegisterResponse>(TestContext.Current.CancellationToken);
-        var userBPayload = await userBResponse.Content.ReadFromJsonAsync<RegisterResponse>(TestContext.Current.CancellationToken);
         userAPayload.Should().NotBeNull();
-        userBPayload.Should().NotBeNull();
 
         // Act - user A tries to revoke user B refresh token
-        var logoutResponse = await _client.SendAuthorizedPostAsync(
-            "/api/auth/logout",
-            new LogoutRequest(userBPayload!.RefreshToken),
+        var logoutResponse = await SendLogoutAsync(
+            GetIssuedRefreshCookie(userBResponse),
             userAPayload!.AccessToken);
 
         // Assert
@@ -381,11 +347,11 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
     [Fact]
     public async Task Logout_WithoutAuthentication_ReturnsUnauthorized()
     {
-        // Arrange
-        var request = new LogoutRequest("any_refresh_token");
-
         // Act
-        var response = await _client.PostAsJsonAsync("/api/auth/logout", request, TestContext.Current.CancellationToken);
+        var response = await _client.PostAsync(
+            "/api/auth/logout",
+            content: null,
+            TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
@@ -405,15 +371,14 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
 
         var registerPayload = await registerResponse.Content.ReadFromJsonAsync<RegisterResponse>(TestContext.Current.CancellationToken);
         registerPayload.Should().NotBeNull();
+        var registerCookie = GetIssuedRefreshCookie(registerResponse);
 
         var loginResponse = await _client.PostAsJsonAsync(
             "/api/auth/login",
             new LoginRequest(registerRequest.Email, registerRequest.Password),
             TestContext.Current.CancellationToken);
         loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        var loginPayload = await loginResponse.Content.ReadFromJsonAsync<LoginResponse>(TestContext.Current.CancellationToken);
-        loginPayload.Should().NotBeNull();
+        var loginCookie = GetIssuedRefreshCookie(loginResponse);
 
         // Act
         var logoutAllResponse = await _client.SendAuthorizedPostNoBodyAsync(
@@ -423,10 +388,7 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
         // Assert
         logoutAllResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
-        var refreshWithRegisterTokenResponse = await _client.PostAsJsonAsync(
-            "/api/auth/refresh",
-            new RefreshTokenRequest(registerPayload.RefreshToken),
-            TestContext.Current.CancellationToken);
+        var refreshWithRegisterTokenResponse = await SendRefreshAsync(registerCookie);
         refreshWithRegisterTokenResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
 
         var refreshWithRegisterTokenError =
@@ -434,10 +396,7 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
         refreshWithRegisterTokenError.Should().NotBeNull();
         refreshWithRegisterTokenError!.Code.Should().Be(ApplicationErrorCodes.Auth.RefreshTokenReuseDetected);
 
-        var refreshWithLoginTokenResponse = await _client.PostAsJsonAsync(
-            "/api/auth/refresh",
-            new RefreshTokenRequest(loginPayload!.RefreshToken),
-            TestContext.Current.CancellationToken);
+        var refreshWithLoginTokenResponse = await SendRefreshAsync(loginCookie);
         refreshWithLoginTokenResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
 
         var refreshWithLoginTokenError =
@@ -457,7 +416,7 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
     }
 
     [Fact]
-    public async Task Logout_WithEmptyRefreshToken_ReturnsBadRequest()
+    public async Task Logout_WithoutRefreshCookie_ReturnsBadRequest()
     {
         // Arrange
         var registerRequest = new RegisterRequest(
@@ -472,9 +431,8 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
         registerPayload.Should().NotBeNull();
 
         // Act
-        var response = await _client.SendAuthorizedPostAsync(
+        var response = await _client.SendAuthorizedPostNoBodyAsync(
             "/api/auth/logout",
-            new LogoutRequest(string.Empty),
             registerPayload!.AccessToken);
 
         // Assert
@@ -483,6 +441,23 @@ public sealed class AuthEndpointsTests : IClassFixture<HarmonieWebApplicationFac
         var error = await response.Content.ReadFromJsonAsync<ApplicationError>(TestContext.Current.CancellationToken);
         error.Should().NotBeNull();
         error!.Code.Should().Be(ApplicationErrorCodes.Common.ValidationFailed);
+    }
+
+    private async Task<HttpResponseMessage> SendRefreshAsync(string refreshCookie)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/auth/refresh");
+        request.Headers.Add("Cookie", $"{RefreshTokenCookie.Name}={refreshCookie}");
+
+        return await _client.SendAsync(request, TestContext.Current.CancellationToken);
+    }
+
+    private async Task<HttpResponseMessage> SendLogoutAsync(string refreshCookie, string accessToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/auth/logout");
+        request.Headers.Authorization = new("Bearer", accessToken);
+        request.Headers.Add("Cookie", $"{RefreshTokenCookie.Name}={refreshCookie}");
+
+        return await _client.SendAsync(request, TestContext.Current.CancellationToken);
     }
 
     private static string GetIssuedRefreshCookie(HttpResponseMessage response)

--- a/tests/Harmonie.Application.Tests/Auth/LoginHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Auth/LoginHandlerTests.cs
@@ -88,9 +88,9 @@ public sealed class LoginHandlerTests
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
         response.Data.Should().NotBeNull();
-        response.Data!.Email.Should().Be(user.Email.Value);
-        response.Data.Username.Should().Be(user.Username.Value);
-        response.Data.AccessToken.Should().Be("access_token");
+        response.Data!.Response.Email.Should().Be(user.Email.Value);
+        response.Data.Response.Username.Should().Be(user.Username.Value);
+        response.Data.Response.AccessToken.Should().Be("access_token");
         response.Data.RefreshToken.Should().Be("refresh_token");
 
         _unitOfWorkMock.Verify(x => x.BeginAsync(It.IsAny<CancellationToken>()), Times.Once);
@@ -143,7 +143,7 @@ public sealed class LoginHandlerTests
         // Assert
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
-        response.Data!.Username.Should().Be("testuser");
+        response.Data!.Response.Username.Should().Be("testuser");
         _userRepositoryMock.Verify(x => x.GetByUsernameAsync(It.IsAny<Username>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 

--- a/tests/Harmonie.Application.Tests/Auth/RefreshTokenHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Auth/RefreshTokenHandlerTests.cs
@@ -95,7 +95,7 @@ public sealed class RefreshTokenHandlerTests
         response.Success.Should().BeTrue();
         response.Data.Should().NotBeNull();
         response.Error.Should().BeNull();
-        response.Data!.AccessToken.Should().Be("new_access_token");
+        response.Data!.Response.AccessToken.Should().Be("new_access_token");
         response.Data.RefreshToken.Should().Be("new_refresh_token");
 
         _refreshTokenRepositoryMock.Verify(x => x.RotateAsync(

--- a/tests/Harmonie.Application.Tests/Auth/RegisterHandlerTests.cs
+++ b/tests/Harmonie.Application.Tests/Auth/RegisterHandlerTests.cs
@@ -95,9 +95,9 @@ public sealed class RegisterHandlerTests
         response.Success.Should().BeTrue();
         response.Error.Should().BeNull();
         response.Data.Should().NotBeNull();
-        response.Data!.Email.Should().Be("test@harmonie.chat");
-        response.Data.Username.Should().Be("testuser");
-        response.Data.AccessToken.Should().Be("access_token");
+        response.Data!.Response.Email.Should().Be("test@harmonie.chat");
+        response.Data.Response.Username.Should().Be("testuser");
+        response.Data.Response.AccessToken.Should().Be("access_token");
         response.Data.RefreshToken.Should().Be("refresh_token");
 
         _unitOfWorkMock.Verify(
@@ -338,8 +338,8 @@ public sealed class RegisterHandlerTests
 
         // Assert
         response.Success.Should().BeTrue();
-        response.Data!.Avatar.Should().BeNull();
-        response.Data.Theme.Should().Be("default");
+        response.Data!.Response.Avatar.Should().BeNull();
+        response.Data.Response.Theme.Should().Be("default");
     }
 
     [Fact]
@@ -364,11 +364,11 @@ public sealed class RegisterHandlerTests
 
         // Assert
         response.Success.Should().BeTrue();
-        response.Data!.Avatar.Should().NotBeNull();
-        response.Data.Avatar!.Color.Should().Be("#ff0000");
-        response.Data.Avatar.Icon.Should().Be("star");
-        response.Data.Avatar.Bg.Should().Be("#0000ff");
-        response.Data.Theme.Should().Be("dark");
+        response.Data!.Response.Avatar.Should().NotBeNull();
+        response.Data.Response.Avatar!.Color.Should().Be("#ff0000");
+        response.Data.Response.Avatar.Icon.Should().Be("star");
+        response.Data.Response.Avatar.Bg.Should().Be("#0000ff");
+        response.Data.Response.Theme.Should().Be("dark");
     }
 
     [Fact]
@@ -392,11 +392,11 @@ public sealed class RegisterHandlerTests
 
         // Assert
         response.Success.Should().BeTrue();
-        response.Data!.Avatar.Should().NotBeNull();
-        response.Data.Avatar!.Color.Should().Be("#ff0000");
-        response.Data.Avatar.Icon.Should().BeNull();
-        response.Data.Avatar.Bg.Should().BeNull();
-        response.Data.Theme.Should().Be("default");
+        response.Data!.Response.Avatar.Should().NotBeNull();
+        response.Data.Response.Avatar!.Color.Should().Be("#ff0000");
+        response.Data.Response.Avatar.Icon.Should().BeNull();
+        response.Data.Response.Avatar.Bg.Should().BeNull();
+        response.Data.Response.Theme.Should().Be("default");
     }
 
     private void SetupSuccessfulTokenMocks()


### PR DESCRIPTION
## Summary

- remove refresh tokens from register, login, and refresh response payloads
- remove refresh-token request bodies from refresh and logout
- read the refresh credential exclusively from the HttpOnly cookie
- separate internal session issuance data from public HTTP response DTOs
- keep cookie rotation, reuse detection, revocation, and deletion behavior unchanged
- update integration tests to exercise bodyless cookie-only refresh and logout requests
- verify that public authentication responses never contain `refreshToken`

## Coordinated rollout

This is a breaking contract cleanup coordinated with Harmonie-chat/harmonie-client#202. The server and client changes must be deployed together; the client PR already sends bodyless credentialed requests.

## Validation

- Release build: 0 warnings, 0 errors
- Full server suite: 1,412 tests passed
- Auth integration suite: 19 tests passed
- formatting verified on all changed files

Closes #436

Closes #434