### PR TITLE
feat(conversations): sort by latest message activity

### DIFF
--- a/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
+++ b/src/Harmonie.Infrastructure/Persistence/Conversations/ConversationRepository.cs
@@ -213,10 +213,20 @@ public sealed class ConversationRepository : IConversationRepository
                            INNER JOIN conversations c ON c.id = cp1.conversation_id
                            INNER JOIN conversation_participants cp2 ON cp2.conversation_id = c.id
                            INNER JOIN users u ON u.id = cp2.user_id
+                           LEFT JOIN LATERAL (
+                               SELECT m.created_at_utc AS last_message_at_utc
+                               FROM messages m
+                               WHERE m.conversation_id = c.id
+                                 AND m.deleted_at_utc IS NULL
+                               ORDER BY m.created_at_utc DESC, m.id DESC
+                               LIMIT 1
+                           ) lm ON TRUE
                            WHERE cp1.user_id = @UserId
                              AND cp1.hidden_at_utc IS NULL
                              AND u.deleted_at IS NULL
-                           ORDER BY c.created_at_utc DESC, c.id ASC, cp2.user_id ASC;
+                           ORDER BY COALESCE(lm.last_message_at_utc, c.created_at_utc) DESC,
+                                    c.id ASC,
+                                    cp2.user_id ASC;
 
                            SELECT DISTINCT m.conversation_id AS "ConversationId"
                            FROM messages m

--- a/tests/Harmonie.API.IntegrationTests/Conversations/ConversationEndpointsTests.cs
+++ b/tests/Harmonie.API.IntegrationTests/Conversations/ConversationEndpointsTests.cs
@@ -191,6 +191,137 @@ public sealed class ConversationEndpointsTests : IClassFixture<HarmonieWebApplic
     }
 
     [Fact]
+    public async Task ListConversations_ShouldOrderByLatestReceivedOrSentMessage()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var targetOne = await AuthTestHelper.RegisterAsync(_client);
+        var targetTwo = await AuthTestHelper.RegisterAsync(_client);
+        var firstConversationId = await ConversationTestHelper.OpenConversationAsync(
+            _client,
+            caller.AccessToken,
+            targetOne.UserId);
+        var secondConversationId = await ConversationTestHelper.OpenConversationAsync(
+            _client,
+            caller.AccessToken,
+            targetTwo.UserId);
+
+        await ConversationTestHelper.SendConversationMessageAsync(
+            _client,
+            secondConversationId,
+            "older received message",
+            targetTwo.AccessToken);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
+        await ConversationTestHelper.SendConversationMessageAsync(
+            _client,
+            firstConversationId,
+            "newer received message",
+            targetOne.AccessToken);
+
+        var receivedListResponse = await _client.SendAuthorizedGetAsync(
+            "/api/conversations",
+            caller.AccessToken);
+        var receivedList = await receivedListResponse.Content.ReadFromJsonAsync<ListConversationsResponse>(
+            TestContext.Current.CancellationToken);
+
+        receivedListResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        receivedList.Should().NotBeNull();
+        receivedList!.Conversations.Select(c => c.ConversationId)
+            .Should().Equal(firstConversationId, secondConversationId);
+
+        await Task.Delay(20, TestContext.Current.CancellationToken);
+        await ConversationTestHelper.SendConversationMessageAsync(
+            _client,
+            secondConversationId,
+            "newest sent message",
+            caller.AccessToken);
+
+        var sentListResponse = await _client.SendAuthorizedGetAsync(
+            "/api/conversations",
+            caller.AccessToken);
+        var sentList = await sentListResponse.Content.ReadFromJsonAsync<ListConversationsResponse>(
+            TestContext.Current.CancellationToken);
+
+        sentListResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        sentList.Should().NotBeNull();
+        sentList!.Conversations.Select(c => c.ConversationId)
+            .Should().Equal(secondConversationId, firstConversationId);
+    }
+
+    [Fact]
+    public async Task ListConversations_WithoutMessages_ShouldOrderByCreationDate()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var targetOne = await AuthTestHelper.RegisterAsync(_client);
+        var targetTwo = await AuthTestHelper.RegisterAsync(_client);
+        var olderConversationId = await ConversationTestHelper.OpenConversationAsync(
+            _client,
+            caller.AccessToken,
+            targetOne.UserId);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
+        var newerConversationId = await ConversationTestHelper.OpenConversationAsync(
+            _client,
+            caller.AccessToken,
+            targetTwo.UserId);
+
+        var response = await _client.SendAuthorizedGetAsync("/api/conversations", caller.AccessToken);
+        var payload = await response.Content.ReadFromJsonAsync<ListConversationsResponse>(
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        payload.Should().NotBeNull();
+        payload!.Conversations.Select(c => c.ConversationId)
+            .Should().Equal(newerConversationId, olderConversationId);
+    }
+
+    [Fact]
+    public async Task ListConversations_ShouldIgnoreDeletedMessagesWhenOrdering()
+    {
+        var caller = await AuthTestHelper.RegisterAsync(_client);
+        var targetOne = await AuthTestHelper.RegisterAsync(_client);
+        var targetTwo = await AuthTestHelper.RegisterAsync(_client);
+        var firstConversationId = await ConversationTestHelper.OpenConversationAsync(
+            _client,
+            caller.AccessToken,
+            targetOne.UserId);
+        var secondConversationId = await ConversationTestHelper.OpenConversationAsync(
+            _client,
+            caller.AccessToken,
+            targetTwo.UserId);
+
+        await ConversationTestHelper.SendConversationMessageAsync(
+            _client,
+            firstConversationId,
+            "older visible message",
+            caller.AccessToken);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
+        await ConversationTestHelper.SendConversationMessageAsync(
+            _client,
+            secondConversationId,
+            "newer visible message",
+            targetTwo.AccessToken);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
+        var deletedMessage = await ConversationTestHelper.SendConversationMessageAsync(
+            _client,
+            firstConversationId,
+            "newest deleted message",
+            caller.AccessToken);
+
+        var deleteResponse = await _client.SendAuthorizedDeleteAsync(
+            $"/api/conversations/{firstConversationId}/messages/{deletedMessage.MessageId}",
+            caller.AccessToken);
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var response = await _client.SendAuthorizedGetAsync("/api/conversations", caller.AccessToken);
+        var payload = await response.Content.ReadFromJsonAsync<ListConversationsResponse>(
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        payload.Should().NotBeNull();
+        payload!.Conversations.Select(c => c.ConversationId)
+            .Should().Equal(secondConversationId, firstConversationId);
+    }
+
+    [Fact]
     public async Task ListConversations_WhenUserHasNoConversations_ShouldReturnEmptyArray()
     {
         var caller = await AuthTestHelper.RegisterAsync(_client);


### PR DESCRIPTION
## Summary

- sort conversations by their latest non-deleted message
- fall back to conversation creation time when no message exists
- keep ordering deterministic with the conversation ID
- cover received messages, sent messages, empty conversations, and deleted messages with integration tests

## Alignment

The implementation follows the existing conversation list repository flow and aligns latest-message ordering with message pagination/search conventions and unread-list query patterns.

## Tests

- `ConnectionStrings__DefaultConnection='Host=localhost;Port=54321;Database=harmonie;Username=harmonie_user;Password=harmonie_password' dotnet test`

Closes #439
